### PR TITLE
DistributedContext API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: ruby
+rvm:
+ - 2.4
+ - 2.5
+ - 2.6
+ - jruby
+install: ( cd api && bundle install --jobs=3 --retry=3 )
+script: ( cd api && rake )

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 [![Join the chat at https://gitter.im/open-telemetry/opentelemetry-ruby](https://badges.gitter.im/open-telemetry/opentelemetry-ruby.svg)](https://gitter.im/open-telemetry/opentelemetry-ruby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/open-telemetry/opentelemetry-ruby.svg?branch=master)](https://travis-ci.org/open-telemetry/opentelemetry-ruby)

--- a/api/lib/opentelemetry.rb
+++ b/api/lib/opentelemetry.rb
@@ -6,6 +6,7 @@
 
 require 'opentelemetry/context'
 require 'opentelemetry/distributed_context'
+require 'opentelemetry/internal'
 require 'opentelemetry/metrics'
 require 'opentelemetry/resources'
 require 'opentelemetry/trace'

--- a/api/lib/opentelemetry/distributed_context.rb
+++ b/api/lib/opentelemetry/distributed_context.rb
@@ -4,4 +4,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require 'opentelemetry/distributed_context/distributed_context'
+require 'opentelemetry/distributed_context/entry'
 require 'opentelemetry/distributed_context/manager'
+require 'opentelemetry/distributed_context/propagation'
+
+module OpenTelemetry
+  # DistributedContext is an abstract data type that represents a collection of entries. Each key of a DistributedContext is
+  # associated with exactly one value. DistributedContext is serializable, to facilitate propagating it not only inside the
+  # process but also across process boundaries. DistributedContext is used to annotate telemetry with the name:value pair
+  # Entry. Those values can be used to add dimensions to the metric or additional context properties to logs and traces.
+  module DistributedContext
+  end
+end

--- a/api/lib/opentelemetry/distributed_context/distributed_context.rb
+++ b/api/lib/opentelemetry/distributed_context/distributed_context.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module DistributedContext
+    # An immutable implementation of the DistributedContext that does not contain any entries.
+    class DistributedContext
+      def entries
+        []
+      end
+
+      def [](_key)
+        nil
+      end
+    end
+  end
+end

--- a/api/lib/opentelemetry/distributed_context/distributed_context.rb
+++ b/api/lib/opentelemetry/distributed_context/distributed_context.rb
@@ -8,8 +8,12 @@ module OpenTelemetry
   module DistributedContext
     # An immutable implementation of the DistributedContext that does not contain any entries.
     class DistributedContext
+      EMPTY_ENTRIES = [].freeze
+
+      private_constant(:EMPTY_ENTRIES)
+
       def entries
-        []
+        EMPTY_ENTRIES
       end
 
       def [](_key)

--- a/api/lib/opentelemetry/distributed_context/entry.rb
+++ b/api/lib/opentelemetry/distributed_context/entry.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module DistributedContext
+    # An Entry consists of Entry::Metadata, Entry::Key, and Entry::Value.
+    class Entry
+      attr_reader :metadata, :key, :value
+
+      # Entry::Key is the name of the Entry. Entry::Key along with Entry::Value can be used to aggregate and group stats,
+      # annotate traces and logs, etc.
+      #
+      # Restrictions
+      # - Must contain only printable ASCII (codes between 32 and 126 inclusive)
+      # - Must have length greater than zero and less than 256.
+      # - Must not be empty.
+      class Key
+        attr_reader :name
+
+        def initialize(name)
+          # TODO: name should be printable ascii (32..126), not just ascii.
+          raise ArgumentError unless name&.ascii_compatible? && (1..255).include?(name.length)
+
+          @name = -name
+        end
+      end
+
+      # Entry::Value wraps a string. It MUST contain only printable ASCII (codes between 32 and 126).
+      class Value
+        def initialize(value)
+          # TODO: value should be printable ascii (32..126), not just ascii.
+          raise ArgumentError unless value&.ascii_compatible?
+
+          @value = -value
+        end
+
+        def to_s
+          @value
+        end
+      end
+
+      # Entry::Metadata contains properties associated with an Entry. For now only the property entry_ttl is defined.
+      # In future, additional properties may be added to address specific situations.
+      #
+      # The creator of entries determines metadata of an entry it creates.
+      class Metadata
+        attr_reader :entry_ttl
+
+        # An @see Entry with NO_PROPAGATION is considered to have local scope and is used within the process
+        # where it is created.
+        NO_PROPAGATION = 0
+
+        # An @see Entry with UNLIMITED_PROPAGATION can propagate unlimited hops. However, it is still subject
+        # to outgoing and incoming (on remote side) filter criteria.
+        UNLIMITED_PROPAGATION = -1
+
+        def initialize(entry_ttl)
+          raise ArgumentError unless entry_ttl&.integer?
+
+          @entry_ttl = entry_ttl
+        end
+      end
+    end
+  end
+end

--- a/api/lib/opentelemetry/distributed_context/entry.rb
+++ b/api/lib/opentelemetry/distributed_context/entry.rb
@@ -21,8 +21,7 @@ module OpenTelemetry
         attr_reader :name
 
         def initialize(name)
-          # TODO: name should be printable ascii (32..126), not just ascii.
-          raise ArgumentError unless name&.ascii_compatible? && (1..255).include?(name.length)
+          raise ArgumentError unless Internal.printable_ascii?(name) && (1..255).include?(name.length)
 
           @name = -name
         end
@@ -31,8 +30,7 @@ module OpenTelemetry
       # Entry::Value wraps a string. It MUST contain only printable ASCII (codes between 32 and 126).
       class Value
         def initialize(value)
-          # TODO: value should be printable ascii (32..126), not just ascii.
-          raise ArgumentError unless value&.ascii_compatible?
+          raise ArgumentError unless Internal.printable_ascii?(value)
 
           @value = -value
         end

--- a/api/lib/opentelemetry/distributed_context/entry.rb
+++ b/api/lib/opentelemetry/distributed_context/entry.rb
@@ -58,7 +58,7 @@ module OpenTelemetry
         UNLIMITED_PROPAGATION = -1
 
         def initialize(entry_ttl)
-          raise ArgumentError unless entry_ttl&.integer?
+          raise ArgumentError unless entry_ttl.is_a?(Integer)
 
           @entry_ttl = entry_ttl
         end

--- a/api/lib/opentelemetry/distributed_context/propagation.rb
+++ b/api/lib/opentelemetry/distributed_context/propagation.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry/distributed_context/propagation/binary_format'
+require 'opentelemetry/distributed_context/propagation/http_text_format'
+
+module OpenTelemetry
+  module DistributedContext
+    # Propagation API consists of two main formats:
+    # - @see BinaryFormat is used to serialize and deserialize a value into a binary representation.
+    # - @see HTTPTextFormat is used to inject and extract a value as text into carriers that travel in-band across process boundaries.
+    module Propagation
+    end
+  end
+end

--- a/api/lib/opentelemetry/distributed_context/propagation/binary_format.rb
+++ b/api/lib/opentelemetry/distributed_context/propagation/binary_format.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module DistributedContext
+    module Propagation
+      # Formatter for serializing and deserializing a SpanContext into a binary format.
+      class BinaryFormat
+        def to_bytes(span_context)
+          raise ArgumentError if span_context.nil?
+
+          []
+        end
+
+        def from_bytes(bytes)
+          raise ArgumentError if bytes.nil?
+
+          SpanContext.INVALID
+        end
+      end
+    end
+  end
+end

--- a/api/lib/opentelemetry/distributed_context/propagation/binary_format.rb
+++ b/api/lib/opentelemetry/distributed_context/propagation/binary_format.rb
@@ -9,10 +9,14 @@ module OpenTelemetry
     module Propagation
       # Formatter for serializing and deserializing a SpanContext into a binary format.
       class BinaryFormat
+        EMPTY_BYTE_ARRAY = [].freeze
+
+        private_constant(:EMPTY_BYTE_ARRAY)
+
         def to_bytes(span_context)
           raise ArgumentError if span_context.nil?
 
-          []
+          EMPTY_BYTE_ARRAY
         end
 
         def from_bytes(bytes)

--- a/api/lib/opentelemetry/distributed_context/propagation/http_text_format.rb
+++ b/api/lib/opentelemetry/distributed_context/propagation/http_text_format.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module DistributedContext
+    module Propagation
+      # HTTPTextFormat is a formatter that injects and extracts a value as text into carriers that travel in-band across
+      # process boundaries.
+      #
+      # Encoding is expected to conform to the HTTP Header Field semantics. Values are often encoded as RPC/HTTP request
+      # headers.
+      #
+      # The carrier of propagated data on both the client (injector) and server (extractor) side is usually an http request.
+      # Propagation is usually implemented via library-specific request interceptors, where the client-side injects values
+      # and the server-side extracts them.
+      class HTTPTextFormat
+        # TODO
+      end
+    end
+  end
+end

--- a/api/lib/opentelemetry/internal.rb
+++ b/api/lib/opentelemetry/internal.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  # Internal contains helpers used by the no-op API implementation.
+  module Internal
+    extend self
+
+    def printable_ascii?(string)
+      return false unless string.is_a?(String)
+
+      r = 32..126
+      string.each_codepoint { |c| return false unless r.include?(c) }
+      true
+    end
+  end
+end

--- a/api/lib/opentelemetry/metrics/meter.rb
+++ b/api/lib/opentelemetry/metrics/meter.rb
@@ -16,7 +16,7 @@ module OpenTelemetry
       def record(*measurements, distributed_context: nil, exemplar: nil); end
 
       def create_measure(name, description: nil, unit: nil, type: :double)
-        raise ArgumentError if name.nil? # TODO: The Java implementation also constrains the name to be printable and 255 chars or less.
+        raise ArgumentError unless Internal.printable_ascii?(name) && name.length <= 255
 
         case type
         when :double

--- a/api/lib/opentelemetry/trace/tracer.rb
+++ b/api/lib/opentelemetry/trace/tracer.rb
@@ -9,26 +9,10 @@ module OpenTelemetry
     # No-op implementation of Tracer.
     class Tracer
       CONTEXT_SPAN_KEY = :__span__
-      HTTP_TEXT_FORMAT = nil # TODO: implement HttpTraceContext
+      HTTP_TEXT_FORMAT = DistributedContext::Propagation::HTTPTextFormat.new
+      BINARY_FORMAT = DistributedContext::Propagation::BinaryFormat.new
 
-      # Formatter for serializing and deserializing a SpanContext into a binary format.
-      module NoopBinaryFormat
-        extend self
-
-        def to_bytes(span_context)
-          raise ArgumentError if span_context.nil?
-
-          []
-        end
-
-        def from_bytes(bytes)
-          raise ArgumentError if bytes.nil?
-
-          SpanContext.INVALID
-        end
-      end
-
-      private_constant(:CONTEXT_SPAN_KEY, :HTTP_TEXT_FORMAT, :NoopBinaryFormat)
+      private_constant(:CONTEXT_SPAN_KEY, :HTTP_TEXT_FORMAT, :BINARY_FORMAT)
 
       def current_span
         Context.get(CONTEXT_SPAN_KEY) || Span.INVALID
@@ -78,7 +62,7 @@ module OpenTelemetry
       end
 
       def binary_format
-        NoopBinaryFormat
+        BINARY_FORMAT
       end
 
       def http_text_format


### PR DESCRIPTION
This PR provides the [`DistributedContext` API](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/distributedcontext-api.md) and the [`BinaryFormat`](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/propagators-api.md#binary-format) part of the `Propagators` API.

Note: `DistributedContext::Manager` is part of https://github.com/open-telemetry/opentelemetry-ruby/pull/17