### PR TITLE
Sort dependencies alphabetically

### DIFF
--- a/api/opentelemetry-api.gemspec
+++ b/api/opentelemetry-api.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'simplecov', '~> 0.17'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
-  spec.add_development_dependency 'simplecov', '~> 0.17'
 end


### PR DESCRIPTION
This PR addresses the following Rubocop offense about our dependency ordering.

```
Offenses:

opentelemetry-api.gemspec:35:3: C: Gemspec/OrderedDependencies: Dependencies should be sorted in an alphabetical order within their section of the gemspec. Dependency simplecov should appear before yard-doctest.
  spec.add_development_dependency 'simplecov', '~> 0.17'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```