### PR TITLE
Code examples: HTTP server (grape) instrumentation example

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,17 @@ services:
       context: .
     working_dir: /app
 
+  # docker-compose run --rm ex-grape bundle install
+  # docker-compose run --rm --service-ports ex-grape
+  ex-grape:
+    <<: *base
+    command: bundle exec rackup --host 0.0.0.0 --port 4568 --debug
+    environment:
+      BUNDLE_GEMFILE: Gemfile
+    ports:
+      - 4568:4568
+    working_dir: /app/examples/http/server/grape
+
   sdk:
     <<: *base
     working_dir: /app/sdk

--- a/examples/exporters/console.rb
+++ b/examples/exporters/console.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry/sdk'
+require 'pp'
+
+module Examples
+  module Exporters
+    # Outputs span data to the console.
+    class Console
+      include OpenTelemetry::SDK::Trace::Export
+
+      def export(spans)
+        Array(spans).each { |s| pp s }
+
+        SUCCESS
+      end
+    end
+  end
+end

--- a/examples/http/server/grape/Gemfile
+++ b/examples/http/server/grape/Gemfile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source "https://rubygems.org"
+
+gem "grape", "~> 1.2"
+gem "opentelemetry-api", path: "/app/api"
+gem "opentelemetry-sdk", path: "/app/sdk"

--- a/examples/http/server/grape/Gemfile.lock
+++ b/examples/http/server/grape/Gemfile.lock
@@ -1,0 +1,68 @@
+PATH
+  remote: /app/api
+  specs:
+    opentelemetry-api (0.0.0)
+
+PATH
+  remote: /app/sdk
+  specs:
+    opentelemetry-sdk (0.0.0)
+      opentelemetry-api (~> 0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (6.0.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.1, >= 2.1.8)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
+    builder (3.2.3)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
+    concurrent-ruby (1.1.5)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
+    equalizer (0.0.11)
+    grape (1.2.4)
+      activesupport
+      builder
+      mustermann-grape (~> 1.0.0)
+      rack (>= 1.3.0)
+      rack-accept
+      virtus (>= 1.0.0)
+    i18n (1.7.0)
+      concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
+    minitest (5.12.2)
+    mustermann (1.0.3)
+    mustermann-grape (1.0.0)
+      mustermann (~> 1.0.0)
+    rack (2.0.7)
+    rack-accept (0.4.5)
+      rack (>= 0.4)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+    virtus (1.0.5)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
+    zeitwerk (2.1.10)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  grape (~> 1.2)
+  opentelemetry-api!
+  opentelemetry-sdk!
+
+BUNDLED WITH
+   2.0.2

--- a/examples/http/server/grape/README.md
+++ b/examples/http/server/grape/README.md
@@ -1,0 +1,23 @@
+# OpenTelemetry Ruby Example
+
+## HTTP (Grape)
+
+This example demonstrates tracing an HTTP server response. The example shows several aspects of tracing, such as:
+
+* Using the `TracerFactory`
+* Span Events
+* Span Attributes
+* Creating a simple exporter (`Examples::Exporters::Console`)
+
+### Running the example
+
+The example uses Docker Compose to get things up and running.
+
+1. Follow the `Developer Setup` instructions in [the main README](../../../README.md)
+
+
+1. Bring the server up using the `ex-http` compose service
+    * `docker-compose up ex-grape`
+1. Make a request
+    * `curl "localhost:4568/test"`
+1. You should see console output for the server session

--- a/examples/http/server/grape/config.ru
+++ b/examples/http/server/grape/config.ru
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'rubygems'
+
+require_relative 'example_api'
+
+run ExampleAPI

--- a/examples/http/server/grape/example_api.rb
+++ b/examples/http/server/grape/example_api.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'grape'
+
+require_relative 'tracer_middleware'
+
+class ExampleAPI < Grape::API
+  # Integrate with OpenTelemetry:
+  use TracerMiddleware
+
+  get '/' do
+    'root'
+  end
+
+  get 'test' do
+    'Test'
+  end
+end

--- a/examples/http/server/grape/tracer_middleware.rb
+++ b/examples/http/server/grape/tracer_middleware.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry/sdk'
+
+require_relative '../../../exporters/console'
+
+class TracerMiddleware < Grape::Middleware::Base
+
+  SDK = OpenTelemetry::SDK
+
+  def call(env)
+    # see: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md#http-server
+
+    # span name SHOULD be set to route:
+    span_name = env['grape.routing_args'][:route_info].path
+    # if route cannot be determined, it MUST be set to path value:
+    # span_name = env['PATH_INFO']
+
+    # """For a HTTP server span, SpanKind MUST be Server"""
+    tracer.in_span(span_name, kind: OpenTelemetry::Trace::SpanKind::SERVER) do |span|
+      span.add_event(name: 'handle request')
+      span.set_attribute('component', 'http') # required
+      span.set_attribute('http.method', env['REQUEST_METHOD']) # required
+      span.set_attribute('http.route', span_name) # not required
+      span.set_attribute('http.url', env['REQUEST_URI']) # not required
+
+      dup.call!(env).tap do |response|
+        span.set_attribute('http.status_code', response.status) # not required
+        span.set_attribute('http.status_text', Rack::Utils::HTTP_STATUS_CODES[response.status]) # not required
+
+        # allow output to flush via exporter:
+        span.finish
+      end
+    end
+  end
+
+  private
+
+  def tracer
+    # named tracer should be the library name
+    @tracer ||= tracer_factory.tracer('grape', 'semver:1.0').tap do |t|
+      t.add_span_processor(processor)
+    end
+  end
+
+  def tracer_factory
+    @tracer_factory ||= SDK::Trace::TracerFactory.new
+  end
+
+  def processor
+    @processor ||= SDK::Trace::Export::SimpleSpanProcessor.new(exporter)
+  end
+
+  def exporter
+    @exporter ||= Examples::Exporters::Console.new
+  end
+end


### PR DESCRIPTION
# Overview

This is a standalone http server example using `grape`.  It helps toward #97 and should work in conjunction with #130/#131.

The intention is to demonstrate (as correctly as possible), the usage of the api/sdk as middleware.

## Details

* Adds `examples/http/server/grape/`, to demonstrate 'http server' wiring
* Adds 'ex-grape' docker-compose service, for running in isolated environment
* Example runs on port 4568, so it can run alongside another example server