### PR TITLE
General cleanup of yardocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 **/Gemfile.lock
 **/.yardoc
+**/doc
 **/docs
 **/coverage
 **/*.gem

--- a/api/.rubocop.yml
+++ b/api/.rubocop.yml
@@ -1,13 +1,18 @@
 AllCops:
   TargetRubyVersion: '2.4.0'
 
-Metrics/LineLength:
+Lint/UnusedMethodArgument:
   Enabled: false
-Metrics/ParameterLists:
+Metrics/AbcSize:
+  Max: 18
+Metrics/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Max: 20
-Style/ModuleFunction:
+Metrics/ParameterLists:
   Enabled: false
-Lint/UnusedMethodArgument:
+Naming/FileName:
+  Exclude:
+    - "lib/opentelemetry-api.rb"
+Style/ModuleFunction:
   Enabled: false

--- a/api/.yardopts
+++ b/api/.yardopts
@@ -1,0 +1,9 @@
+--no-private
+--title=OpenTelemetry API
+--markup=markdown
+--main=OVERVIEW.md
+./lib/opentelemetry/**/*.rb
+./lib/opentelemetry.rb
+-
+OVERVIEW.md
+CHANGELOG.md

--- a/api/OVERVIEW.md
+++ b/api/OVERVIEW.md
@@ -1,0 +1,66 @@
+# opentelemetry-api
+
+The `opentelemetry-api` gem defines the core OpenTelemetry interfaces for Ruby applications. Using `opentelemetry-api`, a library or application can code against the OpenTelemetry interfaces to produce telemetry data such as distributed traces and metrics.
+
+## What is OpenTelemetry?
+
+[OpenTelemetry][opentelemetry-home] is an open source observability framework, providing a general-purpose API, SDK, and related tools required for the instrumentation of cloud-native software, frameworks, and libraries.
+
+OpenTelemetry provides a single set of APIs, libraries, agents, and collector services to capture distributed traces and metrics from your application. You can analyze them using Prometheus, Jaeger, and other observability tools.
+
+## How does this gem fit in?
+
+The `opentelemetry-api` gem defines the core OpenTelemetry interfaces in the form of abstract classes and no-op implementations. That is, it defines interfaces and data types sufficient for a library or application to code against to produce telemetry data, but does not actually collect, analyze, or export the data.
+
+To collect and analyze telemtry data, *applications* should also install a concrete implementation of the API, such as the `opentelemetry-sdk` gem. However, *libraries* that produce telemetry data should depend only on `opentelemetry-api`, deferring the choise of concrete implementation to the application developer.
+
+## How do I get started?
+
+Install the gem using:
+
+```
+gem install opentelemetry-api
+```
+
+Or, if you use [bundler][bundler-home], include `opentelemetry-api` in your `Gemfile`.
+
+Then, use the OpenTelemetry interfaces to produces traces and other telemetry data. Following is a basic example.
+
+```ruby
+require 'opentelemetry'
+
+# Obtain the current default tracer factory
+factory = OpenTelemetry.tracer_factory
+
+# Create a trace
+tracer = factory.tracer('my_app', '1.0')
+
+# Record spans
+tracer.in_span('my_task') do |task_span|
+  tracer.in_span('inner') do |inner_span|
+    # Do something here
+  end
+end
+```
+
+For additional examples, see the [examples on github][examples-github].
+
+## How can I get involved?
+
+The `opentelemetry-api` gem source is [on github][repo-github], along with related gems including `opentelemetry-sdk`.
+
+The OpenTelemetry Ruby gems are maintained by the OpenTelemetry-Ruby special interest group (SIG). You can get involved by joining us on our [gitter channel][ruby-gitter] or attending our weekly meeting. See the [meeting calendar][community-meetings] for dates and times. For more information on this and other language SIGs, see the OpenTelemetry [community page][ruby-sig].
+
+## License
+
+The `opentelemetry-api` gem is distributed under the Apache 2.0 license. See [LICENSE][license-github] for more information.
+
+
+[opentelemetry-home]: https://opentelemetry.io
+[bundler-home]: https://bundler.io
+[repo-github]: https://github.com/open-telemetry/opentelemetry-ruby
+[license-github]: https://github.com/open-telemetry/opentelemetry-ruby/blob/master/LICENSE
+[examples-github]: https://github.com/open-telemetry/opentelemetry-ruby/tree/master/examples
+[ruby-sig]: https://github.com/open-telemetry/community#ruby-sig
+[community-meetings]: https://github.com/open-telemetry/community#community-meetings
+[ruby-gitter]: https://gitter.im/open-telemetry/opentelemetry-ruby

--- a/api/OVERVIEW.md
+++ b/api/OVERVIEW.md
@@ -12,7 +12,7 @@ OpenTelemetry provides a single set of APIs, libraries, agents, and collector se
 
 The `opentelemetry-api` gem defines the core OpenTelemetry interfaces in the form of abstract classes and no-op implementations. That is, it defines interfaces and data types sufficient for a library or application to code against to produce telemetry data, but does not actually collect, analyze, or export the data.
 
-To collect and analyze telemtry data, *applications* should also install a concrete implementation of the API, such as the `opentelemetry-sdk` gem. However, *libraries* that produce telemetry data should depend only on `opentelemetry-api`, deferring the choise of concrete implementation to the application developer.
+To collect and analyze telemetry data, *applications* should also install a concrete implementation of the API, such as the `opentelemetry-sdk` gem. However, *libraries* that produce telemetry data should depend only on `opentelemetry-api`, deferring the choise of concrete implementation to the application developer.
 
 ## How do I get started?
 

--- a/api/Rakefile
+++ b/api/Rakefile
@@ -18,16 +18,7 @@ Rake::TestTask.new :test do |t|
 end
 
 YARD::Rake::YardocTask.new do |t|
-  files = Dir.glob('./lib/**/*.rb')
-
-  # Move ./lib/opentelemetry.rb to the end of the array. Otherwise other files
-  # will overwrite the OpenTelemetry module comments with the license
-  # information.
-  files = files.insert(-1, files.delete_at(files.index('./lib/opentelemetry.rb')))
-
-  t.files = files # optional
-  t.options = ['--output-dir', 'docs/api'] # optional
-  t.stats_options = ['--list-undoc'] # optional
+  t.stats_options = ['--list-undoc']
 end
 
 if RUBY_ENGINE == 'truffleruby'

--- a/api/lib/opentelemetry-api.rb
+++ b/api/lib/opentelemetry-api.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry'

--- a/api/lib/opentelemetry.rb
+++ b/api/lib/opentelemetry.rb
@@ -3,6 +3,7 @@
 # Copyright 2019 OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
+
 require 'logger'
 
 require 'opentelemetry/error'
@@ -13,7 +14,11 @@ require 'opentelemetry/metrics'
 require 'opentelemetry/trace'
 require 'opentelemetry/version'
 
-# OpenTelemetry provides global accessors for telemetry objects
+# OpenTelemetry is an open source observability framework, providing a
+# general-purpose API, SDK, and related tools required for the instrumentation
+# of cloud-native software, frameworks, and libraries.
+#
+# The OpenTelemetry module provides global accessors for telemetry objects.
 module OpenTelemetry
   extend self
 

--- a/api/opentelemetry-api.gemspec
+++ b/api/opentelemetry-api.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.files = ::Dir.glob('lib/**/*.rb') +
                ::Dir.glob('*.md') +
-               ['LICENSE']
+               ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.4.0'
 

--- a/exporters/jaeger/.rubocop.yml
+++ b/exporters/jaeger/.rubocop.yml
@@ -3,15 +3,18 @@ AllCops:
   Exclude:
     - "thrift/**/*"
 
+Lint/UnusedMethodArgument:
+  Enabled: false
 Metrics/AbcSize:
   Max: 18
 Metrics/LineLength:
   Enabled: false
-Metrics/ParameterLists:
-  Enabled: false
 Metrics/MethodLength:
   Max: 20
-Style/ModuleFunction:
+Metrics/ParameterLists:
   Enabled: false
-Lint/UnusedMethodArgument:
+Naming/FileName:
+  Exclude:
+    - "lib/opentelemetry-exporters-jaeger.rb"
+Style/ModuleFunction:
   Enabled: false

--- a/exporters/jaeger/.yardopts
+++ b/exporters/jaeger/.yardopts
@@ -1,0 +1,9 @@
+--no-private
+--title=OpenTelemetry Jaeger Exporter
+--markup=markdown
+--main=OVERVIEW.md
+./lib/opentelemetry/exporters/jaeger/**/*.rb
+./lib/opentelemetry/exporters/jaeger.rb
+-
+OVERVIEW.md
+CHANGELOG.md

--- a/exporters/jaeger/OVERVIEW.md
+++ b/exporters/jaeger/OVERVIEW.md
@@ -1,0 +1,81 @@
+# opentelemetry-exporters-jaeger
+
+The `opentelemetry-exporters-jaeger` gem provides a Jaeger exporter for OpenTelemetry for Ruby. Using `opentelemetry-exporters-jaeger`, an application can configure OpenTelemetry to export collected tracing data to [Jaeger][jaeger-home].
+
+## What is OpenTelemetry?
+
+[OpenTelemetry][opentelemetry-home] is an open source observability framework, providing a general-purpose API, SDK, and related tools required for the instrumentation of cloud-native software, frameworks, and libraries.
+
+OpenTelemetry provides a single set of APIs, libraries, agents, and collector services to capture distributed traces and metrics from your application. You can analyze them using Prometheus, Jaeger, and other observability tools.
+
+## How does this gem fit in?
+
+The `opentelemetry-exporters-jaeger` gem is a plugin that provides Jaeger Tracing export. To export to Jaeger, an application can include this gem along with `opentelemetry-sdk`, and configure the `TracerFactory` to use the provided Jaeger exporter as a span processor.
+
+Generally, *libraries* that produce telemetry data should avoid depending directly on specific exporters, deferring that choice to the application developer.
+
+## How do I get started?
+
+Install the gem using:
+
+```
+gem install opentelemetry-sdk
+gem install opentelemetry-exporters-jaeger
+```
+
+Or, if you use [bundler][bundler-home], include `opentelemetry-sdk` in your `Gemfile`.
+
+Then, configure the SDK to use the Jaeger exporter as a span processor, and use the OpenTelemetry interfaces to produces traces and other information. Following is a basic example.
+
+```ruby
+require 'opentelemetry/sdk'
+require 'opentelemetry/exporters/jaeger'
+
+# Create a concrete tracer factory
+factory = OpenTelemetry::SDK::Trace::TracerFactory.new
+
+# Configure the tracer factory
+factory.add_span_processor(
+  OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(
+    OpenTelemetry::Exporters::Jaeger::Exporter.new(
+      service_name: 'my-service', host: 'localhost', port: 14268
+    )
+  )
+)
+
+# Set it as the default tracer factory
+OpenTelemetry.tracer_factory = factory
+
+# Create a trace using the factory
+tracer = factory.tracer('my_app_or_gem', '1.0')
+
+# Record spans
+tracer.in_span('my_task') do |task_span|
+  tracer.in_span('inner') do |inner_span|
+    # Do something here
+  end
+end
+```
+
+For additional examples, see the [examples on github][examples-github].
+
+## How can I get involved?
+
+The `opentelemetry-exporters-jaeger` gem source is [on github][repo-github], along with related gems including `opentelemetry-sdk`.
+
+The OpenTelemetry Ruby gems are maintained by the OpenTelemetry-Ruby special interest group (SIG). You can get involved by joining us on our [gitter channel][ruby-gitter] or attending our weekly meeting. See the [meeting calendar][community-meetings] for dates and times. For more information on this and other language SIGs, see the OpenTelemetry [community page][ruby-sig].
+
+## License
+
+The `opentelemetry-exporters-jaeger` gem is distributed under the Apache 2.0 license. See [LICENSE][license-github] for more information.
+
+
+[jaeger-home]: https://www.jaegertracing.io
+[opentelemetry-home]: https://opentelemetry.io
+[bundler-home]: https://bundler.io
+[repo-github]: https://github.com/open-telemetry/opentelemetry-ruby
+[license-github]: https://github.com/open-telemetry/opentelemetry-ruby/blob/master/LICENSE
+[examples-github]: https://github.com/open-telemetry/opentelemetry-ruby/tree/master/examples
+[ruby-sig]: https://github.com/open-telemetry/community#ruby-sig
+[community-meetings]: https://github.com/open-telemetry/community#community-meetings
+[ruby-gitter]: https://gitter.im/open-telemetry/opentelemetry-ruby

--- a/exporters/jaeger/Rakefile
+++ b/exporters/jaeger/Rakefile
@@ -20,17 +20,7 @@ Rake::TestTask.new :test do |t|
 end
 
 YARD::Rake::YardocTask.new do |t|
-  files = Dir.glob('./lib/**/*.rb')
-
-  # Move ./lib/opentelemetry/jaeger.rb to the end of the array. Otherwise other
-  # files will overwrite the OpenTelemetry module comments with the license
-  # information.
-  # jaeger_index = files.index('./lib/opentelemetry/jaeger.rb')
-  # files = files.insert(-1, files.delete_at(jaeger_index))
-
-  t.files = files # optional
-  t.options = ['--output-dir', 'docs/jaeger'] # optional
-  t.stats_options = ['--list-undoc'] # optional
+  t.stats_options = ['--list-undoc']
 end
 
 if RUBY_ENGINE == 'truffleruby'

--- a/exporters/jaeger/lib/opentelemetry-exporters-jaeger.rb
+++ b/exporters/jaeger/lib/opentelemetry-exporters-jaeger.rb
@@ -4,10 +4,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'simplecov'
-SimpleCov.start
-
 require 'opentelemetry/exporters/jaeger'
-require 'minitest/autorun'
-
-OpenTelemetry.logger = Logger.new('/dev/null')

--- a/exporters/jaeger/lib/opentelemetry/exporters/jaeger.rb
+++ b/exporters/jaeger/lib/opentelemetry/exporters/jaeger.rb
@@ -4,7 +4,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'opentelemetry'
+require 'opentelemetry/exporters/jaeger/exporter'
+require 'opentelemetry/exporters/jaeger/transport'
+require 'opentelemetry/exporters/jaeger/version'
 
 # OpenTelemetry is an open source observability framework, providing a
 # general-purpose API, SDK, and related tools required for the instrumentation
@@ -13,12 +15,4 @@ require 'opentelemetry'
 # The OpenTelemetry module provides global accessors for telemetry objects.
 # See the documentation for the `opentelemetry-api` gem for details.
 module OpenTelemetry
-  # SDK provides the reference implementation of the OpenTelemetry API.
-  module SDK
-  end
 end
-
-require 'opentelemetry/sdk/internal'
-require 'opentelemetry/sdk/resources'
-require 'opentelemetry/sdk/trace'
-require 'opentelemetry/sdk/version'

--- a/exporters/jaeger/lib/opentelemetry/exporters/jaeger/exporter.rb
+++ b/exporters/jaeger/lib/opentelemetry/exporters/jaeger/exporter.rb
@@ -9,7 +9,6 @@ $LOAD_PATH.push(File.dirname(__FILE__) + '/../../../../thrift/gen-rb')
 require 'agent'
 require 'opentelemetry/sdk'
 require 'socket'
-require_relative 'transport'
 
 module OpenTelemetry
   module Exporters

--- a/exporters/jaeger/opentelemetry-exporters-jaeger.gemspec
+++ b/exporters/jaeger/opentelemetry-exporters-jaeger.gemspec
@@ -20,8 +20,9 @@ Gem::Specification.new do |spec|
   spec.license     = 'Apache-2.0'
 
   spec.files = ::Dir.glob('lib/**/*.rb') +
+               ::Dir.glob('thrift/gen-rb/**/*.rb') +
                ::Dir.glob('*.md') +
-               ['LICENSE']
+               ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.4.0'
 

--- a/sdk/.rubocop.yml
+++ b/sdk/.rubocop.yml
@@ -1,15 +1,18 @@
 AllCops:
   TargetRubyVersion: '2.4.0'
 
+Lint/UnusedMethodArgument:
+  Enabled: false
 Metrics/AbcSize:
   Max: 18
 Metrics/LineLength:
   Enabled: false
-Metrics/ParameterLists:
-  Enabled: false
 Metrics/MethodLength:
   Max: 20
-Style/ModuleFunction:
+Metrics/ParameterLists:
   Enabled: false
-Lint/UnusedMethodArgument:
+Naming/FileName:
+  Exclude:
+    - "lib/opentelemetry-sdk.rb"
+Style/ModuleFunction:
   Enabled: false

--- a/sdk/.yardopts
+++ b/sdk/.yardopts
@@ -1,0 +1,9 @@
+--no-private
+--title=OpenTelemetry SDK
+--markup=markdown
+--main=OVERVIEW.md
+./lib/opentelemetry/sdk/**/*.rb
+./lib/opentelemetry/sdk.rb
+-
+OVERVIEW.md
+CHANGELOG.md

--- a/sdk/OVERVIEW.md
+++ b/sdk/OVERVIEW.md
@@ -1,0 +1,76 @@
+# opentelemetry-sdk
+
+The `opentelemetry-sdk` gem provides the reference implementation of the OpenTelemetry Ruby API. Using `opentelemetry-sdk`, an application can collect, analyze, and export telemetry data such as distributed traces and metrics.
+
+## What is OpenTelemetry?
+
+[OpenTelemetry][opentelemetry-home] is an open source observability framework, providing a general-purpose API, SDK, and related tools required for the instrumentation of cloud-native software, frameworks, and libraries.
+
+OpenTelemetry provides a single set of APIs, libraries, agents, and collector services to capture distributed traces and metrics from your application. You can analyze them using Prometheus, Jaeger, and other observability tools.
+
+## How does this gem fit in?
+
+The `opentelemetry-sdk` gem provides the reference implementation of the OpenTelemetry Ruby interfaces defined in the `opentelemetry-api` gem. That is, it includes the *functionality* needed to collect, analyze, and export telemetry data produced using the API.
+
+Generally, Ruby *applications* should install `opentelemetry-sdk` (or other concrete implementation of the OpenTelemetry API). Using the SDK, an application can configure how it wants telemetry data to be handled, including which data should be persisted, how it should be formatted, and where it should be recorded or exported. However, *libraries* that produce telemetry data should generally depend only on `opentelemetry-api`, deferring the choise of concrete implementation to the application developer.
+
+## How do I get started?
+
+Install the gem using:
+
+```
+gem install opentelemetry-sdk
+```
+
+Or, if you use [bundler][bundler-home], include `opentelemetry-sdk` in your `Gemfile`.
+
+Then, configure the SDK according to your desired handling of telemetry data, and use the OpenTelemetry interfaces to produces traces and other information. Following is a basic example.
+
+```ruby
+require 'opentelemetry/sdk'
+
+# Create a concrete tracer factory
+factory = OpenTelemetry::SDK::Trace::TracerFactory.new
+
+# Configure the tracer factory
+factory.add_span_processor(
+  OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(
+    OpenTelemetry::SDK::Trace::Export::ConsoleSpanExporter.new
+  )
+)
+
+# Set it as the default tracer factory
+OpenTelemetry.tracer_factory = factory
+
+# Create a trace using the factory
+tracer = factory.tracer('my_app_or_gem', '1.0')
+
+# Record spans
+tracer.in_span('my_task') do |task_span|
+  tracer.in_span('inner') do |inner_span|
+    # Do something here
+  end
+end
+```
+
+For additional examples, see the [examples on github][examples-github].
+
+## How can I get involved?
+
+The `opentelemetry-sdk` gem source is [on github][repo-github], along with related gems including `opentelemetry-api`.
+
+The OpenTelemetry Ruby gems are maintained by the OpenTelemetry-Ruby special interest group (SIG). You can get involved by joining us on our [gitter channel][ruby-gitter] or attending our weekly meeting. See the [meeting calendar][community-meetings] for dates and times. For more information on this and other language SIGs, see the OpenTelemetry [community page][ruby-sig].
+
+## License
+
+The `opentelemetry-sdk` gem is distributed under the Apache 2.0 license. See [LICENSE][license-github] for more information.
+
+
+[opentelemetry-home]: https://opentelemetry.io
+[bundler-home]: https://bundler.io
+[repo-github]: https://github.com/open-telemetry/opentelemetry-ruby
+[license-github]: https://github.com/open-telemetry/opentelemetry-ruby/blob/master/LICENSE
+[examples-github]: https://github.com/open-telemetry/opentelemetry-ruby/tree/master/examples
+[ruby-sig]: https://github.com/open-telemetry/community#ruby-sig
+[community-meetings]: https://github.com/open-telemetry/community#community-meetings
+[ruby-gitter]: https://gitter.im/open-telemetry/opentelemetry-ruby

--- a/sdk/Rakefile
+++ b/sdk/Rakefile
@@ -19,17 +19,7 @@ Rake::TestTask.new :test do |t|
 end
 
 YARD::Rake::YardocTask.new do |t|
-  files = Dir.glob('./lib/**/*.rb')
-
-  # Move ./lib/opentelemetry/sdk.rb to the end of the array. Otherwise other
-  # files will overwrite the OpenTelemetry module comments with the license
-  # information.
-  sdk_index = files.index('./lib/opentelemetry/sdk.rb')
-  files = files.insert(-1, files.delete_at(sdk_index))
-
-  t.files = files # optional
-  t.options = ['--output-dir', 'docs/sdk'] # optional
-  t.stats_options = ['--list-undoc'] # optional
+  t.stats_options = ['--list-undoc']
 end
 
 if RUBY_ENGINE == 'truffleruby'

--- a/sdk/lib/opentelemetry-sdk.rb
+++ b/sdk/lib/opentelemetry-sdk.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry/sdk'

--- a/sdk/opentelemetry-sdk.gemspec
+++ b/sdk/opentelemetry-sdk.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.files = ::Dir.glob('lib/**/*.rb') +
                ::Dir.glob('*.md') +
-               ['LICENSE']
+               ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.4.0'
 


### PR DESCRIPTION
This includes a bunch of cleanup changes targeted toward making the YARD docs work well.

Specifics:
* Wrote an `OVERVIEW.md` file for each gem, to be used as the "front page" for YARD docs.
* Also included the changelog in the YARD output.
* Set a title on the YARD docs.
* Omitted private objects
* Built the docs into the default output directory (`doc`) instead of a custom directory (e.g. `docs/api`).
* Moved the pertinent arguments from the YARD rake tasks into `.yardopts` files (and added those to the gemspec) so that rubydoc.info will know how to build the docs properly.

Notes:
* `.yardopts` doesn't include Ruby code, so the hack involving reordering the list of files to avoid the copyright notice being listed as the documentation for the toplevel module doesn't work. But I was able simply to specify the file order statically so the "main" entrypoint file is last.
* Unfortunately, the Apache `LICENSE` files aren't building correctly since they're not markdown-formatted, so I'm omitting them for now. I'll figure out later what to do with those.

This also includes the following mostly unrelated cleanup and fixes.
* Added a Ruby file to each gem, named for the gem name (so `Bundler.require` will work properly with these gems).
* Added the file `lib/opentelemetry/exporters/jaeger.rb` as a better entrypoint for the Jaeger exporter. Avoids the weirdness of having to require a deeper file as the entrypoint.
* The Jaeger exporter gem didn't include the generated thrift files. Fixed.