### PR TITLE
Improve Resource

### DIFF
--- a/api/lib/opentelemetry/resources/resource.rb
+++ b/api/lib/opentelemetry/resources/resource.rb
@@ -9,8 +9,16 @@ module OpenTelemetry
     # Resource represents a resource, which captures identifying information about the entities
     # for which telemetry (metrics or traces) is reported.
     class Resource
+      # Returns the labels for this {Resource}
+      #
+      # @return [Hash<String, String>]
       attr_reader :labels
 
+      # Returns a newly created {Resource} with the specified labels
+      #
+      # @param [Hash<String, String>] kvs Hash of key-value pairs to be used
+      #   as labels for this resource
+      # @return [Resource]
       def initialize(kvs)
         # TODO: how defensive should we be here?
         @labels = kvs.each_with_object({}) do |(k, v), memo|
@@ -18,6 +26,13 @@ module OpenTelemetry
         end
       end
 
+      # Returns a new, merged {Resource} by merging the current {Resource} with
+      # the other {Resource}. In case of a collision, the current {Resource}
+      # takes precedence
+      #
+      # @param [Resource] other The other resource to merge
+      # @return [Resource] A new resource formed by merging the current resource
+      #   with other
       def merge(other)
         raise ArgumentError unless other.is_a?(Resource)
 

--- a/api/lib/opentelemetry/resources/resource.rb
+++ b/api/lib/opentelemetry/resources/resource.rb
@@ -18,11 +18,17 @@ module OpenTelemetry
         end
       end
 
-      # TODO: Already set labels MUST NOT be overwritten unless they are empty string.
       def merge(other)
         raise ArgumentError unless other.is_a?(Resource)
 
-        self.class.new(labels.merge(other.labels))
+        merged_labels = \
+          other.labels.each_with_object(labels.dup) do |(k, v), memo|
+            next if (current = memo[k]) && !current.empty?
+
+            memo[k] = v
+          end
+
+        self.class.new(merged_labels)
       end
     end
   end

--- a/api/lib/opentelemetry/resources/resource.rb
+++ b/api/lib/opentelemetry/resources/resource.rb
@@ -19,11 +19,8 @@ module OpenTelemetry
       # @param [Hash<String, String>] kvs Hash of key-value pairs to be used
       #   as labels for this resource
       # @return [Resource]
-      def initialize(kvs = {})
-        # TODO: how defensive should we be here?
-        @labels = kvs.each_with_object({}) do |(k, v), memo|
-          memo[-k] = -v
-        end
+      def initialize(raw_labels = {})
+        @labels = check_and_freeze_labels(raw_labels)
       end
 
       # Returns a new, merged {Resource} by merging the current {Resource} with
@@ -44,6 +41,16 @@ module OpenTelemetry
           end
 
         self.class.new(merged_labels)
+      end
+
+      private
+
+      def check_and_freeze_labels(raw_labels)
+        raw_labels.each_with_object({}) do |(k, v), memo|
+          raise ArgumentError, 'label keys and values must be strings' unless k.is_a?(String) && v.is_a?(String)
+
+          memo[-k] = -v
+        end.freeze
       end
     end
   end

--- a/api/lib/opentelemetry/resources/resource.rb
+++ b/api/lib/opentelemetry/resources/resource.rb
@@ -32,10 +32,6 @@ module OpenTelemetry
           end.freeze
         end
       end
-      # Returns the labels for this {Resource}
-      #
-      # @return [Hash<String, String>]
-      attr_reader :labels
 
       # @api private
       # The constructor is private and only for use internally by the class.
@@ -47,6 +43,13 @@ module OpenTelemetry
       # @return [Resource]
       def initialize(frozen_labels)
         @labels = frozen_labels
+      end
+
+      # Returns an enumerator for labels of this {Resource}
+      #
+      # @return [Enumerator]
+      def label_enumerator
+        @label_enumerator ||= labels.to_enum
       end
 
       # Returns a new, merged {Resource} by merging the current {Resource} with
@@ -65,6 +68,10 @@ module OpenTelemetry
 
         self.class.send(:new, merged_labels.freeze)
       end
+
+      protected
+
+      attr_reader :labels
     end
   end
 end

--- a/api/lib/opentelemetry/resources/resource.rb
+++ b/api/lib/opentelemetry/resources/resource.rb
@@ -19,17 +19,13 @@ module OpenTelemetry
         # @raise [ArgumentError] If label keys and values are not strings
         # @return [Resource]
         def create(labels = {})
-          new(check_and_freeze_labels(labels))
-        end
-
-        private
-
-        def check_and_freeze_labels(labels)
-          labels.each_with_object({}) do |(k, v), memo|
+          frozen_labels = labels.each_with_object({}) do |(k, v), memo|
             raise ArgumentError, 'label keys and values must be strings' unless k.is_a?(String) && v.is_a?(String)
 
             memo[-k] = -v
           end.freeze
+
+          new(frozen_labels)
         end
       end
 

--- a/api/lib/opentelemetry/resources/resource.rb
+++ b/api/lib/opentelemetry/resources/resource.rb
@@ -19,7 +19,7 @@ module OpenTelemetry
       # @param [Hash<String, String>] kvs Hash of key-value pairs to be used
       #   as labels for this resource
       # @return [Resource]
-      def initialize(kvs)
+      def initialize(kvs = {})
         # TODO: how defensive should we be here?
         @labels = kvs.each_with_object({}) do |(k, v), memo|
           memo[-k] = -v

--- a/api/lib/opentelemetry/resources/resource.rb
+++ b/api/lib/opentelemetry/resources/resource.rb
@@ -11,9 +11,11 @@ module OpenTelemetry
     class Resource
       attr_reader :labels
 
-      def initialize(**kvs)
+      def initialize(kvs)
         # TODO: how defensive should we be here?
-        @labels = kvs.to_h { |k, v| [k.to_s.clone.freeze, v.to_s.clone.freeze] }.freeze
+        @labels = kvs.each_with_object({}) do |(k, v), memo|
+          memo[-k] = -v
+        end
       end
 
       # TODO: Already set labels MUST NOT be overwritten unless they are empty string.

--- a/api/test/resources/resource_test.rb
+++ b/api/test/resources/resource_test.rb
@@ -17,12 +17,12 @@ describe OpenTelemetry::Resources::Resource do
     it 'can be initialized with labels' do
       expected_labels = { 'k1' => 'v1', 'k2' => 'v2' }
       resource = OpenTelemetry::Resources::Resource.create(expected_labels)
-      resource.labels.must_equal(expected_labels)
+      resource.label_enumerator.to_h.must_equal(expected_labels)
     end
 
     it 'can be empty' do
       resource = OpenTelemetry::Resources::Resource.create
-      resource.labels.must_be_empty
+      resource.label_enumerator.to_h.must_be_empty
     end
 
     it 'enforces keys are strings' do
@@ -44,10 +44,10 @@ describe OpenTelemetry::Resources::Resource do
                                                        'k4' => 'v4')
       res3 = res1.merge(res2)
 
-      res3.labels.must_equal('k1' => 'v1', 'k2' => 'v2',
-                             'k3' => 'v3', 'k4' => 'v4')
-      res1.labels.must_equal('k1' => 'v1', 'k2' => 'v2')
-      res2.labels.must_equal('k3' => 'v3', 'k4' => 'v4')
+      res3.label_enumerator.to_h.must_equal('k1' => 'v1', 'k2' => 'v2',
+                                            'k3' => 'v3', 'k4' => 'v4')
+      res1.label_enumerator.to_h.must_equal('k1' => 'v1', 'k2' => 'v2')
+      res2.label_enumerator.to_h.must_equal('k3' => 'v3', 'k4' => 'v4')
     end
 
     it 'does not overwrite receiver\'s keys when value is non-empty' do
@@ -57,7 +57,9 @@ describe OpenTelemetry::Resources::Resource do
                                                        'k3' => '2v3')
       res3 = res1.merge(res2)
 
-      res3.labels.must_equal('k1' => 'v1', 'k2' => 'v2', 'k3' => '2v3')
+      res3.label_enumerator.to_h.must_equal('k1' => 'v1',
+                                            'k2' => 'v2',
+                                            'k3' => '2v3')
     end
 
     it 'overwrites receiver\'s key when value is empty' do
@@ -67,7 +69,9 @@ describe OpenTelemetry::Resources::Resource do
                                                        'k3' => '2v3')
       res3 = res1.merge(res2)
 
-      res3.labels.must_equal('k1' => 'v1', 'k2' => '2v2', 'k3' => '2v3')
+      res3.label_enumerator.to_h.must_equal('k1' => 'v1',
+                                            'k2' => '2v2',
+                                            'k3' => '2v3')
     end
   end
 end

--- a/api/test/resources/resource_test.rb
+++ b/api/test/resources/resource_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+describe OpenTelemetry::Resources::Resource do
+  describe '#labels' do
+    it 'returns a hash of labels' do
+      resource = OpenTelemetry::Resources::Resource.new(k1: 'v1', k2: 'v2')
+      expected_labels = { 'k1' => 'v1', 'k2' => 'v2' }
+      resource.labels.must_equal(expected_labels)
+    end
+  end
+end

--- a/api/test/resources/resource_test.rb
+++ b/api/test/resources/resource_test.rb
@@ -18,6 +18,16 @@ describe OpenTelemetry::Resources::Resource do
       resource = OpenTelemetry::Resources::Resource.new
       resource.labels.must_be_empty
     end
+
+    it 'enforces keys are strings' do
+      -> { OpenTelemetry::Resources::Resource.new(k1: 'v1', k2: 'v2') }\
+        .must_raise(ArgumentError)
+    end
+
+    it 'enforces values are strings' do
+      -> { OpenTelemetry::Resources::Resource.new('k1' => :v1, 'k2' => :v2) }\
+        .must_raise(ArgumentError)
+    end
   end
 
   describe '#merge' do

--- a/api/test/resources/resource_test.rb
+++ b/api/test/resources/resource_test.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 require 'test_helper'
 
 describe OpenTelemetry::Resources::Resource do

--- a/api/test/resources/resource_test.rb
+++ b/api/test/resources/resource_test.rb
@@ -5,9 +5,22 @@ require 'test_helper'
 describe OpenTelemetry::Resources::Resource do
   describe '#labels' do
     it 'returns a hash of labels' do
-      resource = OpenTelemetry::Resources::Resource.new(k1: 'v1', k2: 'v2')
       expected_labels = { 'k1' => 'v1', 'k2' => 'v2' }
+      resource = OpenTelemetry::Resources::Resource.new(expected_labels)
       resource.labels.must_equal(expected_labels)
+    end
+  end
+
+  describe '#merge' do
+    it 'merges two resources into a third' do
+      res1 = OpenTelemetry::Resources::Resource.new('k1' => 'v1', 'k2' => 'v2')
+      res2 = OpenTelemetry::Resources::Resource.new('k3' => 'v3', 'k4' => 'v4')
+      res3 = res1.merge(res2)
+
+      res3.labels.must_equal('k1' => 'v1', 'k2' => 'v2',
+                             'k3' => 'v3', 'k4' => 'v4')
+      res1.labels.must_equal('k1' => 'v1', 'k2' => 'v2')
+      res2.labels.must_equal('k3' => 'v3', 'k4' => 'v4')
     end
   end
 end

--- a/api/test/resources/resource_test.rb
+++ b/api/test/resources/resource_test.rb
@@ -7,33 +7,41 @@
 require 'test_helper'
 
 describe OpenTelemetry::Resources::Resource do
-  describe '#initialize' do
+  describe '.new' do
+    it 'is private' do
+      -> { OpenTelemetry::Resources::Resource.new('k1' => 'v1') }\
+        .must_raise(NoMethodError)
+    end
+  end
+  describe '.create' do
     it 'can be initialized with labels' do
       expected_labels = { 'k1' => 'v1', 'k2' => 'v2' }
-      resource = OpenTelemetry::Resources::Resource.new(expected_labels)
+      resource = OpenTelemetry::Resources::Resource.create(expected_labels)
       resource.labels.must_equal(expected_labels)
     end
 
     it 'can be empty' do
-      resource = OpenTelemetry::Resources::Resource.new
+      resource = OpenTelemetry::Resources::Resource.create
       resource.labels.must_be_empty
     end
 
     it 'enforces keys are strings' do
-      -> { OpenTelemetry::Resources::Resource.new(k1: 'v1', k2: 'v2') }\
+      -> { OpenTelemetry::Resources::Resource.create(k1: 'v1') }\
         .must_raise(ArgumentError)
     end
 
     it 'enforces values are strings' do
-      -> { OpenTelemetry::Resources::Resource.new('k1' => :v1, 'k2' => :v2) }\
+      -> { OpenTelemetry::Resources::Resource.create('k1' => :v1) }\
         .must_raise(ArgumentError)
     end
   end
 
   describe '#merge' do
     it 'merges two resources into a third' do
-      res1 = OpenTelemetry::Resources::Resource.new('k1' => 'v1', 'k2' => 'v2')
-      res2 = OpenTelemetry::Resources::Resource.new('k3' => 'v3', 'k4' => 'v4')
+      res1 = OpenTelemetry::Resources::Resource.create('k1' => 'v1',
+                                                       'k2' => 'v2')
+      res2 = OpenTelemetry::Resources::Resource.create('k3' => 'v3',
+                                                       'k4' => 'v4')
       res3 = res1.merge(res2)
 
       res3.labels.must_equal('k1' => 'v1', 'k2' => 'v2',
@@ -43,20 +51,20 @@ describe OpenTelemetry::Resources::Resource do
     end
 
     it 'does not overwrite receiver\'s keys when value is non-empty' do
-      res1 = OpenTelemetry::Resources::Resource.new('k1' => 'v1',
-                                                    'k2' => 'v2')
-      res2 = OpenTelemetry::Resources::Resource.new('k2' => '2v2',
-                                                    'k3' => '2v3')
+      res1 = OpenTelemetry::Resources::Resource.create('k1' => 'v1',
+                                                       'k2' => 'v2')
+      res2 = OpenTelemetry::Resources::Resource.create('k2' => '2v2',
+                                                       'k3' => '2v3')
       res3 = res1.merge(res2)
 
       res3.labels.must_equal('k1' => 'v1', 'k2' => 'v2', 'k3' => '2v3')
     end
 
     it 'overwrites receiver\'s key when value is empty' do
-      res1 = OpenTelemetry::Resources::Resource.new('k1' => 'v1',
-                                                    'k2' => '')
-      res2 = OpenTelemetry::Resources::Resource.new('k2' => '2v2',
-                                                    'k3' => '2v3')
+      res1 = OpenTelemetry::Resources::Resource.create('k1' => 'v1',
+                                                       'k2' => '')
+      res2 = OpenTelemetry::Resources::Resource.create('k2' => '2v2',
+                                                       'k3' => '2v3')
       res3 = res1.merge(res2)
 
       res3.labels.must_equal('k1' => 'v1', 'k2' => '2v2', 'k3' => '2v3')

--- a/api/test/resources/resource_test.rb
+++ b/api/test/resources/resource_test.rb
@@ -7,11 +7,16 @@
 require 'test_helper'
 
 describe OpenTelemetry::Resources::Resource do
-  describe '#labels' do
-    it 'returns a hash of labels' do
+  describe '#initialize' do
+    it 'can be initialized with labels' do
       expected_labels = { 'k1' => 'v1', 'k2' => 'v2' }
       resource = OpenTelemetry::Resources::Resource.new(expected_labels)
       resource.labels.must_equal(expected_labels)
+    end
+
+    it 'can be empty' do
+      resource = OpenTelemetry::Resources::Resource.new
+      resource.labels.must_be_empty
     end
   end
 

--- a/api/test/resources/resource_test.rb
+++ b/api/test/resources/resource_test.rb
@@ -22,5 +22,25 @@ describe OpenTelemetry::Resources::Resource do
       res1.labels.must_equal('k1' => 'v1', 'k2' => 'v2')
       res2.labels.must_equal('k3' => 'v3', 'k4' => 'v4')
     end
+
+    it 'does not overwrite receiver\'s keys when value is non-empty' do
+      res1 = OpenTelemetry::Resources::Resource.new('k1' => 'v1',
+                                                    'k2' => 'v2')
+      res2 = OpenTelemetry::Resources::Resource.new('k2' => '2v2',
+                                                    'k3' => '2v3')
+      res3 = res1.merge(res2)
+
+      res3.labels.must_equal('k1' => 'v1', 'k2' => 'v2', 'k3' => '2v3')
+    end
+
+    it 'overwrites receiver\'s key when value is empty' do
+      res1 = OpenTelemetry::Resources::Resource.new('k1' => 'v1',
+                                                    'k2' => '')
+      res2 = OpenTelemetry::Resources::Resource.new('k2' => '2v2',
+                                                    'k3' => '2v3')
+      res3 = res1.merge(res2)
+
+      res3.labels.must_equal('k1' => 'v1', 'k2' => '2v2', 'k3' => '2v3')
+    end
   end
 end


### PR DESCRIPTION
This PR makes some improvements to the `Resource` class. It implements `merge` according to the [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/api-resources.md) and also adds tests and documentation. While working on this, I discovered that the original `merge` implementation wasn't working. This was because `initialize` expects labels as kwargs, but merge was passing them in as a `Hash<String, String>`. Since the labels are stored as a `Hash<String, String>` in resource, I updated `initialize` to expect a hash instead. See the comment and code in [this commit](https://github.com/open-telemetry/opentelemetry-ruby/commit/ecdc1e4897602fdb640abdacc1b8159536423b2b) for more context.