### PR TITLE
API: Add OpenTelemetry::Adapter interface

### DIFF
--- a/api/lib/opentelemetry.rb
+++ b/api/lib/opentelemetry.rb
@@ -6,6 +6,7 @@
 require 'logger'
 
 require 'opentelemetry/error'
+require 'opentelemetry/adapter'
 require 'opentelemetry/context'
 require 'opentelemetry/distributed_context'
 require 'opentelemetry/internal'

--- a/api/lib/opentelemetry/adapter.rb
+++ b/api/lib/opentelemetry/adapter.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  # The basic interface for Adapter objects
+  class Adapter
+    class << self
+      attr_reader :config
+
+      def install(config = {})
+        @config = config
+        new.install
+      end
+
+      def tracer
+        OpenTelemetry.tracer_factory.tracer(config[:name], config[:version])
+      end
+    end
+  end
+end

--- a/api/lib/opentelemetry/adapter.rb
+++ b/api/lib/opentelemetry/adapter.rb
@@ -15,6 +15,10 @@ module OpenTelemetry
         new.install
       end
 
+      def http_formatter
+        OpenTelemetry.tracer_factory.http_text_format
+      end
+
       def tracer
         OpenTelemetry.tracer_factory.tracer(config[:name], config[:version])
       end

--- a/api/lib/opentelemetry/adapter.rb
+++ b/api/lib/opentelemetry/adapter.rb
@@ -7,7 +7,20 @@
 require 'opentelemetry'
 
 module OpenTelemetry
-  # The basic interface for Adapter objects
+  # The basic interface for Adapter objects.
+  #
+  # Adapter class is intended to be subclassed, e.g.,
+  #
+  #   module Adapters
+  #     module Faraday
+  #       class Adapter < OpenTelemetry::Adapter
+  #       end
+  #     end
+  #   end
+  #
+  # then,
+  #
+  #   Adapters::Faraday.install(name: ..., version: ...)
   class Adapter
     class << self
       attr_reader :config,

--- a/api/lib/opentelemetry/adapter.rb
+++ b/api/lib/opentelemetry/adapter.rb
@@ -10,7 +10,7 @@ module OpenTelemetry
   # Adapter class is intended to be subclassed, e.g.,
   #
   #   module Adapters
-  #     module Faraday
+  #     module SomeLibrary
   #       class Adapter < OpenTelemetry::Adapter
   #       end
   #     end
@@ -18,7 +18,7 @@ module OpenTelemetry
   #
   # then,
   #
-  #   Adapters::Faraday.install(name: ..., version: ...)
+  #   Adapters::SomeLibrary.install(name: ..., version: ...)
   class Adapter
     class << self
       attr_reader :config,

--- a/api/lib/opentelemetry/adapter.rb
+++ b/api/lib/opentelemetry/adapter.rb
@@ -4,22 +4,30 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require 'opentelemetry'
+
 module OpenTelemetry
   # The basic interface for Adapter objects
   class Adapter
     class << self
-      attr_reader :config
+      attr_reader :config,
+                  :http_formatter,
+                  :tracer
 
       def install(config = {})
         @config = config
+        @http_formatter = config[:http_formatter] || default_http_formatter
+        @tracer = config[:tracer] || default_tracer
         new.install
       end
 
-      def http_formatter
+      private
+
+      def default_http_formatter
         OpenTelemetry.tracer_factory.http_text_format
       end
 
-      def tracer
+      def default_tracer
         OpenTelemetry.tracer_factory.tracer(config[:name], config[:version])
       end
     end

--- a/api/lib/opentelemetry/adapter.rb
+++ b/api/lib/opentelemetry/adapter.rb
@@ -4,8 +4,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'opentelemetry'
-
 module OpenTelemetry
   # The basic interface for Adapter objects.
   #

--- a/api/lib/opentelemetry/adapter.rb
+++ b/api/lib/opentelemetry/adapter.rb
@@ -18,7 +18,7 @@ module OpenTelemetry
   #
   # then,
   #
-  #   Adapters::SomeLibrary.install(name: ..., version: ...)
+  #   Adapters::SomeLibrary.install(config: { name: ..., version: ... })
   class Adapter
     class << self
       attr_reader :config,

--- a/api/lib/opentelemetry/adapter.rb
+++ b/api/lib/opentelemetry/adapter.rb
@@ -22,13 +22,19 @@ module OpenTelemetry
   class Adapter
     class << self
       attr_reader :config,
-                  :http_formatter,
+                  :meter,
+                  :propagation_format,
                   :tracer
 
-      def install(config = {})
-        @config = config
-        @http_formatter = config[:http_formatter] || default_http_formatter
-        @tracer = config[:tracer] || default_tracer
+      def install(config: nil,
+                  meter: nil,
+                  propagation_format: nil,
+                  tracer: nil)
+        @config = config || {}
+        @meter = meter
+        @propagation_format = propagation_format || default_http_formatter
+        @tracer = tracer || default_tracer
+
         new.install
       end
 

--- a/api/test/opentelemetry/adapter_test.rb
+++ b/api/test/opentelemetry/adapter_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+describe OpenTelemetry::Adapter do
+  class TestAdapter < OpenTelemetry::Adapter
+    attr_accessor :state
+    def install
+      self.state = :called
+      self
+    end
+  end
+
+  class TestAdapter2 < OpenTelemetry::Adapter
+    def install; end
+  end
+
+  describe '.install' do
+    before do
+      @test_adapter = TestAdapter.install(name: 'foo', version: 'bar')
+      TestAdapter2.install(name: 'foo2', version: 'bar2')
+    end
+
+    it 'retains configuration separately' do
+      _(TestAdapter.config[:name]).must_equal 'foo'
+      _(TestAdapter2.config[:name]).must_equal 'foo2'
+    end
+
+    it 'calls #install on subclass' do
+      _(@test_adapter.state).must_equal :called
+    end
+  end
+end

--- a/api/test/opentelemetry/adapter_test.rb
+++ b/api/test/opentelemetry/adapter_test.rb
@@ -10,7 +10,7 @@ describe OpenTelemetry::Adapter do
   class TestAdapter < OpenTelemetry::Adapter
     attr_accessor :state
     def install
-      self.state = :called
+      self.state = :called_install
       self
     end
   end
@@ -21,8 +21,8 @@ describe OpenTelemetry::Adapter do
 
   describe '.install' do
     before do
-      @test_adapter = TestAdapter.install(name: 'foo', version: 'bar')
-      TestAdapter2.install(name: 'foo2', version: 'bar2')
+      @test_adapter = TestAdapter.install(config: { name: 'foo', version: 'bar' })
+      TestAdapter2.install(config: { name: 'foo2', version: 'bar2' })
     end
 
     it 'retains configuration separately' do
@@ -30,8 +30,16 @@ describe OpenTelemetry::Adapter do
       _(TestAdapter2.config[:name]).must_equal 'foo2'
     end
 
+    it 'provides default propagation_format' do
+      _(TestAdapter.propagation_format).wont_be_nil
+    end
+
+    it 'provides default tracer' do
+      _(TestAdapter.tracer).wont_be_nil
+    end
+
     it 'calls #install on subclass' do
-      _(@test_adapter.state).must_equal :called
+      _(@test_adapter.state).must_equal :called_install
     end
   end
 end


### PR DESCRIPTION
# Overview
Adds `OpenTelemetry::Adapter` API components that are used in #148, #149 (instrumentation adapters).

Provides a way for specific adapter implementations to interact with OpenTelemetry API configurations, tracers, formatters, etc.

## Details
* extracted from #148

## Related
* #67 
* #148 
* #149