### PR TITLE
Improve test robustness under heavily loaded CI

### DIFF
--- a/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
@@ -229,7 +229,7 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
     end
 
     describe 'when exporter runs too long' do
-      let(:exporter_sleeps_for_millis) { exporter_timeout_millis + 1 }
+      let(:exporter_sleeps_for_millis) { exporter_timeout_millis + 700 }
 
       it 'is interrupted by a timeout' do
         _(exporter.state).must_equal(:called)


### PR DESCRIPTION
# Overview
Increases the timeout threshold of the "interrupt exporter" (batch span processor) test by 700ms.

This should improve the SDK test suite's robustness.

## Background
https://github.com/open-telemetry/opentelemetry-ruby/pull/133#discussion_r340676385 raised some concerns that have since been witnessed a few times

The value was determined experimentally, on a development laptop.