### PR TITLE
Update Tracer#in_span to finish the Span

### DIFF
--- a/api/lib/opentelemetry/trace/tracer.rb
+++ b/api/lib/opentelemetry/trace/tracer.rb
@@ -29,6 +29,8 @@ module OpenTelemetry
       def in_span(name, attributes: nil, links: nil, start_timestamp: nil, kind: nil, sampling_hint: nil)
         span = start_span(name, attributes: attributes, links: links, start_timestamp: start_timestamp, kind: kind, sampling_hint: sampling_hint)
         with_span(span) { |s| yield s }
+      ensure
+        span.finish
       end
 
       # Activates/deactivates the Span within the current Context, which makes the "current span"

--- a/api/test/opentelemetry/trace/tracer_factory_test.rb
+++ b/api/test/opentelemetry/trace/tracer_factory_test.rb
@@ -16,4 +16,20 @@ describe OpenTelemetry::Trace::TracerFactory do
       _(tracer1).must_equal(tracer2)
     end
   end
+
+  describe '#binary_format' do
+    it 'returns an instance of BinaryFormat' do
+      _(tracer_factory.binary_format).must_be_instance_of(
+        Propagation::BinaryFormat
+      )
+    end
+  end
+
+  describe '#http_text_format' do
+    it 'returns an instance of HTTPTextFormat' do
+      _(tracer_factory.http_text_format).must_be_instance_of(
+        Propagation::HTTPTextFormat
+      )
+    end
+  end
 end

--- a/api/test/opentelemetry/trace/tracer_test.rb
+++ b/api/test/opentelemetry/trace/tracer_test.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+describe OpenTelemetry::Trace::Tracer do
+  Propagation = OpenTelemetry::DistributedContext::Propagation
+  Tracer = OpenTelemetry::Trace::Tracer
+
+  # Tracer to verify expectation that `Span#finish` is called
+  class TestInSpanFinishTracer < Tracer
+    # Override `start_span` to return mock span
+    def start_span(*)
+      Minitest::Mock.new.expect(:finish, nil)
+    end
+  end
+
+  let(:invalid_span) { OpenTelemetry::Trace::Span::INVALID }
+  let(:tracer) { Tracer.new }
+
+  describe '#current_span' do
+    let(:current_span) { tracer.start_span('current') }
+
+    it 'returns an invalid span by default' do
+      _(tracer.current_span).must_equal(invalid_span)
+    end
+
+    it 'returns the current span' do
+      wrapper_span = tracer.start_span('wrapper')
+
+      tracer.with_span(wrapper_span) do
+        _(tracer.current_span).must_equal(wrapper_span)
+      end
+    end
+  end
+
+  describe '#in_span' do
+    it 'yields the new span' do
+      tracer.in_span('wrapper') do |span|
+        _(span).wont_equal(invalid_span)
+        _(tracer.current_span).must_equal(span)
+      end
+    end
+
+    it 'returns the result of the block' do
+      result = tracer.in_span('wrapper') { 'my-result' }
+      _(result).must_equal('my-result')
+    end
+
+    it 'finishes the new span at the end of the block' do
+      finish_tracer = TestInSpanFinishTracer.new
+      mock_span = nil
+      finish_tracer.in_span('wrapper') { |span| mock_span = span }
+      mock_span.verify
+    end
+  end
+
+  describe '#with_span' do
+    it 'yields the passed in span' do
+      wrapper_span = tracer.start_span('wrapper')
+
+      tracer.with_span(wrapper_span) do |span|
+        _(span).must_equal(wrapper_span)
+      end
+    end
+
+    it 'should reactive the span after the block' do
+      outer = tracer.start_span('outer')
+      inner = tracer.start_span('inner')
+
+      tracer.with_span(outer) do
+        _(tracer.current_span).must_equal(outer)
+
+        tracer.with_span(inner) do
+          _(tracer.current_span).must_equal(inner)
+        end
+
+        _(tracer.current_span).must_equal(outer)
+      end
+    end
+  end
+
+  describe '#start_root_span' do
+    it 'returns a valid span' do
+      span = tracer.start_root_span('root')
+      _(span.context).must_be :valid?
+    end
+  end
+
+  describe '#start_span' do
+    let(:context) { OpenTelemetry::Trace::SpanContext.new }
+    let(:invalid_context) { OpenTelemetry::Trace::SpanContext::INVALID }
+    let(:parent) { tracer.start_span('parent') }
+
+    it 'returns a valid span' do
+      span = tracer.start_span('op', with_parent_context: context)
+      _(span.context).must_be :valid?
+    end
+
+    it 'returns a span with a new context by default' do
+      span = tracer.start_span('op')
+      _(span.context).wont_equal(tracer.current_span.context)
+    end
+
+    it 'returns a span with the same context as the parent' do
+      span = tracer.start_span('op', with_parent: parent)
+      _(span.context).must_equal(parent.context)
+    end
+
+    it 'returns a span with a new context when passed an invalid context' do
+      span = tracer.start_span('op', with_parent_context: invalid_context)
+      _(span.context).wont_equal(invalid_context)
+    end
+  end
+end

--- a/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
@@ -224,7 +224,7 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
       let(:exporter_sleeps_for_millis) { exporter_timeout_millis - 1 }
 
       it 'exporter is not interrupted' do
-        exporter.state.must_equal(:not_interrupted)
+        _(exporter.state).must_equal(:not_interrupted)
       end
     end
 
@@ -232,7 +232,7 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
       let(:exporter_sleeps_for_millis) { exporter_timeout_millis + 1 }
 
       it 'is interrupted by a timeout' do
-        exporter.state.must_equal(:called)
+        _(exporter.state).must_equal(:called)
       end
     end
   end

--- a/sdk/test/opentelemetry/sdk/trace/tracer_factory_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/tracer_factory_test.rb
@@ -58,6 +58,7 @@ describe OpenTelemetry::SDK::Trace::TracerFactory do
     it 'adds the span processor to the active span processors' do
       mock_span_processor = Minitest::Mock.new
       mock_span_processor.expect(:on_start, nil, [Span])
+      mock_span_processor.expect(:on_finish, nil, [Span])
       tracer_factory.add_span_processor(mock_span_processor)
       tracer_factory.tracer.in_span('span') {}
       mock_span_processor.verify


### PR DESCRIPTION
# Overview

Updates `Tracer#in_span` to call `Span#finish` at the end of the block and adds API tests for `Tracer`.

## Details

While creating some examples based on the DataDog auto-instrumentation work I noticed that the `Tracer#in_span` implementation wasn't finishing the span as expected. I looked into the [Python implementation](https://github.com/open-telemetry/opentelemetry-python/blob/master/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py#L386) and saw the call the `end()`. This adds the call to `#finish` and adds tests to both the API and SDK.

The tests are going through some slight acrobatics to verify things are working as expected. Please let me know if there are better ways to do this given the implementation(s).

I added tests for the existing API `Tracer` implementation before updating `#in_span` to make sure the changes wouldn't cause us trouble in other methods.

## Thoughts

* I like that the Python API makes the call to `finish`/`end` optional. If we're interested in that I can open a new PR for that functionality. @fbogsany mentioned we may want to do this.
* It's usually bad form to add methods just to ease testing but you can see that I had to poke at the internals a bit to figure out if a span has ended. Any reason not to add `Span#ended?`?
