### PR TITLE
Propagate tracestate

### DIFF
--- a/api/lib/opentelemetry/distributed_context/propagation/http_text_format.rb
+++ b/api/lib/opentelemetry/distributed_context/propagation/http_text_format.rb
@@ -26,7 +26,9 @@ module OpenTelemetry
           header = yield carrier, TraceParent::TRACE_PARENT_HEADER
           tp = TraceParent.from_string(header)
 
-          Trace::SpanContext.new(trace_id: tp.trace_id, span_id: tp.span_id, trace_flags: tp.flags, remote: true)
+          tracestate = yield carrier, 'tracestate'
+
+          Trace::SpanContext.new(trace_id: tp.trace_id, span_id: tp.span_id, trace_flags: tp.flags, tracestate: tracestate, remote: true)
         rescue OpenTelemetry::Error
           Trace::SpanContext.new
         end
@@ -37,6 +39,7 @@ module OpenTelemetry
         # @yield [Carrier, String, String] carrier, header key, header value.
         def inject(context, carrier)
           yield carrier, TraceParent::TRACE_PARENT_HEADER, TraceParent.from_context(context).to_s
+          yield carrier, 'tracestate', context.tracestate
         end
 
         def fields

--- a/api/lib/opentelemetry/trace/span_context.rb
+++ b/api/lib/opentelemetry/trace/span_context.rb
@@ -8,26 +8,30 @@ module OpenTelemetry
   module Trace
     # A SpanContext contains the state that must propagate to child {Span}s and across process boundaries.
     # It contains the identifiers (a trace ID and span ID) associated with the {Span}, a set of
-    # {TraceFlags}, and a boolean indicating that the SpanContext was extracted from the wire.
+    # {TraceFlags}, a system-specific tracestate, and a boolean indicating that the SpanContext was
+    # extracted from the wire.
     class SpanContext
-      attr_reader :trace_id, :span_id, :trace_flags
+      attr_reader :trace_id, :span_id, :trace_flags, :tracestate
 
       # Returns a new {SpanContext}.
       #
       # @param [optional String] trace_id The trace ID associated with a {Span}.
       # @param [optional String] span_id The span ID associated with a {Span}.
       # @param [optional TraceFlags] trace_flags The trace flags associated with a {Span}.
+      # @param [optional String] tracestate The tracestate associated with a {Span}. May be nil.
       # @param [optional Boolean] remote Whether the {SpanContext} was extracted from the wire.
       # @return [SpanContext]
       def initialize(
         trace_id: Trace.generate_trace_id,
         span_id: Trace.generate_span_id,
         trace_flags: TraceFlags::DEFAULT,
+        tracestate: nil,
         remote: false
       )
         @trace_id = trace_id
         @span_id = span_id
         @trace_flags = trace_flags
+        @tracestate = tracestate
         @remote = remote
       end
 

--- a/sdk/test/opentelemetry/sdk/trace/tracer_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/tracer_test.rb
@@ -142,7 +142,7 @@ describe OpenTelemetry::SDK::Trace::Tracer do
   end
 
   describe '#start_span' do
-    let(:context) { OpenTelemetry::Trace::SpanContext.new }
+    let(:context) { OpenTelemetry::Trace::SpanContext.new(tracestate: 'vendorname=opaquevalue') }
 
     it 'provides a default name' do
       _(tracer.start_span(nil, with_parent_context: context).name).wont_be_nil
@@ -161,6 +161,11 @@ describe OpenTelemetry::SDK::Trace::Tracer do
     it 'returns a span with the parent context span ID' do
       span = tracer.start_span('op', with_parent_context: context)
       span.parent_span_id.must_equal(context.span_id)
+    end
+
+    it 'returns a span with the parent context tracestate' do
+      span = tracer.start_span('op', with_parent_context: context)
+      _(span.context.tracestate).must_equal(context.tracestate)
     end
 
     it 'returns a no-op span if sampler says do not record events' do


### PR DESCRIPTION
This propagates `tracestate` according to https://github.com/open-telemetry/opentelemetry-specification/pull/334

### TODO
- [ ] fix HTTPTextFormat tests