### PR TITLE
Simplify SpanKind

### DIFF
--- a/api/lib/opentelemetry/trace/span_kind.rb
+++ b/api/lib/opentelemetry/trace/span_kind.rb
@@ -7,26 +7,29 @@
 module OpenTelemetry
   module Trace
     # Type of span. Can be used to specify additional relationships between spans in addition to a
-    # parent/child relationship.
+    # parent/child relationship. For API ergonomics, use of the symbols rather than the constants
+    # may be preferred. For example:
+    #
+    #   span = tracer.start_span('op', kind: :client)
     module SpanKind
       # Default value. Indicates that the span is used internally.
-      INTERNAL = :__span_kind_internal__
+      INTERNAL = :internal
 
       # Indicates that the span covers server-side handling of an RPC or other remote request.
-      SERVER = :__span_kind_server__
+      SERVER = :server
 
       # Indicates that the span covers the client-side wrapper around an RPC or other remote request.
-      CLIENT = :__span_kind_client__
+      CLIENT = :client
 
       # Indicates that the span describes producer sending a message to a broker. Unlike client and
       # server, there is no direct critical path latency relationship between producer and consumer
       # spans.
-      PRODUCER = :__span_kind_producer__
+      PRODUCER = :producer
 
       # Indicates that the span describes consumer recieving a message from a broker. Unlike client
       # and server, there is no direct critical path latency relationship between producer and
       # consumer spans.
-      CONSUMER = :__span_kind_consumer__
+      CONSUMER = :consumer
     end
   end
 end


### PR DESCRIPTION
This simplifies the symbols used for `SpanKind` constants to improve API ergonomics. Users may prefer:
```ruby
span = tracer.start_span('op', kind: :client)
```
to
```ruby
span = tracer.start_span('op', kind: OpenTelemetry::Trace::SpanKind::CLIENT)
```