### PR TITLE
Create an initial release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,7 @@
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 version: 2.1
 executors:
   ruby24:
@@ -17,7 +21,11 @@ executors:
 commands:
   rake:
     parameters:
-      dir: {type: string}
+      dir:
+        type: string
+      task:
+        type: string
+        default: default
     steps:
       - checkout
       - run:
@@ -25,49 +33,115 @@ commands:
           command: "cd << parameters.dir >> && gem install --no-document bundler && bundle install --jobs=3 --retry=3"
       - run:
           name: CI
-          command: "cd << parameters.dir >> && bundle exec rake"
+          command: "cd << parameters.dir >> && bundle exec rake << parameters.task >>"
 jobs:
   test-api-ruby24:
     executor: ruby24
     steps:
-      - rake: {dir: api}
+      - rake:
+          dir: api
   test-api-ruby25:
     executor: ruby25
     steps:
-      - rake: {dir: api}
+      - rake:
+          dir: api
   test-api-ruby26:
     executor: ruby26
     steps:
-      - rake: {dir: api}
+      - rake:
+          dir: api
   test-api-jruby:
     executor: jruby
     steps:
-      - rake: {dir: api}
+      - rake:
+          dir: api
   test-sdk-ruby24:
     executor: ruby24
     steps:
-      - rake: {dir: sdk}
+      - rake:
+          dir: sdk
   test-sdk-ruby25:
     executor: ruby25
     steps:
-      - rake: {dir: sdk}
+      - rake:
+          dir: sdk
   test-sdk-ruby26:
     executor: ruby26
     steps:
-      - rake: {dir: sdk}
+      - rake:
+          dir: sdk
   test-sdk-jruby:
     executor: jruby
     steps:
-      - rake: {dir: sdk}
+      - rake:
+          dir: sdk
+  release-api:
+    executor: ruby26
+    steps:
+      - rake:
+          dir: api
+          task: push_release
+  release-sdk:
+    executor: ruby26
+    steps:
+      - rake:
+          dir: sdk
+          task: push_release
 workflows:
   version: 2
-  test-all:
+  builds:
     jobs:
-      - test-api-ruby24
-      - test-api-ruby25
-      - test-api-ruby26
-      - test-api-jruby
-      - test-sdk-ruby24
-      - test-sdk-ruby25
-      - test-sdk-ruby26
-      - test-sdk-jruby
+      - test-api-ruby24:
+          filters:
+            tags:
+              only: /^opentelemetry-api\/v\d.*$/
+      - test-api-ruby25:
+          filters:
+            tags:
+              only: /^opentelemetry-api\/v\d.*$/
+      - test-api-ruby26:
+          filters:
+            tags:
+              only: /^opentelemetry-api\/v\d.*$/
+      - test-api-jruby:
+          filters:
+            tags:
+              only: /^opentelemetry-api\/v\d.*$/
+      - test-sdk-ruby24:
+          filters:
+            tags:
+              only: /^opentelemetry-sdk\/v\d.*$/
+      - test-sdk-ruby25:
+          filters:
+            tags:
+              only: /^opentelemetry-sdk\/v\d.*$/
+      - test-sdk-ruby26:
+          filters:
+            tags:
+              only: /^opentelemetry-sdk\/v\d.*$/
+      - test-sdk-jruby:
+          filters:
+            tags:
+              only: /^opentelemetry-sdk\/v\d.*$/
+      - release-api:
+          requires:
+            - test-api-ruby24
+            - test-api-ruby25
+            - test-api-ruby26
+            - test-api-jruby
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^opentelemetry-api\/v\d.*$/
+      - release-sdk:
+          requires:
+            - test-sdk-ruby24
+            - test-sdk-ruby25
+            - test-sdk-ruby26
+            - test-sdk-jruby
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^opentelemetry-sdk\/v\d.*$/

--- a/api/Rakefile
+++ b/api/Rakefile
@@ -30,6 +30,56 @@ YARD::Rake::YardocTask.new do |t|
   t.stats_options = ['--list-undoc'] # optional
 end
 
+task 'push_release' do
+  version = check_version
+  using_api_key do
+    run_command('gem build opentelemetry-api.gemspec')
+    if ENV['OPENTELEMETRY_RELEASES_ENABLED'] == 'true'
+      run_command("gem push opentelemetry-api-#{version}.gem")
+      puts("Released opentelemetry-api #{version}")
+    else
+      run_command("test -f opentelemetry-api-#{version}.gem")
+      puts("Mock release of opentelemetry-api #{version}")
+    end
+  end
+end
+
+def check_version
+  tag = ENV['CIRCLE_TAG']
+  match = %r{^opentelemetry-api/v(.*)$}.match(tag)
+  abort_release("Unexpected tag: #{tag.inspect}") unless match
+  version = match[1]
+  require_relative 'lib/opentelemetry/version.rb'
+  unless version == OpenTelemetry::VERSION
+    abort_release("Tagged version #{version.inspect} doesn't match" \
+                  " library version #{OpenTelemetry::VERSION.inspect}")
+  end
+  version
+end
+
+def using_api_key
+  api_key = ENV['OPENTELEMETRY_RUBYGEMS_API_KEY']
+  abort_release('OPENTELEMETRY_RUBYGEMS_API_KEY not found') unless api_key
+  home_dir = ENV['HOME']
+  FileUtils.mkdir_p("#{home_dir}/.gem")
+  File.open("#{home_dir}/.gem/credentials", 'w', 0o600) do |file|
+    file.puts("---\n:rubygems_api_key: #{api_key}")
+  end
+  puts('Using OPENTELEMETRY_RUBYGEMS_API_KEY')
+  yield
+ensure
+  system("shred -u #{home_dir}/.gem/credentials")
+end
+
+def run_command(cmd)
+  puts(cmd)
+  abort_release('Last command failed') unless system(cmd)
+end
+
+def abort_release(message)
+  abort("!!!! Aborting opentelemetry-api release !!!!\n#{message}")
+end
+
 if RUBY_ENGINE == 'truffleruby'
   task default: %i[test]
 else

--- a/sdk/Rakefile
+++ b/sdk/Rakefile
@@ -7,6 +7,7 @@
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'yard'
+require 'fileutils'
 
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
@@ -30,6 +31,56 @@ YARD::Rake::YardocTask.new do |t|
   t.files = files # optional
   t.options = ['--output-dir', 'docs/sdk'] # optional
   t.stats_options = ['--list-undoc'] # optional
+end
+
+task 'push_release' do
+  version = check_version
+  using_api_key do
+    run_command('gem build opentelemetry-sdk.gemspec')
+    if ENV['OPENTELEMETRY_RELEASES_ENABLED'] == 'true'
+      run_command("gem push opentelemetry-sdk-#{version}.gem")
+      puts("Released opentelemetry-sdk #{version}")
+    else
+      run_command("test -f opentelemetry-sdk-#{version}.gem")
+      puts("Mock release of opentelemetry-sdk #{version}")
+    end
+  end
+end
+
+def check_version
+  tag = ENV['CIRCLE_TAG']
+  match = %r{^opentelemetry-sdk/v(.*)$}.match(tag)
+  abort_release("Unexpected tag: #{tag.inspect}") unless match
+  version = match[1]
+  require_relative 'lib/opentelemetry/sdk/version.rb'
+  unless version == OpenTelemetry::SDK::VERSION
+    abort_release("Tagged version #{version.inspect} doesn't match" \
+                  " library version #{OpenTelemetry::SDK::VERSION.inspect}")
+  end
+  version
+end
+
+def using_api_key
+  api_key = ENV['OPENTELEMETRY_RUBYGEMS_API_KEY']
+  abort_release('OPENTELEMETRY_RUBYGEMS_API_KEY not found') unless api_key
+  home_dir = ENV['HOME']
+  FileUtils.mkdir_p("#{home_dir}/.gem")
+  File.open("#{home_dir}/.gem/credentials", 'w', 0o600) do |file|
+    file.puts("---\n:rubygems_api_key: #{api_key}")
+  end
+  puts('Using OPENTELEMETRY_RUBYGEMS_API_KEY')
+  yield
+ensure
+  system("shred -u #{home_dir}/.gem/credentials")
+end
+
+def run_command(cmd)
+  puts(cmd)
+  abort_release('Last command failed') unless system(cmd)
+end
+
+def abort_release(message)
+  abort("!!!! Aborting opentelemetry-sdk release !!!!\n#{message}")
 end
 
 if RUBY_ENGINE == 'truffleruby'


### PR DESCRIPTION
Implementation of #94.

Implements scripts that build and push releases of the API and SDK to Rubygems, and augments the CI config to trigger them.

The proposed release process is as follows. To release a gem:
1. The version constant must be set to the version to be released.
2. A tag called `#{gem_name}/v#{version}` must be created and pushed to Github. (e.g. `opentelemetry-api/v1.2.3`). Thus, anyone with direct write access to the repo will be able to initiate a release.

When the tag is created in Github, CircleCI will automatically (after running that gem's tests one final time) run the release script. This script:
1. Verifies that the tag's version matches the gem's version constant
2. Builds the gem and pushes to Rubygems.

The release script requires the following environment variable configuration to be set on the CircleCI project (currently not yet done):
* The `OPENTELEMETRY_RUBYGEMS_API_KEY` environment variable must be set with credentials for the Rubygems account we want to use to push the gem. Rubygems credentials will be held by the CI; individuals will not need direct access to them.
* The `OPENTELEMETRY_RELEASES_ENABLED` environment variable should be set to the value `true`. (If it is not, the release script will run in test mode, and will go through the motions of building and verifying the gem, but will not actually push it to Rubygems.)

Current limitations, which I can address once we've agreed on the basic approach:
* The Jaeger exporter is not yet covered. (Actually it's not yet covered by the CI at all. I can add it.)
* The release script probably could check up front whether the proposed version has already been released, and fail fast with a more useful error message. As it is, I believe it will only fail at the end when the `gem push` is attempted.
* The script is not enforcing any CHANGELOG updates. Indeed, we don't even have a changelog at all yet. At some point in the future, I think it might make sense to adopt [conventional commits](https://conventionalcommits.org) and have the release script automatically populate the changelog based on commit messages.
