### PR TITLE
Update release schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,17 +115,16 @@ for a complete example.
 
 ## Release Schedule
 
-OpenTelemetry Ruby is under active development. Our goal is to release an
-_alpha_ version of the library at the end of September 2019. This release isn't
-guaranteed to conform to a specific version of the specification, and future
-releases will not attempt to maintain backwards compatibility with the alpha
-release.
+OpenTelemetry Ruby is under active development. Below is the release schedule
+for the Ruby library. The first version of the release isn't guaranteed to
+conform  to a specific version of the specification, and future releases will
+not attempt to maintain backward compatibility with the alpha release.
 
 | Component                   | Version       | Target Date       | Release Date      |
 | --------------------------- | ------------- | ----------------- | ----------------- |
-| Tracing API                 | Alpha v0.2.0  | September 30 2019 | September 30 2019 |
-| Tracing SDK                 | Alpha v0.2.0  | September 30 2019 | September 30 2019 |
-| Jaeger Trace Exporter       | Alpha v0.2.0  | February 24 2020  | Unknown           |
+| Tracing API                 | Alpha v0.2.0  | September 30 2019 | November 13 2019  |
+| Tracing SDK                 | Alpha v0.2.0  | September 30 2019 | November 13 2019  |
+| Jaeger Trace Exporter       | Alpha v0.2.0  | September 30 2019 | November 13 2019           |
 | Metrics API                 | Alpha v0.3.0  | February 24 2020  | Unknown           |
 | Metrics SDK                 | Alpha v0.3.0  | February 24 2020  | Unknown           |
 | Prometheus Metrics Exporter | Alpha v0.3.0  | February 24 2020  | Unknown           |

--- a/README.md
+++ b/README.md
@@ -120,16 +120,19 @@ for the Ruby library. The first version of the release isn't guaranteed to
 conform  to a specific version of the specification, and future releases will
 not attempt to maintain backward compatibility with the alpha release.
 
-| Component                   | Version       | Target Date       | Release Date      |
-| --------------------------- | ------------- | ----------------- | ----------------- |
-| Tracing API                 | Alpha v0.2.0  | September 30 2019 | November 13 2019  |
-| Tracing SDK                 | Alpha v0.2.0  | September 30 2019 | November 13 2019  |
-| Jaeger Trace Exporter       | Alpha v0.2.0  | September 30 2019 | November 13 2019           |
-| Metrics API                 | Alpha v0.3.0  | February 24 2020  | Unknown           |
-| Metrics SDK                 | Alpha v0.3.0  | February 24 2020  | Unknown           |
-| Prometheus Metrics Exporter | Alpha v0.3.0  | February 24 2020  | Unknown           |
-| OpenTracing Bridge          | Alpha v0.3.0  | February 24 2020  | Unknown           |
-| OpenCensus Bridge           | Unknown       | Unknown           | Unknown           |
+| Component                       | Version       | Target Date       | Release Date      |
+| ------------------------------- | ------------- | ----------------- | ----------------- |
+| Tracing API                     | Alpha v0.2.0  | September 30 2019 | November 13 2019  |
+| Tracing SDK                     | Alpha v0.2.0  | September 30 2019 | November 13 2019  |
+| Trace Context Propagation       | Alpha v0.2.0  | September 30 2019 | November 13 2019  |
+| Jaeger Trace Exporter           | Alpha v0.2.0  | September 30 2019 | November 13 2019  |
+| Metrics API                     | Alpha v0.3.0  | February 24 2020  | Unknown           |
+| Metrics SDK                     | Alpha v0.3.0  | February 24 2020  | Unknown           |
+| Prometheus Metrics Exporter     | Alpha v0.3.0  | February 24 2020  | Unknown           |
+| Correlation Context Propagation | Alpha v0.3.0  | February 24 2020  | Unknown           |
+| OpenTracing Bridge              | Alpha v0.3.0  | February 24 2020  | Unknown           |
+| Zipkin Trace Exporter           | Unknown       | Unknown           | Unknown           |
+| OpenCensus Bridge               | Unknown       | Unknown           | Unknown           |
 
 ## Release Process
 

--- a/README.md
+++ b/README.md
@@ -121,16 +121,16 @@ guaranteed to conform to a specific version of the specification, and future
 releases will not attempt to maintain backwards compatibility with the alpha
 release.
 
-| Component                   | Version | Target Date       |
-| --------------------------- | ------- | ----------------- |
-| Tracing API                 | Alpha   | September 30 2019 |
-| Tracing SDK                 | Alpha   | September 30 2019 |
-| Metrics API                 | Alpha   | Unknown           |
-| Metrics SDK                 | Alpha   | Unknown           |
-| Jaeger Trace Exporter       | Alpha   | Unknown           |
-| Prometheus Metrics Exporter | Alpha   | Unknown           |
-| OpenTracing Bridge          | Alpha   | Unknown           |
-| OpenCensus Bridge           | Alpha   | Unknown           |
+| Component                   | Version       | Target Date       | Release Date      |
+| --------------------------- | ------------- | ----------------- | ----------------- |
+| Tracing API                 | Alpha v0.2.0  | September 30 2019 | September 30 2019 |
+| Tracing SDK                 | Alpha v0.2.0  | September 30 2019 | September 30 2019 |
+| Jaeger Trace Exporter       | Alpha v0.2.0  | February 24 2020  | Unknown           |
+| Metrics API                 | Alpha v0.3.0  | February 24 2020  | Unknown           |
+| Metrics SDK                 | Alpha v0.3.0  | February 24 2020  | Unknown           |
+| Prometheus Metrics Exporter | Alpha v0.3.0  | February 24 2020  | Unknown           |
+| OpenTracing Bridge          | Alpha v0.3.0  | February 24 2020  | Unknown           |
+| OpenCensus Bridge           | Unknown       | Unknown           | Unknown           |
 
 ## Release Process
 


### PR DESCRIPTION
Our release schedule was out of date. I updated it to reflect past releases and with estimates for future dates. The dates are just guesses; we should try to make them reasonable guesses, but they aren't binding. We can and should modify the proposed roadmap through comments (on this PR) and at our SIG meeting.

Fixes #169.