### PR TITLE
Add Docker and Docker Compose Configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,79 @@
+# Configuration for Ruby base image
+ARG ALPINE_VERSION=3.10
+ARG RUBY_VERSION=2.6.5
+
+FROM ruby:"${RUBY_VERSION}-alpine${ALPINE_VERSION}" as ruby
+
+# Metadata
+LABEL maintainer="open-telemetry/opentelemetry-ruby"
+
+# User and Group for app isolation
+ARG APP_UID=1000
+ARG APP_USER=app
+ARG APP_GID=1000
+ARG APP_GROUP=app
+ARG APP_DIR=/app
+
+# Rubygems Bundler version
+ARG BUNDLER_VERSION=2.0.2
+
+ENV SHELL /bin/bash
+
+ARG PACKAGES="\
+    autoconf \
+    automake \
+    bash \
+    binutils \
+    build-base \
+    coreutils  \
+    execline \
+    findutils \
+    git \
+    grep \
+    less \
+    libstdc++ \
+    libtool \
+    libxml2-dev \
+    libxslt-dev \
+    openssl \
+    tzdata \
+    util-linux \
+    "
+# Install packages
+RUN apk update && \
+    apk upgrade && \
+    apk add --no-cache ${PACKAGES}
+
+# Configure Bundler and PATH
+ENV LANG=C.UTF-8 \
+    GEM_HOME=/bundle \
+    BUNDLE_JOBS=20 \
+    BUNDLE_RETRY=3
+ENV BUNDLE_PATH $GEM_HOME
+ENV BUNDLE_APP_CONFIG="${BUNDLE_PATH}" \
+    BUNDLE_BIN="${BUNDLE_PATH}/bin" \
+    BUNDLE_GEMFILE=Gemfile
+ENV PATH "${APP_DIR}/bin:${BUNDLE_BIN}:${PATH}"
+
+# Upgrade RubyGems and install required Bundler version
+RUN gem update --system && \
+    gem install "bundler:${BUNDLER_VERSION}" && \
+    gem cleanup
+
+# Add custom app User and Group
+RUN addgroup -S -g "${APP_GID}" "${APP_GROUP}" && \
+    adduser -S -g "${APP_GROUP}" -u "${APP_UID}" "${APP_USER}"
+
+# Create directories for the app code
+RUN mkdir -p "${APP_DIR}" \
+    "${APP_DIR}/tmp" && \
+    chown -R "${APP_USER}":"${APP_GROUP}" "${APP_DIR}" \
+    "${APP_DIR}/tmp" \
+    "${BUNDLE_PATH}/"
+
+USER "${APP_USER}"
+
+WORKDIR "${APP_DIR}"
+
+# Commands will be supplied via `docker-compose`
+CMD []

--- a/README.md
+++ b/README.md
@@ -14,6 +14,34 @@ We'd love your help! Use tags [good first issue][issues-good-first-issue] and
 The Ruby special interest group (SIG) meets regularly. See the OpenTelemetry
 [community page][ruby-sig] repo for information on this and other language SIGs.
 
+## Developer Setup
+
+1. Install Docker and Docker Compose for your operating system
+1. Get the latest code for the project
+1. Build the `opentelemetry/opentelemetry-ruby` image
+    * `docker-compose build`
+    * This makes the image available locally
+1. API:
+    1. Install dependencies
+        * `docker-compose run api bundle install`
+    1. Run the tests
+        * `docker-compose run api bundle exec rake test`
+1. SDK:
+    1. Install dependencies
+        * `docker-compose run sdk bundle install`
+    1. Run the tests for the sdk
+        * `docker-compose run sdk bundle exec rake test`
+
+### Docker Services
+
+We use Docker Compose to configure and build services used in development
+and testing. See `docker-compose.yml` for specific configuration details.
+
+The services provided are:
+
+* `app` - main container environment scoped to the `/app` directory. Used primarily to build and tag the `opentelemetry/opentelemetry-ruby:latest` image.
+* `api` - convenience environment scoped to the `api` gem in the `/app/api` directory.
+* `sdk` - convenience environment scoped to the `sdk` gem in the `/app/sdk` directory.
 
 ## Release Schedule
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3.5"
+
+x-shared-config:
+  base: &base
+    command: /bin/bash
+    image: opentelemetry/opentelemetry-ruby
+    stdin_open: true
+    tmpfs:
+      - /tmp
+    tty: true
+    user: "1000:1000"
+    volumes:
+      - .:/app:cached
+      - bundle:/bundle
+
+services:
+  api:
+    <<: *base
+    working_dir: /app/api
+
+  app:
+    <<: *base
+    build:
+      context: .
+    working_dir: /app
+
+  sdk:
+    <<: *base
+    working_dir: /app/sdk
+
+volumes:
+  bundle:


### PR DESCRIPTION
# Overview

Adds an initial Docker/Docker Compose configuration.

## Details

Adds an initial configuration for Docker and Docker Compose usage in development and testing. The `Dockerfile` has been added to give us a reliable and configurable Ruby environment. If we like this, we can eventually move the Docker image to another repo and make it available for use here.

A Docker Compose configuration is also provided to help with the development ergonimics. From the updated README:

* `app` - main container environment scoped to the `/app` directory. Used primarily to build and tag the `opentelemetry/opentelemetry-ruby:latest` image.
* `api` - convenience environment scoped to the `api` gem in the `/app/api` directory.
* `sdk` - convenience environment scoped to the `sdk` gem in the `/app/sdk` directory.

The README also contains instructions on getting the environment up and running.

A small change was made to the `sdk/Gemfile` so it can use the `api` gem from the local directory.

