### PR TITLE
Make myself a code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @SergeyKanzhelev @fbogsany @bai
+* @SergeyKanzhelev @fbogsany @bai @luvtechno


### PR DESCRIPTION
As per [the community membership guidelines](https://github.com/open-telemetry/community/blob/master/community-membership.md), I'm adding myself to CODEOWNERS.

My membership has been approved in this issue: 
[REQUEST: New membership as Ruby SIG approver for luvtechno · Issue \#121 · open\-telemetry/community](https://github.com/open-telemetry/community/issues/121)

