### PR TITLE
Use string comparisons for ProbabilitySampler

### DIFF
--- a/api/lib/opentelemetry/trace/samplers/always_sample_sampler.rb
+++ b/api/lib/opentelemetry/trace/samplers/always_sample_sampler.rb
@@ -20,8 +20,8 @@ module OpenTelemetry
         #   typically extracted from the wire. Can be nil for a root span.
         # @param [Boolean] extracted_context True if span_context was extracted
         #   from the wire. Can be nil for a root span.
-        # @param [Integer] trace_id The trace_id of the {Span} to be created
-        # @param [Integer] span_id The span_id of the {Span} to be created
+        # @param [String] trace_id The trace_id of the {Span} to be created
+        # @param [String] span_id The span_id of the {Span} to be created
         # @param [String] span_name Name of the {Span} to be created
         # @param [Enumerable<Link>] links A collection of links to be associated
         #   with the {Span} to be created. Can be nil.

--- a/api/lib/opentelemetry/trace/samplers/never_sample_sampler.rb
+++ b/api/lib/opentelemetry/trace/samplers/never_sample_sampler.rb
@@ -20,8 +20,8 @@ module OpenTelemetry
         #   typically extracted from the wire. Can be nil for a root span.
         # @param [Boolean] extracted_context True if span_context was extracted
         #   from the wire. Can be nil for a root span.
-        # @param [Integer] trace_id The trace_id of the {Span} to be created
-        # @param [Integer] span_id The span_id of the {Span} to be created
+        # @param [String] trace_id The trace_id of the {Span} to be created
+        # @param [String] span_id The span_id of the {Span} to be created
         # @param [String] span_name Name of the {Span} to be created
         # @param [Enumerable<Link>] links A collection of links to be associated
         #   with the {Span} to be created. Can be nil.

--- a/api/lib/opentelemetry/trace/samplers/sampler.rb
+++ b/api/lib/opentelemetry/trace/samplers/sampler.rb
@@ -16,8 +16,8 @@ module OpenTelemetry
         #   typically extracted from the wire. Can be nil for a root span.
         # @param [Boolean] extracted_context True if span_context was extracted
         #   from the wire. Can be nil for a root span.
-        # @param [Integer] trace_id The trace_id of the {Span} to be created
-        # @param [Integer] span_id The span_id of the {Span} to be created
+        # @param [String] trace_id The trace_id of the {Span} to be created
+        # @param [String] span_id The span_id of the {Span} to be created
         # @param [String] span_name Name of the {Span} to be created
         # @param [Enumerable<Link>] links A collection of links to be associated
         #   with the {Span} to be created. Can be nil.
@@ -31,8 +31,8 @@ module OpenTelemetry
                      links: nil)
           raise ArgumentError, "expected span_context to be a SpanContext, not #{span_context.class}" if span_context && !span_context.is_a?(SpanContext)
           raise ArgumentError, "expected extracted_context to be a Boolean, not #{extracted_context.class}" if !extracted_context.nil? && !Internal.boolean?(extracted_context)
-          raise ArgumentError, "expected trace_id to be an Integer, not #{trace_id.class}" unless trace_id.is_a?(Integer)
-          raise ArgumentError, "expected span_id to be an Integer, not #{span_id.class}" unless span_id.is_a?(Integer)
+          raise ArgumentError, "expected trace_id to be an String, not #{trace_id.class}" unless trace_id.is_a?(String)
+          raise ArgumentError, "expected span_id to be an String, not #{span_id.class}" unless span_id.is_a?(String)
           raise ArgumentError, "expected span_name to be a String, not #{span_name.class}" unless span_name.is_a?(String)
           raise ArgumentError, 'expected links to be an Enumerable' if links && !links.class.include?(Enumerable)
         end

--- a/api/test/opentelemetry/trace/samplers/always_sample_sampler_test.rb
+++ b/api/test/opentelemetry/trace/samplers/always_sample_sampler_test.rb
@@ -18,8 +18,8 @@ describe OpenTelemetry::Trace::Samplers::AlwaysSampleSampler do
       decision = sampler.decision(
         span_context: nil,
         extracted_context: nil,
-        trace_id: 344,
-        span_id: 178,
+        trace_id: '344',
+        span_id: '178',
         span_name: 'test_span',
         links: nil
       )

--- a/api/test/opentelemetry/trace/samplers/never_sample_sampler_test.rb
+++ b/api/test/opentelemetry/trace/samplers/never_sample_sampler_test.rb
@@ -18,8 +18,8 @@ describe OpenTelemetry::Trace::Samplers::NeverSampleSampler do
       decision = sampler.decision(
         span_context: nil,
         extracted_context: nil,
-        trace_id: 344,
-        span_id: 178,
+        trace_id: '344',
+        span_id: '178',
         span_name: 'test_span',
         links: nil
       )

--- a/api/test/opentelemetry/trace/samplers/sampler_test.rb
+++ b/api/test/opentelemetry/trace/samplers/sampler_test.rb
@@ -32,8 +32,8 @@ describe OpenTelemetry::Trace::Samplers::Sampler do
       decision = sampler.decision(
         span_context: nil,
         extracted_context: nil,
-        trace_id: 344,
-        span_id: 178,
+        trace_id: '344',
+        span_id: '178',
         span_name: 'test_span',
         links: nil
       )
@@ -45,8 +45,8 @@ describe OpenTelemetry::Trace::Samplers::Sampler do
         sampler.decision(
           span_context: Object.new,
           extracted_context: nil,
-          trace_id: 344,
-          span_id: 178,
+          trace_id: '344',
+          span_id: '178',
           span_name: 'test_span',
           links: nil
         )
@@ -58,8 +58,8 @@ describe OpenTelemetry::Trace::Samplers::Sampler do
         sampler.decision(
           span_context: nil,
           extracted_context: Object.new,
-          trace_id: 344,
-          span_id: 178,
+          trace_id: '344',
+          span_id: '178',
           span_name: 'test_span',
           links: nil
         )
@@ -72,7 +72,7 @@ describe OpenTelemetry::Trace::Samplers::Sampler do
           span_context: nil,
           extracted_context: nil,
           trace_id: Object.new,
-          span_id: 178,
+          span_id: '178',
           span_name: 'test_span',
           links: nil
         )
@@ -84,7 +84,7 @@ describe OpenTelemetry::Trace::Samplers::Sampler do
         sampler.decision(
           span_context: nil,
           extracted_context: nil,
-          trace_id: 344,
+          trace_id: '344',
           span_id: Object.new,
           span_name: 'test_span',
           links: nil
@@ -97,8 +97,8 @@ describe OpenTelemetry::Trace::Samplers::Sampler do
         sampler.decision(
           span_context: nil,
           extracted_context: nil,
-          trace_id: 344,
-          span_id: 178,
+          trace_id: '344',
+          span_id: '178',
           span_name: Object.new,
           links: nil
         )
@@ -110,8 +110,8 @@ describe OpenTelemetry::Trace::Samplers::Sampler do
         sampler.decision(
           span_context: nil,
           extracted_context: nil,
-          trace_id: 344,
-          span_id: 178,
+          trace_id: '344',
+          span_id: '178',
           span_name: 'test_span',
           links: Object.new
         )

--- a/sdk/Rakefile
+++ b/sdk/Rakefile
@@ -14,6 +14,7 @@ RuboCop::RakeTask.new
 Rake::TestTask.new :test do |t|
   t.libs << 'test'
   t.libs << 'lib'
+  t.libs << '../api/lib'
   t.test_files = FileList['test/**/*_test.rb']
 end
 

--- a/sdk/test/opentelemetry/sdk/trace/samplers/probability_sampler_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/samplers/probability_sampler_test.rb
@@ -19,8 +19,8 @@ describe OpenTelemetry::SDK::Trace::Samplers::ProbabilitySampler do
     let(:sampler) { ProbabilitySampler.create(Float::MIN) }
     it 'respects parent sample decision' do
       decision = sampler.decision(
-        trace_id: 123,
-        span_id: 456,
+        trace_id: '123',
+        span_id: '456',
         span_name: '',
         span_context: context
       )
@@ -29,25 +29,31 @@ describe OpenTelemetry::SDK::Trace::Samplers::ProbabilitySampler do
     it 'respects link sample decisions' do
       link = OpenTelemetry::Trace::Link.new(span_context: context)
       decision = sampler.decision(
-        trace_id: 123,
-        span_id: 456,
+        trace_id: '123',
+        span_id: '456',
         span_name: '',
         links: [link]
       )
       decision.must_be :sampled?
     end
     it 'returns a decision' do
-      decision = sampler.decision(trace_id: 123, span_id: 456, span_name: '')
+      decision = sampler.decision(trace_id: trace_id(123),
+                                  span_id: '456',
+                                  span_name: '')
       decision.must_be_instance_of(Decision)
     end
     it 'returns a true decision if probability is 1' do
       positive = ProbabilitySampler.create(1)
-      decision = positive.decision(trace_id: 123, span_id: 456, span_name: '')
+      decision = positive.decision(trace_id: 'f' * 32,
+                                   span_id: '456',
+                                   span_name: '')
       decision.must_be :sampled?
     end
     it 'returns a false decision if probability is 0' do
       negative = ProbabilitySampler.create(0)
-      decision = negative.decision(trace_id: 123, span_id: 456, span_name: '')
+      decision = negative.decision(trace_id: trace_id(1),
+                                   span_id: '456',
+                                   span_name: '')
       decision.wont_be :sampled?
     end
   end
@@ -72,5 +78,9 @@ describe OpenTelemetry::SDK::Trace::Samplers::ProbabilitySampler do
       ProbabilitySampler.create(0.5).must_be_kind_of(Sampler)
       ProbabilitySampler.create(1).must_be_kind_of(Sampler)
     end
+  end
+
+  def trace_id(id)
+    format('%032x', id)
   end
 end


### PR DESCRIPTION
This switches comparison in the ProbabilitySampler to be closer to the Java implementation, but compare in the ASCII codespace rather than in Integer space. May need some tweaks if we want an exact match, but I think this is more in the spirit of the "spec" than the `rand` approach.