### PR TITLE
Draft: Sdk Config

### DIFF
--- a/sdk/lib/opentelemetry/sdk.rb
+++ b/sdk/lib/opentelemetry/sdk.rb
@@ -9,9 +9,22 @@ require 'opentelemetry'
 module OpenTelemetry
   # SDK provides the reference implementation of the OpenTelemetry API.
   module SDK
+    extend self
+
+    # Configures SDK and instrumentation
+    #
+    # @yieldparam [Configurator] configurator Yields a configurator to the
+    #   provided block
+    #
+    def configure
+      configurator = Configurator.new
+      yield configurator if block_given?
+      configurator.configure
+    end
   end
 end
 
+require 'opentelemetry/sdk/configurator'
 require 'opentelemetry/sdk/internal'
 require 'opentelemetry/sdk/resources'
 require 'opentelemetry/sdk/trace'

--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -92,7 +92,7 @@ module OpenTelemetry
         #                                   v v v
         # OpenTelemetry.correlation_context_manager = correlation_context_manager
         # OpenTelemetry.propagation = propagation
-        @span_processors.each { |p| tracer_factory.add_span_processor(p) }
+        configure_span_processors
         OpenTelemetry.tracer_factory = tracer_factory
         # These exist in open or future PRs | | |
         #                                   v v v
@@ -114,6 +114,17 @@ module OpenTelemetry
         when USE_MODE_ALL
           OpenTelemtry.instrumentation_registry.install_all(@adapter_config_map)
         end
+      end
+
+      def configure_span_processors
+        processors = @span_processors.empty? ? [default_span_processor] : @span_processors
+        processors.each { |p| tracer_factory.add_span_processor(p) }
+      end
+
+      def default_span_processor
+        Trace::Export::SimpleSpanProcessor.new(
+          Trace::Export::ConsoleSpanExporter.new
+        )
       end
     end
   end

--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -19,6 +19,7 @@ module OpenTelemetry
                   :propagation, :logger
 
       def initialize
+        @adapter_names = []
         @adapter_config_map = {}
         @span_processors = []
         @use_mode = USE_MODE_UNSPECIFIED
@@ -56,7 +57,8 @@ module OpenTelemetry
       # @param [optional Hash] config The config for this adapter
       def use(adapter_name, config = nil)
         check_use_mode!(USE_MODE_ONE)
-        @adapter_config_map[adapter_name] = config
+        @adapter_names << adapter_name
+        @adapter_config_map[adapter_name] = config if config
       end
 
       # Install all registered instrumentation. Configuration for specific
@@ -99,7 +101,7 @@ module OpenTelemetry
       def install_instrumentation
         case @use_mode
         when USE_MODE_ONE
-          OpenTelemetry.instrumentation_registry.install(@adapter_config_map)
+          OpenTelemetry.instrumentation_registry.install(@adapter_names, @adapter_config_map)
         when USE_MODE_ALL
           OpenTelemtry.instrumentation_registry.install_all(@adapter_config_map)
         end

--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -16,12 +16,14 @@ module OpenTelemetry
       private_constant :USE_MODE_UNSPECIFIED, :USE_MODE_ONE, :USE_MODE_ALL
 
       attr_writer :tracer_factory, :meter_factory, :correlation_context_manager,
-                  :propagation, :logger
+                  :global_http_extractors, :global_http_injectors, :logger
 
       def initialize
         @adapter_names = []
         @adapter_config_map = {}
         @span_processors = []
+        # @global_http_extractors = default_http_extractors
+        # @global_http_injectors = default_http_injectors
         @use_mode = USE_MODE_UNSPECIFIED
       end
 
@@ -37,10 +39,6 @@ module OpenTelemetry
 
       # def correlation_context_manager
       #   @correlation_context_manager ||= CorrelationContext::Mangager.new
-      # end
-
-      # def propagation
-      #   @propagation ||= Propagation::Propagation.new
       # end
 
       def logger
@@ -91,7 +89,8 @@ module OpenTelemetry
         # These exist in open or future PRs | | |
         #                                   v v v
         # OpenTelemetry.correlation_context_manager = correlation_context_manager
-        # OpenTelemetry.propagation = propagation
+        # OpenTelemetry.propagation.http_injectors = @global_http_injectors
+        # OpenTelemetry.propagation.http_extractors = @global_http_extractors
         configure_span_processors
         OpenTelemetry.tracer_factory = tracer_factory
         # These exist in open or future PRs | | |
@@ -125,6 +124,20 @@ module OpenTelemetry
         Trace::Export::SimpleSpanProcessor.new(
           Trace::Export::ConsoleSpanExporter.new
         )
+      end
+
+      def default_http_injectors
+        [
+          Trace::Propagation.http_trace_context_injector,
+          CorrelationContext::Propagation.http_injector
+        ]
+      end
+
+      def default_http_extractors
+        [
+          Trace::Propagation.http_trace_context_extractor,
+          CorrelationContext::Propagation.http_extractor
+        ]
       end
     end
   end

--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -9,12 +9,19 @@ module OpenTelemetry
     # The configurator provides defaults and facilitates configuring the
     # SDK for use.
     class Configurator
+      USE_MODE_UNSPECIFIED = 0
+      USE_MODE_ONE = 1
+      USE_MODE_ALL = 2
+
+      private_constant :USE_MODE_UNSPECIFIED, :USE_MODE_ONE, :USE_MODE_ALL
+
       attr_writer :tracer_factory, :meter_factory, :correlation_context_manager,
                   :propagation, :logger
 
       def initialize
         @adapter_config_map = {}
         @span_processors = []
+        @use_mode = USE_MODE_UNSPECIFIED
       end
 
       def tracer_factory
@@ -39,8 +46,30 @@ module OpenTelemetry
         @logger ||= Logger.new(STDOUT)
       end
 
+      # Install an instrumentation adapter with specificied optional +config+.
+      # Use can be called multiple times to install multiple instrumentation
+      # adapters. Only +use+ or +use_all+, but not both when installing
+      # instrumentation. A call to +use_all+ after +use+ will result in an
+      # exception.
+      #
+      # @param [String] adapter_name The name of the instrumentation adapter
+      # @param [optional Hash] config The config for this adapter
       def use(adapter_name, config = nil)
+        check_use_mode!(USE_MODE_ONE)
         @adapter_config_map[adapter_name] = config
+      end
+
+      # Install all registered instrumentation. Configuration for specific
+      # adapters can be provided with the optional +adapter_config_map+
+      # parameter. Only +use+ or +use_all+, but not both when installing
+      # instrumentation. A call to +use+ after +use_all+ will result in an
+      # exception.
+      #
+      # @param [Hash<String,Hash>] adapter_config_map A map with string keys
+      #   representing the adapter name and values specifying the adapter config
+      def use_all(adapter_config_map = {})
+        check_use_mode!(USE_MODE_ALL)
+        @adapter_config_map = adapter_config_map
       end
 
       def add_span_processor(span_processor)
@@ -50,14 +79,30 @@ module OpenTelemetry
       # @api private
       def configure
         OpenTelemetry.logger = logger
-        span_processors.each { |p| tracer_factory.add_span_processor(p) }
+        @span_processors.each { |p| tracer_factory.add_span_processor(p) }
         OpenTelemetry.tracer_factory = tracer_factory
         # These exist in open or future PRs | | |
         #                                   v v v
         # OpenTelemetry.meter_factory = meter_factory
         # OpenTelemetry.correlation_context_manager = correlation_context_manager
         # OpenTelemetry.propagation = propagation
-        # OpenTelemetry::Instrumentation.registry.install_adapters(@adapter_config_map)
+        # install_instrumentation
+      end
+
+      private
+
+      def check_use_mode!(mode)
+        @use_mode = mode if @use_mode == USE_MODE_UNSPECIFIED
+        raise 'Use either `use_all` or `use`, but not both' unless @use_mode == mode
+      end
+
+      def install_instrumentation
+        case @use_mode
+        when USE_MODE_ONE
+          OpenTelemetry.instrumentation_registry.install(@adapter_config_map)
+        when USE_MODE_ALL
+          OpenTelemtry.instrumentation_registry.install_all(@adapter_config_map)
+        end
       end
     end
   end

--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    # The configurator provides defaults and facilitates configuring the
+    # SDK for use.
+    class Configurator
+      attr_writer :tracer_factory, :meter_factory, :correlation_context_manager,
+                  :propagation, :logger
+
+      def initialize
+        @adapter_config_map = {}
+        @span_processors = []
+      end
+
+      def tracer_factory
+        @tracer_factory ||= Trace::TracerFactory.new
+      end
+
+      # These exist in open or future PRs | | |
+      #                                   v v v
+      # def meter_factory
+      #   @meter_factory ||= Metrics::MeterFactory.new
+      # end
+
+      # def correlation_context_manager
+      #   @correlation_context_manager ||= CorrelationContext::Mangager.new
+      # end
+
+      # def propagation
+      #   @propagation ||= Propagation::Propagation.new
+      # end
+
+      def logger
+        @logger ||= Logger.new(STDOUT)
+      end
+
+      def use(adapter_name, config = nil)
+        @adapter_config_map[adapter_name] = config
+      end
+
+      def add_span_processor(span_processor)
+        @span_processors << span_processor
+      end
+
+      # @api private
+      def configure
+        OpenTelemetry.logger = logger
+        span_processors.each { |p| tracer_factory.add_span_processor(p) }
+        OpenTelemetry.tracer_factory = tracer_factory
+        # These exist in open or future PRs | | |
+        #                                   v v v
+        # OpenTelemetry.meter_factory = meter_factory
+        # OpenTelemetry.correlation_context_manager = correlation_context_manager
+        # OpenTelemetry.propagation = propagation
+        # OpenTelemetry::Instrumentation.registry.install_adapters(@adapter_config_map)
+      end
+    end
+  end
+end

--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -79,15 +79,24 @@ module OpenTelemetry
       end
 
       # @api private
+      # The configure method is where we define the setup process. This allows
+      # us to make certain guarantees about which systems and globals are setup
+      # at each stage. Currently, the setup process is roughly:
+      #   - setup logging
+      #   - setup propagation
+      #   - setup tracer_factory and meter_factory
+      #   - install instrumentation
       def configure
         OpenTelemetry.logger = logger
+        # These exist in open or future PRs | | |
+        #                                   v v v
+        # OpenTelemetry.correlation_context_manager = correlation_context_manager
+        # OpenTelemetry.propagation = propagation
         @span_processors.each { |p| tracer_factory.add_span_processor(p) }
         OpenTelemetry.tracer_factory = tracer_factory
         # These exist in open or future PRs | | |
         #                                   v v v
         # OpenTelemetry.meter_factory = meter_factory
-        # OpenTelemetry.correlation_context_manager = correlation_context_manager
-        # OpenTelemetry.propagation = propagation
         # install_instrumentation
       end
 

--- a/sdk/test/opentelemetry/sdk/configurator_test.rb
+++ b/sdk/test/opentelemetry/sdk/configurator_test.rb
@@ -22,4 +22,26 @@ describe OpenTelemetry::SDK::Configurator do
       _(configurator.logger).must_be_instance_of(Logger)
     end
   end
+
+  describe '#use' do
+    it 'can be called multiple times' do
+      configurator.use('TestAdapter', enabled: true)
+      configurator.use('TestAdapter1')
+    end
+  end
+
+  describe '#use, #use_all' do
+    describe 'should be used mutually exclusively' do
+      it 'raises when use_all called after use' do
+        configurator.use('TestAdapter', enabled: true)
+        _(-> { configurator.use_all }).must_raise(StandardError)
+      end
+
+      it 'raises when use called after use_all' do
+        configurator.use_all
+        _(-> { configurator.use('TestAdapter', enabled: true) })
+          .must_raise(StandardError)
+      end
+    end
+  end
 end

--- a/sdk/test/opentelemetry/sdk/configurator_test.rb
+++ b/sdk/test/opentelemetry/sdk/configurator_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+describe OpenTelemetry::SDK::Configurator do
+  let(:configurator) { OpenTelemetry::SDK::Configurator.new }
+
+  describe '#tracer_factory' do
+    it 'defaults to SDK::Trace::TracerFactory' do
+      _(configurator.tracer_factory).must_be_instance_of(
+        OpenTelemetry::SDK::Trace::TracerFactory
+      )
+    end
+  end
+
+  describe '#logger' do
+    it 'returns a logger instance' do
+      _(configurator.logger).must_be_instance_of(Logger)
+    end
+  end
+end


### PR DESCRIPTION
This PR is currently a draft of SDK configuration and global init. It has three main goals.

* Make it easy to setup an SDK by providing sensible defaults and easy way to override them
* Establish a defined sequence of initialization. This allows us to make certain gaurantees about which systems and globals are available at each state. The sequence is roughly:
  * setup logging
  * setup propagation
  * setup the tracer_factory and meter_factory
  * install instrumentation (as the last step)
* Make it easy for users to configure and install instrumentation

It is essentially a builder that exposes and API to setup the SDK, which will in turn setup the proper components on the OpenTelemetry module.

### Example

#### Mimimal Setup

```ruby
OpenTelemetry::SDK.configure

```

This will setup the SDK with:
  - default propagation: W3C Trace Context and W3C Correlation Context
  - basic export: `SimpleSpanProcessor` with `ConsoleExporter`
  - STDOUT logging
  - No instrumentation installed

#### Customized setup

These are the options current available and subject to change as the draft progresses

```ruby
OpenTelemetry::SDK.configure do |c|
  c.tracer_factory = ...
  c.meter_factory = ...
  c.correlation_context_manager = ...
  c.propagation = ...
  c.logger = Logger.new('/dev/null')
  c.add_span_processor(...)
  c.use 'OpenTelemetry::Adapters::Sinatra', {enabled: true}
  c.use 'OpenTelemetry::Adapters::Faraday', {ignore_filters: [/domain\.com/]}
  c.use 'SomeCustom::Adapter::Lib'
end
```

### Installing Instrumentation

This is relevant to #164.

There will be two ways to install instrumentation. 
  * Install adapters individually
  * Install all adapters that are present on the system by way of the discovery system
 
This is how each of those would look. **Note**: this is part of the SDK config draft PR, but an important piece of the instrumentation puzzle:

#### Install adapters individually

```ruby
OpenTelemetry::SDK.configure do |c|
  c.use 'OpenTelemetry::Adapters::Sinatra'
  c.use 'OpenTelemetry::Adapters::Faraday', {some_config: some_value} #config can optionally be passed
end
```

#### Install all adapters with default config

```ruby
OpenTelemetry::SDK.configure do |c|
  c.use_all
end
```

#### Install all adapters with config overrides

Any adapter configs will be passed onto the adapter during installation. Providing them is optional.

```ruby
OpenTelemetry::SDK.configure do |c|
  c.use_all {
    'OpenTelemetry::Adapters::Faraday' => {some_config: some_value}
    ....
  }
end
```

