### PR TITLE
Decentralize contributors

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @SergeyKanzhelev @fbogsany @bai @luvtechno @mwear @elskwid @dazuma
+* @fbogsany @bai @luvtechno @mwear @elskwid @dazuma

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,10 +6,10 @@
 #
 # Learn about membership in OpenTelemetry community:
 #  https://github.com/open-telemetry/community/blob/master/community-membership.md
-# 
 #
-# Learn about CODEOWNERS file format: 
+#
+# Learn about CODEOWNERS file format:
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @SergeyKanzhelev @fbogsany @bai @luvtechno @mwear @elskwid
+* @SergeyKanzhelev @fbogsany @bai @luvtechno @mwear @elskwid @dazuma

--- a/README.md
+++ b/README.md
@@ -14,6 +14,22 @@ We'd love your help! Use tags [good first issue][issues-good-first-issue] and
 The Ruby special interest group (SIG) meets regularly. See the OpenTelemetry
 [community page][ruby-sig] repo for information on this and other language SIGs.
 
+Approvers ([@open-telemetry/ruby-approvers](https://github.com/orgs/open-telemetry/teams/ruby-approvers)):
+
+- [Vlad Gorodetsky](https://github.com/bai), Shopify
+- [Yoshinori Kawasaki](https://github.com/luvtechno), Wantedly
+- [Don Morrison](https://github.com/elskwid), Mutations
+
+*Find more about the approver role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver).*
+
+Maintainers ([@open-telemetry/ruby-maintainers](https://github.com/orgs/open-telemetry/teams/ruby-maintainers)):
+
+- [Francis Bogsanyi](https://github.com/fbogsany), Shopify
+- [Matthew Wear](https://github.com/mwear), LightStep
+- [Daniel Azuma](https://github.com/dazuma), Google
+
+*Find more about the maintainer role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#maintainer).*
+
 ## Developer Setup
 
 1. Install Docker and Docker Compose for your operating system


### PR DESCRIPTION
This PR goes along with: https://github.com/open-telemetry/community/pull/239. It decentralizes the Ruby community members and adds @dazuma to codeowners.