### PR TITLE
Update the span creation API

### DIFF
--- a/api/lib/opentelemetry/trace/span.rb
+++ b/api/lib/opentelemetry/trace/span.rb
@@ -140,6 +140,8 @@ module OpenTelemetry
       #
       # This API MUST be non-blocking.
       #
+      # @param [Time] end_timestamp optional end timestamp for the span.
+      #
       # @return [self] returns itself
       def finish(end_timestamp: nil)
         self

--- a/api/lib/opentelemetry/trace/span.rb
+++ b/api/lib/opentelemetry/trace/span.rb
@@ -72,9 +72,10 @@ module OpenTelemetry
       # @param [Hash<String, Object>] attrs One or more key:value pairs, where
       #   the keys must be strings and the values may be string, boolean or
       #   numeric type.
+      # @param [Time] timestamp optional timestamp for the event.
       #
       # @return [self] returns itself
-      def add_event(name, attrs = nil)
+      def add_event(name, attrs = nil, timestamp: nil)
         raise ArgumentError if name.nil?
         raise ArgumentError unless valid_attributes?(attrs)
 
@@ -140,7 +141,7 @@ module OpenTelemetry
       # This API MUST be non-blocking.
       #
       # @return [self] returns itself
-      def finish
+      def finish(end_timestamp: nil)
         self
       end
 

--- a/api/lib/opentelemetry/trace/tracer.rb
+++ b/api/lib/opentelemetry/trace/tracer.rb
@@ -31,8 +31,8 @@ module OpenTelemetry
       #
       # With this helper:
       # OpenTelemetry.tracer.in_span('do-the-thing') do ... end
-      def in_span(name, sampler: nil, links: nil, recording_events: nil, kind: nil)
-        span = start_span(name, sampler: sampler, links: links, recording_events: recording_events, kind: kind)
+      def in_span(name, attributes: nil, links: nil, events: nil, resource: nil, span_id: nil, start_timestamp: nil)
+        span = start_span(name, attributes: attributes, links: links, events: events, resource: resource, span_id: span_id, start_timestamp: start_timestamp)
         with_span(span) { |s| yield s }
       end
 
@@ -40,13 +40,13 @@ module OpenTelemetry
         Context.with(CONTEXT_SPAN_KEY, span) { |s| yield s }
       end
 
-      def start_root_span(name, sampler: nil, links: nil, recording_events: nil, kind: nil)
+      def start_root_span(name, attributes: nil, links: nil, events: nil, resource: nil, span_id: nil, start_timestamp: nil)
         raise ArgumentError if name.nil?
 
         Span.create_random
       end
 
-      def start_span(name, with_parent: nil, with_parent_context: nil, sampler: nil, links: nil, recording_events: nil, kind: nil)
+      def start_span(name, with_parent: nil, with_parent_context: nil, attributes: nil, links: nil, events: nil, resource: nil, span_id: nil, start_timestamp: nil)
         raise ArgumentError if name.nil?
 
         span_context = with_parent&.context || with_parent_context || current_span.context

--- a/api/lib/opentelemetry/trace/tracer.rb
+++ b/api/lib/opentelemetry/trace/tracer.rb
@@ -31,8 +31,8 @@ module OpenTelemetry
       #
       # With this helper:
       # OpenTelemetry.tracer.in_span('do-the-thing') do ... end
-      def in_span(name, attributes: nil, links: nil, events: nil, resource: nil, span_id: nil, start_timestamp: nil)
-        span = start_span(name, attributes: attributes, links: links, events: events, resource: resource, span_id: span_id, start_timestamp: start_timestamp)
+      def in_span(name, attributes: nil, links: nil, events: nil, start_timestamp: nil)
+        span = start_span(name, attributes: attributes, links: links, events: events, start_timestamp: start_timestamp)
         with_span(span) { |s| yield s }
       end
 
@@ -40,13 +40,13 @@ module OpenTelemetry
         Context.with(CONTEXT_SPAN_KEY, span) { |s| yield s }
       end
 
-      def start_root_span(name, attributes: nil, links: nil, events: nil, resource: nil, span_id: nil, start_timestamp: nil)
+      def start_root_span(name, attributes: nil, links: nil, events: nil, start_timestamp: nil)
         raise ArgumentError if name.nil?
 
         Span.create_random
       end
 
-      def start_span(name, with_parent: nil, with_parent_context: nil, attributes: nil, links: nil, events: nil, resource: nil, span_id: nil, start_timestamp: nil)
+      def start_span(name, with_parent: nil, with_parent_context: nil, attributes: nil, links: nil, events: nil, start_timestamp: nil)
         raise ArgumentError if name.nil?
 
         span_context = with_parent&.context || with_parent_context || current_span.context

--- a/api/lib/opentelemetry/trace/tracer.rb
+++ b/api/lib/opentelemetry/trace/tracer.rb
@@ -31,8 +31,8 @@ module OpenTelemetry
       #
       # With this helper:
       # OpenTelemetry.tracer.in_span('do-the-thing') do ... end
-      def in_span(name, attributes: nil, links: nil, events: nil, start_timestamp: nil)
-        span = start_span(name, attributes: attributes, links: links, events: events, start_timestamp: start_timestamp)
+      def in_span(name, attributes: nil, links: nil, events: nil, start_timestamp: nil, kind: nil)
+        span = start_span(name, attributes: attributes, links: links, events: events, start_timestamp: start_timestamp, kind: kind)
         with_span(span) { |s| yield s }
       end
 
@@ -40,13 +40,13 @@ module OpenTelemetry
         Context.with(CONTEXT_SPAN_KEY, span) { |s| yield s }
       end
 
-      def start_root_span(name, attributes: nil, links: nil, events: nil, start_timestamp: nil)
+      def start_root_span(name, attributes: nil, links: nil, events: nil, start_timestamp: nil, kind: nil)
         raise ArgumentError if name.nil?
 
         Span.create_random
       end
 
-      def start_span(name, with_parent: nil, with_parent_context: nil, attributes: nil, links: nil, events: nil, start_timestamp: nil)
+      def start_span(name, with_parent: nil, with_parent_context: nil, attributes: nil, links: nil, events: nil, start_timestamp: nil, kind: nil)
         raise ArgumentError if name.nil?
 
         span_context = with_parent&.context || with_parent_context || current_span.context


### PR DESCRIPTION
This update the span creation API to reflect the [latest version of the spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/api-tracing.md#span-creation) and the [`SpanData` removal PR](https://github.com/open-telemetry/opentelemetry-specification/pull/215).