### PR TITLE
Add truffleruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,6 @@ rvm:
   - 2.5
   - 2.6
   - jruby
+  - truffleruby
 install: ( cd api && bundle install --jobs=3 --retry=3 )
 script: ( cd api && rake )

--- a/api/Rakefile
+++ b/api/Rakefile
@@ -30,4 +30,8 @@ YARD::Rake::YardocTask.new do |t|
   t.stats_options = ['--list-undoc'] # optional
 end
 
-task default: %i[test rubocop yard]
+if RUBY_ENGINE == 'truffleruby'
+  task default: %i[test]
+else
+  task default: %i[test rubocop yard]
+end

--- a/sdk/Rakefile
+++ b/sdk/Rakefile
@@ -32,4 +32,8 @@ YARD::Rake::YardocTask.new do |t|
   t.stats_options = ['--list-undoc'] # optional
 end
 
-task default: %i[test rubocop yard]
+if RUBY_ENGINE == 'truffleruby'
+  task default: %i[test]
+else
+  task default: %i[test rubocop yard]
+end


### PR DESCRIPTION
This adds support for TruffleRuby to CI. RuboCop is unhappy running on TruffleRuby, so I disabled that, along with Yard (since the builds are already kinda slow).