### PR TITLE
Simplify SpanContext creation in tests

### DIFF
--- a/api/test/opentelemetry/trace/link_test.rb
+++ b/api/test/opentelemetry/trace/link_test.rb
@@ -8,9 +8,7 @@ require 'test_helper'
 
 describe OpenTelemetry::Trace::Link do
   let(:span_context) do
-    OpenTelemetry::Trace::SpanContext.new(trace_id: 123,
-                                          span_id: 456,
-                                          trace_options: 0x0)
+    OpenTelemetry::Trace::SpanContext.new
   end
   describe '.new' do
     it 'accepts a span_context' do

--- a/api/test/opentelemetry/trace/span_test.rb
+++ b/api/test/opentelemetry/trace/span_test.rb
@@ -8,9 +8,7 @@ require 'test_helper'
 
 describe OpenTelemetry::Trace::Span do
   let(:span_context) do
-    OpenTelemetry::Trace::SpanContext.new(trace_id: 123,
-                                          span_id: 456,
-                                          trace_options: 0x0)
+    OpenTelemetry::Trace::SpanContext.new
   end
   let(:span) { build_span(span_context: span_context) }
 


### PR DESCRIPTION
There have a been a few PRs merged into master, and while all of them were passing tests individually, they are failing after integration. There were a couple of tests referring to `trace_flags` as `trace_options`. Recent updates to SpanContext makes creation easier, so I updated the affected tests to use `SpanContext.new` with default instead of explicit arguments.