### PR TITLE
Update versions for v0.2.0 release

### DIFF
--- a/api/lib/opentelemetry/version.rb
+++ b/api/lib/opentelemetry/version.rb
@@ -6,5 +6,5 @@
 
 module OpenTelemetry
   ## Current OpenTelemetry version
-  VERSION = '0.0.0'
+  VERSION = '0.2.0'
 end

--- a/exporters/jaeger/lib/opentelemetry/exporters/jaeger/version.rb
+++ b/exporters/jaeger/lib/opentelemetry/exporters/jaeger/version.rb
@@ -8,7 +8,7 @@ module OpenTelemetry
   module Exporters
     module Jaeger
       ## Current OpenTelemetry Jaeger exporter version
-      VERSION = '0.0.0'
+      VERSION = '0.2.0'
     end
   end
 end

--- a/sdk/lib/opentelemetry/sdk/version.rb
+++ b/sdk/lib/opentelemetry/sdk/version.rb
@@ -7,6 +7,6 @@
 module OpenTelemetry
   module SDK
     ## Current OpenTelemetry version
-    VERSION = '0.0.0'
+    VERSION = '0.2.0'
   end
 end


### PR DESCRIPTION
This PR updates the versions of the API, SDK, and Jaeger Exporter to v0.2.0  for our release. Do these look good to everybody?