### PR TITLE
Add basic benchmarks for tracer and span

### DIFF
--- a/api/benchmarks/span_bench.rb
+++ b/api/benchmarks/span_bench.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'benchmark/ipsa'
+require 'opentelemetry'
+
+span = OpenTelemetry::Trace::Span.new
+
+attributes = {
+  'component' => 'rack',
+  'span.kind' => 'server',
+  'http.method' => 'GET',
+  'http.url' => 'blogs/index'
+}
+
+Benchmark.ipsa do |x|
+  x.report 'name=' do
+    span.name = 'new_name'
+  end
+
+  x.report 'set_attribute' do
+    span.set_attribute('k', 'v')
+  end
+
+  x.report 'add_event' do
+    span.add_event(name: 'test event', attributes: attributes)
+  end
+
+  x.compare!
+end

--- a/api/benchmarks/tracer_bench.rb
+++ b/api/benchmarks/tracer_bench.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'benchmark/ipsa'
+require 'opentelemetry'
+
+tracer = OpenTelemetry::Trace::Tracer.new
+
+parent_span = tracer.start_span('parent')
+
+attributes = {
+  'component' => 'rack',
+  'span.kind' => 'server',
+  'http.method' => 'GET',
+  'http.url' => 'blogs/index'
+}
+
+links = Array.new(3) do
+  OpenTelemetry::Trace::Link.new(
+    OpenTelemetry::Trace::SpanContext.new,
+    attributes
+  )
+end
+
+Benchmark.ipsa do |x|
+  x.report 'start span' do
+    span = tracer.start_span('test_span')
+    span.finish
+  end
+
+  x.report 'start span with parent' do
+    span = tracer.start_span('test_span', with_parent: parent_span)
+    span.finish
+  end
+
+  x.report 'start span with parent context' do
+    span = tracer.start_span('test_span', with_parent_context: parent_span.context)
+    span.finish
+  end
+
+  x.report 'start span with attributes' do
+    span = tracer.start_span('test_span', attributes: attributes)
+    span.finish
+  end
+
+  x.report 'start span with links' do
+    span = tracer.start_span('test_span', links: links)
+    span.finish
+  end
+
+  x.compare!
+end

--- a/api/opentelemetry-api.gemspec
+++ b/api/opentelemetry-api.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.4.0'
 
+  spec.add_development_dependency 'benchmark-ipsa', '~> 0.2.0'
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'faraday', '~> 0.13'
   spec.add_development_dependency 'minitest', '~> 5.0'


### PR DESCRIPTION
I was looking over #115 and thought it would be useful if we had some simple benchmarks as a point of comparison. This PR adds simple benchmarks for tracer and span. They can be run from the `/api` folder by typing: `bundle exec ruby benchmarks/tracer_bench.rb` or `bundle exec ruby benchmarks/span_bench.rb`. If we like these benchmarks, we can look into adding some niceties around running them.