### PR TITLE
Add TraceFlags class

### DIFF
--- a/api/lib/opentelemetry/distributed_context/propagation/binary_format.rb
+++ b/api/lib/opentelemetry/distributed_context/propagation/binary_format.rb
@@ -22,7 +22,7 @@ module OpenTelemetry
         def from_bytes(bytes)
           raise ArgumentError if bytes.nil?
 
-          SpanContext.INVALID
+          OpenTelemetry::Trace::SpanContext.invalid
         end
       end
     end

--- a/api/lib/opentelemetry/distributed_context/propagation/binary_format.rb
+++ b/api/lib/opentelemetry/distributed_context/propagation/binary_format.rb
@@ -22,7 +22,7 @@ module OpenTelemetry
         def from_bytes(bytes)
           raise ArgumentError if bytes.nil?
 
-          OpenTelemetry::Trace::SpanContext.invalid
+          Trace::SpanContext::INVALID
         end
       end
     end

--- a/api/lib/opentelemetry/trace.rb
+++ b/api/lib/opentelemetry/trace.rb
@@ -41,10 +41,10 @@ module OpenTelemetry
   end
 end
 
+require 'opentelemetry/trace/trace_flags'
 require 'opentelemetry/trace/samplers'
 require 'opentelemetry/trace/span_context'
 require 'opentelemetry/trace/span_kind'
 require 'opentelemetry/trace/span'
 require 'opentelemetry/trace/status'
-require 'opentelemetry/trace/trace_flags'
 require 'opentelemetry/trace/tracer'

--- a/api/lib/opentelemetry/trace.rb
+++ b/api/lib/opentelemetry/trace.rb
@@ -4,29 +4,24 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'opentelemetry/trace/samplers'
-require 'opentelemetry/trace/span_context'
-require 'opentelemetry/trace/span_kind'
-require 'opentelemetry/trace/span'
-require 'opentelemetry/trace/status'
-require 'opentelemetry/trace/trace_flags'
-require 'opentelemetry/trace/tracer'
-
 module OpenTelemetry
   # The Trace API allows recording a set of events, triggered as a result of a
   # single logical operation, consolidated across various components of an
   # application.
   module Trace
+    # An invalid trace identifier, a 16-byte array with all zero bytes, encoded
+    # as a hexadecimal string.
     INVALID_TRACE_ID = '0' * 32
-    INVALID_SPAN_ID = '0' * 16
 
-    private_constant(:INVALID_TRACE_ID, :INVALID_SPAN_ID)
+    # An invalid span identifier, an 8-byte array with all zero bytes, encoded
+    # as a hexadecimal string.
+    INVALID_SPAN_ID = '0' * 16
 
     # Generates a valid trace identifier, a 16-byte array with at least one
     # non-zero byte, encoded as a hexadecimal string.
     #
     # @return [String] a hexadecimal string encoding of a valid trace ID.
-    def generate_trace_id
+    def self.generate_trace_id
       loop do
         id = Random::DEFAULT.bytes(16).unpack1('H*')
         return id unless id == INVALID_TRACE_ID
@@ -37,7 +32,7 @@ module OpenTelemetry
     # non-zero byte, encoded as a hexadecimal string.
     #
     # @return [String] a hexadecimal string encoding of a valid span ID.
-    def generate_span_id
+    def self.generate_span_id
       loop do
         id = Random::DEFAULT.bytes(8).unpack1('H*')
         return id unless id == INVALID_SPAN_ID
@@ -45,3 +40,11 @@ module OpenTelemetry
     end
   end
 end
+
+require 'opentelemetry/trace/samplers'
+require 'opentelemetry/trace/span_context'
+require 'opentelemetry/trace/span_kind'
+require 'opentelemetry/trace/span'
+require 'opentelemetry/trace/status'
+require 'opentelemetry/trace/trace_flags'
+require 'opentelemetry/trace/tracer'

--- a/api/lib/opentelemetry/trace.rb
+++ b/api/lib/opentelemetry/trace.rb
@@ -11,3 +11,37 @@ require 'opentelemetry/trace/span'
 require 'opentelemetry/trace/status'
 require 'opentelemetry/trace/trace_flags'
 require 'opentelemetry/trace/tracer'
+
+module OpenTelemetry
+  # The Trace API allows recording a set of events, triggered as a result of a
+  # single logical operation, consolidated across various components of an
+  # application.
+  module Trace
+    INVALID_TRACE_ID = '0' * 32
+    INVALID_SPAN_ID = '0' * 16
+
+    private_constant(:INVALID_TRACE_ID, :INVALID_SPAN_ID)
+
+    # Generates a valid trace identifier, a 16-byte array with at least one
+    # non-zero byte, encoded as a hexadecimal string.
+    #
+    # @return [String] a hexadecimal string encoding of a valid trace ID.
+    def generate_trace_id
+      loop do
+        id = Random::DEFAULT.bytes(16).unpack1('H*')
+        return id unless id == INVALID_TRACE_ID
+      end
+    end
+
+    # Generates a valid span identifier, an 8-byte array with at least one
+    # non-zero byte, encoded as a hexadecimal string.
+    #
+    # @return [String] a hexadecimal string encoding of a valid span ID.
+    def generate_span_id
+      loop do
+        id = Random::DEFAULT.bytes(8).unpack1('H*')
+        return id unless id == INVALID_SPAN_ID
+      end
+    end
+  end
+end

--- a/api/lib/opentelemetry/trace.rb
+++ b/api/lib/opentelemetry/trace.rb
@@ -11,11 +11,11 @@ module OpenTelemetry
   module Trace
     # An invalid trace identifier, a 16-byte array with all zero bytes, encoded
     # as a hexadecimal string.
-    INVALID_TRACE_ID = '0' * 32
+    INVALID_TRACE_ID = ('0' * 32).freeze
 
     # An invalid span identifier, an 8-byte array with all zero bytes, encoded
     # as a hexadecimal string.
-    INVALID_SPAN_ID = '0' * 16
+    INVALID_SPAN_ID = ('0' * 16).freeze
 
     # Generates a valid trace identifier, a 16-byte array with at least one
     # non-zero byte, encoded as a hexadecimal string.

--- a/api/lib/opentelemetry/trace.rb
+++ b/api/lib/opentelemetry/trace.rb
@@ -4,9 +4,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require 'opentelemetry/trace/samplers'
 require 'opentelemetry/trace/span_context'
 require 'opentelemetry/trace/span_kind'
 require 'opentelemetry/trace/span'
 require 'opentelemetry/trace/status'
+require 'opentelemetry/trace/trace_flags'
 require 'opentelemetry/trace/tracer'
-require 'opentelemetry/trace/samplers'

--- a/api/lib/opentelemetry/trace/span_context.rb
+++ b/api/lib/opentelemetry/trace/span_context.rb
@@ -6,24 +6,39 @@
 
 module OpenTelemetry
   module Trace
-    # A SpanContext contains the state that must propagate to child @see Spans and across process boundaries.
-    # It contains the identifiers (a @see TraceId and @see SpanId) associated with the @see Span and a set of
-    # @see TraceOptions.
+    # A SpanContext contains the state that must propagate to child {Span}s and across process boundaries.
+    # It contains the identifiers (a trace ID and span ID) associated with the {Span} and a set of
+    # {TraceFlags}.
     class SpanContext
-      attr_reader :trace_id, :span_id, :trace_options
+      attr_reader :trace_id, :span_id, :trace_flags
 
       def initialize(
         trace_id: generate_trace_id,
         span_id: generate_span_id,
-        trace_options: TraceOptions::DEFAULT
+        trace_flags: TraceFlags::DEFAULT
       )
         @trace_id = trace_id
         @span_id = span_id
-        @trace_options = trace_options
+        @trace_flags = trace_flags
       end
 
       def valid?
         !(@trace_id.zero? || @span_id.zero?)
+      end
+
+      private
+
+      SPAN_ID_RANGE = (1..(2**64 - 1)).freeze
+      TRACE_ID_RANGE = (1..(2**128 - 1)).freeze
+
+      private_constant(:SPAN_ID_RANGE, :TRACE_ID_RANGE)
+
+      def generate_trace_id
+        rand(TRACE_ID_RANGE)
+      end
+
+      def generate_span_id
+        rand(SPAN_ID_RANGE)
       end
     end
   end

--- a/api/lib/opentelemetry/trace/span_context.rb
+++ b/api/lib/opentelemetry/trace/span_context.rb
@@ -28,17 +28,23 @@ module OpenTelemetry
 
       private
 
-      SPAN_ID_RANGE = (1..(2**64 - 1)).freeze
-      TRACE_ID_RANGE = (1..(2**128 - 1)).freeze
+      INVALID_TRACE_ID = '0' * 32
+      INVALID_SPAN_ID = '0' * 16
 
-      private_constant(:SPAN_ID_RANGE, :TRACE_ID_RANGE)
+      private_constant(:INVALID_TRACE_ID, :INVALID_SPAN_ID)
 
       def generate_trace_id
-        rand(TRACE_ID_RANGE)
+        loop do
+          id = Random::DEFAULT.bytes(16).unpack1('H*')
+          return id unless id == INVALID_TRACE_ID
+        end
       end
 
       def generate_span_id
-        rand(SPAN_ID_RANGE)
+        loop do
+          id = Random::DEFAULT.bytes(8).unpack1('H*')
+          return id unless id == INVALID_SPAN_ID
+        end
       end
     end
   end

--- a/api/lib/opentelemetry/trace/span_context.rb
+++ b/api/lib/opentelemetry/trace/span_context.rb
@@ -13,9 +13,9 @@ module OpenTelemetry
       attr_reader :trace_id, :span_id, :trace_flags
 
       def initialize(
-        trace_id: OpenTelemetry::Trace.generate_trace_id,
-        span_id: OpenTelemetry::Trace.generate_span_id,
-        trace_flags: OpenTelemetry::Trace::TraceFlags::DEFAULT
+        trace_id: Trace.generate_trace_id,
+        span_id: Trace.generate_span_id,
+        trace_flags: TraceFlags::DEFAULT
       )
         @trace_id = trace_id
         @span_id = span_id
@@ -23,16 +23,10 @@ module OpenTelemetry
       end
 
       def valid?
-        @trace_id != OpenTelemetry::Trace::INVALID_TRACE_ID &&
-          @span_id != OpenTelemetry::Trace::INVALID_SPAN_ID
+        @trace_id != INVALID_TRACE_ID && @span_id != INVALID_SPAN_ID
       end
 
-      def self.invalid
-        @invalid ||= new(
-          trace_id: OpenTelemetry::Trace::INVALID_TRACE_ID,
-          span_id: OpenTelemetry::Trace::INVALID_SPAN_ID
-        )
-      end
+      INVALID = new(trace_id: INVALID_TRACE_ID, span_id: INVALID_SPAN_ID)
     end
   end
 end

--- a/api/lib/opentelemetry/trace/span_context.rb
+++ b/api/lib/opentelemetry/trace/span_context.rb
@@ -25,27 +25,6 @@ module OpenTelemetry
       def valid?
         !(@trace_id.zero? || @span_id.zero?)
       end
-
-      private
-
-      INVALID_TRACE_ID = '0' * 32
-      INVALID_SPAN_ID = '0' * 16
-
-      private_constant(:INVALID_TRACE_ID, :INVALID_SPAN_ID)
-
-      def generate_trace_id
-        loop do
-          id = Random::DEFAULT.bytes(16).unpack1('H*')
-          return id unless id == INVALID_TRACE_ID
-        end
-      end
-
-      def generate_span_id
-        loop do
-          id = Random::DEFAULT.bytes(8).unpack1('H*')
-          return id unless id == INVALID_SPAN_ID
-        end
-      end
     end
   end
 end

--- a/api/lib/opentelemetry/trace/span_context.rb
+++ b/api/lib/opentelemetry/trace/span_context.rb
@@ -13,9 +13,9 @@ module OpenTelemetry
       attr_reader :trace_id, :span_id, :trace_flags
 
       def initialize(
-        trace_id: generate_trace_id,
-        span_id: generate_span_id,
-        trace_flags: TraceFlags::DEFAULT
+        trace_id: OpenTelemetry::Trace.generate_trace_id,
+        span_id: OpenTelemetry::Trace.generate_span_id,
+        trace_flags: OpenTelemetry::Trace::TraceFlags::DEFAULT
       )
         @trace_id = trace_id
         @span_id = span_id
@@ -23,7 +23,15 @@ module OpenTelemetry
       end
 
       def valid?
-        !(@trace_id.zero? || @span_id.zero?)
+        @trace_id != OpenTelemetry::Trace::INVALID_TRACE_ID &&
+          @span_id != OpenTelemetry::Trace::INVALID_SPAN_ID
+      end
+
+      def self.invalid
+        @invalid ||= new(
+          trace_id: OpenTelemetry::Trace::INVALID_TRACE_ID,
+          span_id: OpenTelemetry::Trace::INVALID_SPAN_ID
+        )
       end
     end
   end

--- a/api/lib/opentelemetry/trace/trace_flags.rb
+++ b/api/lib/opentelemetry/trace/trace_flags.rb
@@ -19,7 +19,7 @@ module OpenTelemetry
         # @raise [ArgumentError] If flags is not an 8-bit byte
         # @return [TraceFlags]
         def from_byte(flags)
-          raise ArgumentError, 'flags must be an 8-bit byte' unless (0..255).include?(flags)
+          raise ArgumentError, 'flags must be an 8-bit byte' unless flags & ~0xFF == 0
 
           new(flags)
         end

--- a/api/lib/opentelemetry/trace/trace_flags.rb
+++ b/api/lib/opentelemetry/trace/trace_flags.rb
@@ -19,7 +19,7 @@ module OpenTelemetry
         # @raise [ArgumentError] If flags is not an 8-bit byte
         # @return [TraceFlags]
         def from_byte(flags)
-          raise ArgumentError, 'flags must be an 8-bit byte' unless flags & ~0xFF == 0
+          raise ArgumentError, 'flags must be an 8-bit byte' unless (flags & ~0xFF).zero?
 
           new(flags)
         end

--- a/api/lib/opentelemetry/trace/trace_flags.rb
+++ b/api/lib/opentelemetry/trace/trace_flags.rb
@@ -19,7 +19,7 @@ module OpenTelemetry
         # @raise [ArgumentError] If flags is not an 8-bit byte
         # @return [TraceFlags]
         def from_byte(flags)
-          raise ArgumentError, 'flags must be an 8-bit byte' unless (flags & ~0xFF).zero?
+          raise ArgumentError, 'flags must be an 8-bit byte' unless flags & ~0xFF == 0 # rubocop:disable Style/NumericPredicate
 
           new(flags)
         end

--- a/api/lib/opentelemetry/trace/trace_flags.rb
+++ b/api/lib/opentelemetry/trace/trace_flags.rb
@@ -27,7 +27,7 @@ module OpenTelemetry
 
       # @api private
       # The constructor is private and only for use internally by the class.
-      # Users should use the {fromByte} factory method to obtain a {TraceFlags}
+      # Users should use the {from_byte} factory method to obtain a {TraceFlags}
       # instance.
       #
       # @param [Integer] flags 8-bit byte of bit flags

--- a/api/lib/opentelemetry/trace/trace_flags.rb
+++ b/api/lib/opentelemetry/trace/trace_flags.rb
@@ -41,7 +41,7 @@ module OpenTelemetry
       #
       # @return [Boolean]
       def sampled?
-        @flags.anybits?(1)
+        (@flags & 1) != 0
       end
 
       DEFAULT = from_byte(0)

--- a/api/lib/opentelemetry/trace/trace_flags.rb
+++ b/api/lib/opentelemetry/trace/trace_flags.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Trace
+    # TraceFlags contain details about the trace. Unlike Tracestate values,
+    # TraceFlags are present in all traces. Currently, the only TraceFlag is a
+    # boolean {sampled?} {https://www.w3.org/TR/trace-context/#trace-flags flag}.
+    class TraceFlags
+      class << self
+        private :new # rubocop:disable Style/AccessModifierDeclarations
+
+        # Returns a newly created {TraceFlags} with the specified flags.
+        #
+        # @param [Integer] flags 8-bit byte of bit flags
+        # @raise [ArgumentError] If flags is not an 8-bit byte
+        # @return [TraceFlags]
+        def from_byte(flags)
+          raise ArgumentError, 'flags must be an 8-bit byte' unless (0..255).include?(flags)
+
+          new(flags)
+        end
+      end
+
+      # @api private
+      # The constructor is private and only for use internally by the class.
+      # Users should use the {fromByte} factory method to obtain a {TraceFlags}
+      # instance.
+      #
+      # @param [Integer] flags 8-bit byte of bit flags
+      # @return [TraceFlags]
+      def initialize(flags)
+        @flags = flags
+      end
+
+      # Returns whether the caller may have recorded trace data. When false,
+      # the caller did not record trace data out-of-band.
+      #
+      # @return [Boolean]
+      def sampled?
+        @flags.anybits?(1)
+      end
+
+      DEFAULT = from_byte(0)
+    end
+  end
+end

--- a/api/lib/opentelemetry/trace/tracer.rb
+++ b/api/lib/opentelemetry/trace/tracer.rb
@@ -50,10 +50,10 @@ module OpenTelemetry
         raise ArgumentError if name.nil?
 
         span_context = with_parent&.context || with_parent_context || current_span.context
-        if SpanContext.INVALID == span_context
-          Span.create_random
-        else
+        if span_context.valid?
           Span.new(span_context)
+        else
+          Span.create_random
         end
       end
 

--- a/api/test/opentelemetry/trace/span_context_test.rb
+++ b/api/test/opentelemetry/trace/span_context_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 describe OpenTelemetry::Trace::SpanContext do
   let(:span_context) { OpenTelemetry::Trace::SpanContext.new }
-  let(:invalid_context) { OpenTelemetry::Trace::SpanContext.invalid }
+  let(:invalid_context) { OpenTelemetry::Trace::SpanContext::INVALID }
 
   describe '#initialize' do
     it 'must generate valid span_id and trace_id by default' do

--- a/api/test/opentelemetry/trace/span_context_test.rb
+++ b/api/test/opentelemetry/trace/span_context_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+describe OpenTelemetry::Trace::SpanContext do
+  let(:span_context) { OpenTelemetry::Trace::SpanContext.new }
+  let(:invalid_context) { OpenTelemetry::Trace::SpanContext.invalid }
+
+  describe '#initialize' do
+    it 'must generate valid span_id and trace_id by default' do
+      span_context.trace_id.wont_equal(OpenTelemetry::Trace::INVALID_TRACE_ID)
+      span_context.span_id.wont_equal(OpenTelemetry::Trace::INVALID_SPAN_ID)
+    end
+  end
+
+  describe '#valid?' do
+    it 'is true by default' do
+      span_context.must_be(:valid?)
+    end
+
+    it 'is false for invalid context' do
+      invalid_context.wont_be(:valid?)
+    end
+  end
+
+  describe '#trace_id' do
+    it 'reflects the value passed in' do
+      trace_id = OpenTelemetry::Trace.generate_trace_id
+      context = OpenTelemetry::Trace::SpanContext.new(trace_id: trace_id)
+      context.trace_id.must_equal(trace_id)
+    end
+
+    it 'is invalid for invalid context' do
+      invalid_context.trace_id
+                     .must_equal(OpenTelemetry::Trace::INVALID_TRACE_ID)
+    end
+  end
+
+  describe '#span_id' do
+    it 'reflects the value passed in' do
+      span_id = OpenTelemetry::Trace.generate_span_id
+      context = OpenTelemetry::Trace::SpanContext.new(span_id: span_id)
+      context.span_id.must_equal(span_id)
+    end
+
+    it 'is invalid for invalid context' do
+      invalid_context.span_id.must_equal(OpenTelemetry::Trace::INVALID_SPAN_ID)
+    end
+  end
+
+  describe '#trace_flags' do
+    it 'is unsampled by default' do
+      span_context.trace_flags.wont_be(:sampled?)
+    end
+
+    it 'reflects the value passed in' do
+      flags = OpenTelemetry::Trace::TraceFlags.from_byte(1)
+      context = OpenTelemetry::Trace::SpanContext.new(trace_flags: flags)
+      context.trace_flags.must_equal(flags)
+    end
+  end
+end

--- a/api/test/opentelemetry/trace/trace_flags_test.rb
+++ b/api/test/opentelemetry/trace/trace_flags_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+describe OpenTelemetry::Trace::TraceFlags do
+  describe '.new' do
+    it 'is private' do
+      -> { OpenTelemetry::Trace::TraceFlags.new(0) }\
+        .must_raise(NoMethodError)
+    end
+  end
+  describe '.fromByte' do
+    it 'can be initialized with a byte' do
+      flags = OpenTelemetry::Trace::TraceFlags.from_byte(0)
+      flags.sampled?.must_equal(false)
+    end
+
+    it 'enforces flags is an 8-bit byte' do
+      -> { OpenTelemetry::Trace::TraceFlags.from_byte(256) }\
+        .must_raise(ArgumentError)
+    end
+  end
+
+  describe '#sampled?' do
+    it 'reflects the least-significant bit in the flags' do
+      sampled = OpenTelemetry::Trace::TraceFlags.from_byte(1)
+      not_sampled = OpenTelemetry::Trace::TraceFlags.from_byte(0)
+
+      sampled.sampled?.must_equal(true)
+      not_sampled.sampled?.must_equal(false)
+    end
+  end
+end

--- a/api/test/opentelemetry/trace/trace_flags_test.rb
+++ b/api/test/opentelemetry/trace/trace_flags_test.rb
@@ -9,7 +9,7 @@ describe OpenTelemetry::Trace::TraceFlags do
         .must_raise(NoMethodError)
     end
   end
-  describe '.fromByte' do
+  describe '.from_byte' do
     it 'can be initialized with a byte' do
       flags = OpenTelemetry::Trace::TraceFlags.from_byte(0)
       flags.sampled?.must_equal(false)


### PR DESCRIPTION
This implement `TraceFlags`. This used to be called `TraceOptions`, but https://github.com/open-telemetry/opentelemetry-specification/pull/234 proposes a rename to match the W3C spec.

This also implements `generate_span_id` and `generate_trace_id` in `SpanContext`.