### PR TITLE
Make @mwear CODEOWNER as maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @SergeyKanzhelev @fbogsany @bai @luvtechno
+* @SergeyKanzhelev @fbogsany @bai @luvtechno @mwear


### PR DESCRIPTION
Per [Nominating @mwear as Ruby maintainer by fbogsany · Pull Request \#142 · open\-telemetry/community](https://github.com/open-telemetry/community/pull/142), @mwear is now a maintainer. Adding him to CODEOWNERS.