### PR TITLE
Update error messages in Span#set_attribute

### DIFF
--- a/api/lib/opentelemetry/trace/span.rb
+++ b/api/lib/opentelemetry/trace/span.rb
@@ -54,8 +54,8 @@ module OpenTelemetry
       #
       # @return [self] returns itself
       def set_attribute(key, value)
-        raise ArgumentError unless Internal.valid_key?(key)
-        raise ArgumentError unless Internal.valid_value?(value)
+        raise ArgumentError, 'invalid key' unless Internal.valid_key?(key)
+        raise ArgumentError, 'invalid value' unless Internal.valid_value?(value)
 
         self
       end

--- a/api/test/opentelemetry/trace/span_test.rb
+++ b/api/test/opentelemetry/trace/span_test.rb
@@ -25,6 +25,18 @@ describe OpenTelemetry::Trace::Span do
   end
 
   describe '#set_attribute' do
+    it 'returns an error when the key is invalid' do
+      proc { span.set_attribute(:foo, 'bar') }
+        .must_raise(ArgumentError)
+        .message.must_equal('invalid key')
+    end
+
+    it 'returns an error when the value is invalid' do
+      proc { span.set_attribute('foo', :bar) }
+        .must_raise(ArgumentError)
+        .message.must_equal('invalid value')
+    end
+
     it 'returns self' do
       span.set_attribute('foo', 'bar').must_equal(span)
     end


### PR DESCRIPTION
# Overview

Updates the error messages in `Span#set_attribute` to provide more information about the argument error and adds tests for the improvements.

## Details

I found I needed a little more information from `#set_attribute` while working on some examples. This just tells the caller if the `key` or the `value` is the reason they're receiving the error.
