### PR TITLE
API: Add HTTP to Status convenience mapper

### DIFF
--- a/api/lib/opentelemetry/trace/status.rb
+++ b/api/lib/opentelemetry/trace/status.rb
@@ -19,9 +19,56 @@ module OpenTelemetry
       # @return [String]
       attr_reader :description
 
+      # Implemented according to
+      # https://cloud.google.com/apis/design/errors#handling_errors
+      #
+      # Note that some HTTP status do not map 1-to-1 to a gRPC status.
+      #
+      # @param code Numeric HTTP status
+      #
+      # @return Status
+      def self.from_http_status(code) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
+        case code.to_i
+        when 200
+          new(OK)
+        when 400
+          new(INVALID_ARGUMENT)
+          # or, possibly (no one-to-one mapping):
+          # new(FAILED_PRECONDITION)
+          # new(OUT_OF_RANGE)
+        when 401
+          new(UNAUTHENTICATED)
+        when 403
+          new(PERMISSION_DENIED)
+        when 404
+          new(NOT_FOUND)
+        when 409
+          new(ABORTED)
+          # or, possibly (no one-to-one mapping):
+          # new(ALREADY_EXISTS)
+        when 429
+          new(RESOURCE_EXHAUSTED)
+        when 499
+          new(CANCELLED)
+        when 500
+          new(DATA_LOSS)
+          # or, possibly (no one-to-one mapping):
+          # new(UNKNOWN_ERROR)
+          # new(INTERNAL_ERROR)
+        when 501
+          new(UNIMPLEMENTED)
+        when 503
+          new(UNAVAILABLE)
+        when 504
+          new(DEADLINE_EXCEEDED)
+        else
+          new(UNKNOWN_ERROR)
+        end
+      end
+
       # Initialize a Status.
       #
-      # @param [Integer] canonical_code One of the standard GRPC codes: https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
+      # @param [Integer] canonical_code One of the standard gRPC codes: https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
       # @param [String] description
       def initialize(canonical_code, description: '')
         @canonical_code = canonical_code
@@ -36,7 +83,7 @@ module OpenTelemetry
       end
 
       # The following represents the canonical set of status codes of a
-      # finished {Span}, following the standard GRPC codes:
+      # finished {Span}, following the standard gRPC codes:
       # https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
 
       # The operation completed successfully.

--- a/api/lib/opentelemetry/trace/status.rb
+++ b/api/lib/opentelemetry/trace/status.rb
@@ -4,11 +4,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require 'opentelemetry/trace/util/http_to_status'
+
 module OpenTelemetry
   module Trace
     # Status represents the status of a finished {Span}. It is composed of a
     # canonical code in conjunction with an optional descriptive message.
     class Status
+      # Convenience utility, not in API spec:
+      extend Util::HttpToStatus
+
       # Retrieve the canonical code of this Status.
       #
       # @return [Integer]
@@ -18,53 +23,6 @@ module OpenTelemetry
       #
       # @return [String]
       attr_reader :description
-
-      # Implemented according to
-      # https://cloud.google.com/apis/design/errors#handling_errors
-      #
-      # Note that some HTTP status do not map 1-to-1 to a gRPC status.
-      #
-      # @param code Numeric HTTP status
-      #
-      # @return Status
-      def self.from_http_status(code) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
-        case code.to_i
-        when 200
-          new(OK)
-        when 400
-          new(INVALID_ARGUMENT)
-          # or, possibly (no one-to-one mapping):
-          # new(FAILED_PRECONDITION)
-          # new(OUT_OF_RANGE)
-        when 401
-          new(UNAUTHENTICATED)
-        when 403
-          new(PERMISSION_DENIED)
-        when 404
-          new(NOT_FOUND)
-        when 409
-          new(ABORTED)
-          # or, possibly (no one-to-one mapping):
-          # new(ALREADY_EXISTS)
-        when 429
-          new(RESOURCE_EXHAUSTED)
-        when 499
-          new(CANCELLED)
-        when 500
-          new(DATA_LOSS)
-          # or, possibly (no one-to-one mapping):
-          # new(UNKNOWN_ERROR)
-          # new(INTERNAL_ERROR)
-        when 501
-          new(UNIMPLEMENTED)
-        when 503
-          new(UNAVAILABLE)
-        when 504
-          new(DEADLINE_EXCEEDED)
-        else
-          new(UNKNOWN_ERROR)
-        end
-      end
 
       # Initialize a Status.
       #

--- a/api/lib/opentelemetry/trace/util/http_to_status.rb
+++ b/api/lib/opentelemetry/trace/util/http_to_status.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Trace
+    module Util
+      # Convenience methods, not necessarily required by the API specification.
+      module HttpToStatus
+        # Implemented according to
+        # https://github.com/open-telemetry/opentelemetry-specification/issues/306
+        # https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-http.md#status
+        #
+        # @param code Numeric HTTP status
+        # @return Status
+        def http_to_status(code) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
+          case code.to_i
+          when 100..299
+            new(const_get(:OK))
+          when 300..399
+            new(const_get(:OK))
+            # TODO: or DEADLINE_EXCEEDED in case of a loop
+          when 401
+            new(const_get(:UNAUTHENTICATED))
+          when 403
+            new(const_get(:PERMISSION_DENIED))
+          when 404
+            new(const_get(:NOT_FOUND))
+          when 429
+            new(const_get(:RESOURCE_EXHAUSTED))
+          when 400..499
+            new(const_get(:INVALID_ARGUMENT))
+          when 501
+            new(const_get(:UNIMPLEMENTED))
+          when 503
+            new(const_get(:UNAVAILABLE))
+          when 504
+            new(const_get(:DEADLINE_EXCEEDED))
+          when 500..599
+            new(const_get(:INTERNAL_ERROR))
+          else
+            new(const_get(:UNKNOWN_ERROR))
+          end
+        end
+      end
+    end
+  end
+end

--- a/api/lib/opentelemetry/trace/util/http_to_status.rb
+++ b/api/lib/opentelemetry/trace/util/http_to_status.rb
@@ -17,11 +17,8 @@ module OpenTelemetry
         # @return Status
         def http_to_status(code) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
           case code.to_i
-          when 100..299
+          when 100..399
             new(const_get(:OK))
-          when 300..399
-            new(const_get(:OK))
-            # TODO: or DEADLINE_EXCEEDED in case of a loop
           when 401
             new(const_get(:UNAUTHENTICATED))
           when 403

--- a/api/test/opentelemetry/trace/status_test.rb
+++ b/api/test/opentelemetry/trace/status_test.rb
@@ -7,6 +7,40 @@
 require 'test_helper'
 
 describe OpenTelemetry::Trace::Status do
+  let(:trace_status) { OpenTelemetry::Trace::Status }
+
+  describe '.from_http_status' do
+    it 'returns Status' do
+      _(trace_status.from_http_status(400)).must_be_kind_of trace_status
+    end
+
+    def assert_http_to_status(http_code, trace_status_code)
+      _(trace_status.from_http_status(http_code).canonical_code).must_equal trace_status_code
+    end
+
+    it 'maps http 200' do
+      assert_http_to_status(200, trace_status::OK)
+    end
+
+    it 'maps common 4xx http codes' do
+      assert_http_to_status(400, trace_status::INVALID_ARGUMENT)
+      assert_http_to_status(401, trace_status::UNAUTHENTICATED)
+      assert_http_to_status(403, trace_status::PERMISSION_DENIED)
+      assert_http_to_status(404, trace_status::NOT_FOUND)
+      assert_http_to_status(409, trace_status::ABORTED)
+      assert_http_to_status(429, trace_status::RESOURCE_EXHAUSTED)
+      assert_http_to_status(499, trace_status::CANCELLED)
+    end
+
+    it 'maps common 5xx http codes' do
+      assert_http_to_status(500, trace_status::DATA_LOSS)
+      assert_http_to_status(501, trace_status::UNIMPLEMENTED)
+      assert_http_to_status(502, trace_status::UNKNOWN_ERROR)
+      assert_http_to_status(503, trace_status::UNAVAILABLE)
+      assert_http_to_status(504, trace_status::DEADLINE_EXCEEDED)
+    end
+  end
+
   describe '.canonical_code' do
     it 'reflects the value passed in' do
       status = OpenTelemetry::Trace::Status.new(0)

--- a/api/test/opentelemetry/trace/status_test.rb
+++ b/api/test/opentelemetry/trace/status_test.rb
@@ -9,35 +9,47 @@ require 'test_helper'
 describe OpenTelemetry::Trace::Status do
   let(:trace_status) { OpenTelemetry::Trace::Status }
 
-  describe '.from_http_status' do
+  describe '.http_to_status' do
     it 'returns Status' do
-      _(trace_status.from_http_status(400)).must_be_kind_of trace_status
+      _(trace_status.http_to_status(200)).must_be_kind_of trace_status
     end
 
     def assert_http_to_status(http_code, trace_status_code)
-      _(trace_status.from_http_status(http_code).canonical_code).must_equal trace_status_code
+      _(trace_status.http_to_status(http_code).canonical_code).must_equal trace_status_code
     end
 
-    it 'maps http 200' do
+    it 'maps http 1xx codes' do
+      assert_http_to_status(100, trace_status::OK)
+      assert_http_to_status(199, trace_status::OK)
+    end
+
+    it 'maps http 2xx codes' do
       assert_http_to_status(200, trace_status::OK)
+      assert_http_to_status(299, trace_status::OK)
     end
 
-    it 'maps common 4xx http codes' do
+    it 'maps http 3xx codes' do
+      assert_http_to_status(300, trace_status::OK)
+      assert_http_to_status(399, trace_status::OK)
+    end
+
+    it 'maps http 4xx codes' do
       assert_http_to_status(400, trace_status::INVALID_ARGUMENT)
       assert_http_to_status(401, trace_status::UNAUTHENTICATED)
       assert_http_to_status(403, trace_status::PERMISSION_DENIED)
       assert_http_to_status(404, trace_status::NOT_FOUND)
-      assert_http_to_status(409, trace_status::ABORTED)
+      assert_http_to_status(409, trace_status::INVALID_ARGUMENT)
       assert_http_to_status(429, trace_status::RESOURCE_EXHAUSTED)
-      assert_http_to_status(499, trace_status::CANCELLED)
+      assert_http_to_status(499, trace_status::INVALID_ARGUMENT)
     end
 
-    it 'maps common 5xx http codes' do
-      assert_http_to_status(500, trace_status::DATA_LOSS)
+    it 'maps http 5xx codes' do
+      assert_http_to_status(500, trace_status::INTERNAL_ERROR)
       assert_http_to_status(501, trace_status::UNIMPLEMENTED)
-      assert_http_to_status(502, trace_status::UNKNOWN_ERROR)
+      assert_http_to_status(502, trace_status::INTERNAL_ERROR)
       assert_http_to_status(503, trace_status::UNAVAILABLE)
       assert_http_to_status(504, trace_status::DEADLINE_EXCEEDED)
+      assert_http_to_status(599, trace_status::INTERNAL_ERROR)
     end
   end
 


### PR DESCRIPTION
# Overview
Adds a `Trace::Status.http_to_status(code)` method to facilitate mapping from http status code to `Status`.

## Background
* https://github.com/open-telemetry/opentelemetry-specification/issues/306
* [Status Canonical Code](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/api-tracing.md#statuscanonicalcode)
* [HTTP to Status Mapping Guidance](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-http.md#status)
* Extracted from #149 

## Related
* #149