### PR TITLE
Preliminary sdk config

### DIFF
--- a/sdk/lib/opentelemetry/sdk.rb
+++ b/sdk/lib/opentelemetry/sdk.rb
@@ -22,6 +22,36 @@ module OpenTelemetry
     # @yieldparam [Configurator] configurator Yields a configurator to the
     #   provided block
     #
+    # Example usage:
+    #   Without a block defaults are installed without any instrumentation
+    #
+    #     OpenTelemetry::SDK.configure
+    #
+    #   Install instrumentation individually with optional config
+    #
+    #     OpenTelemetry::SDK.configure do |c|
+    #       c.use 'OpenTelemetry::Adapters::Faraday', tracer_middleware: SomeMiddleware
+    #     end
+    #
+    #   Install all instrumentation with optional config
+    #
+    #     OpenTelemetry::SDK.configure do |c|
+    #       c.use_all 'OpenTelemetry::Adapters::Faraday' => { tracer_middleware: SomeMiddleware }
+    #     end
+    #
+    #   Add a span processor
+    #
+    #     OpenTelemetry::SDK.configure do |c|
+    #       c.add_span_processor SpanProcessor.new(SomeExporter.new)
+    #     end
+    #
+    #   Configure everything
+    #
+    #     OpenTelemetry::SDK.configure do |c|
+    #       c.tracer_factor = SomeTracerFactory.new
+    #       c.add_span_processor SpanProcessor.new(SomeExporter.new)
+    #       c.use_all
+    #     end
     def configure
       configurator = Configurator.new
       yield configurator if block_given?

--- a/sdk/lib/opentelemetry/sdk.rb
+++ b/sdk/lib/opentelemetry/sdk.rb
@@ -15,9 +15,22 @@ require 'opentelemetry'
 module OpenTelemetry
   # SDK provides the reference implementation of the OpenTelemetry API.
   module SDK
+    extend self
+
+    # Configures SDK and instrumentation
+    #
+    # @yieldparam [Configurator] configurator Yields a configurator to the
+    #   provided block
+    #
+    def configure
+      configurator = Configurator.new
+      yield configurator if block_given?
+      configurator.configure
+    end
   end
 end
 
+require 'opentelemetry/sdk/configurator'
 require 'opentelemetry/sdk/internal'
 require 'opentelemetry/sdk/resources'
 require 'opentelemetry/sdk/trace'

--- a/sdk/lib/opentelemetry/sdk.rb
+++ b/sdk/lib/opentelemetry/sdk.rb
@@ -48,7 +48,7 @@ module OpenTelemetry
     #   Configure everything
     #
     #     OpenTelemetry::SDK.configure do |c|
-    #       c.tracer_factor = SomeTracerFactory.new
+    #       c.logger = Logger.new('/dev/null')
     #       c.add_span_processor SpanProcessor.new(SomeExporter.new)
     #       c.use_all
     #     end

--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -92,7 +92,7 @@ module OpenTelemetry
         #                                   v v v
         # OpenTelemetry.correlation_context_manager = correlation_context_manager
         # OpenTelemetry.propagation = propagation
-        @span_processors.each { |p| tracer_factory.add_span_processor(p) }
+        configure_span_processors
         OpenTelemetry.tracer_factory = tracer_factory
         # These exist in open or future PRs | | |
         #                                   v v v
@@ -114,6 +114,17 @@ module OpenTelemetry
         when USE_MODE_ALL
           OpenTelemtry.instrumentation_registry.install_all(@adapter_config_map)
         end
+      end
+
+      def configure_span_processors
+        processors = @span_processors.empty? ? [default_span_processor] : @span_processors
+        processors.each { |p| tracer_factory.add_span_processor(p) }
+      end
+
+      def default_span_processor
+        Trace::Export::SimpleSpanProcessor.new(
+          Trace::Export::ConsoleSpanExporter.new
+        )
       end
     end
   end

--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -19,6 +19,7 @@ module OpenTelemetry
                   :propagation, :logger
 
       def initialize
+        @adapter_names = []
         @adapter_config_map = {}
         @span_processors = []
         @use_mode = USE_MODE_UNSPECIFIED
@@ -56,7 +57,8 @@ module OpenTelemetry
       # @param [optional Hash] config The config for this adapter
       def use(adapter_name, config = nil)
         check_use_mode!(USE_MODE_ONE)
-        @adapter_config_map[adapter_name] = config
+        @adapter_names << adapter_name
+        @adapter_config_map[adapter_name] = config if config
       end
 
       # Install all registered instrumentation. Configuration for specific
@@ -99,7 +101,7 @@ module OpenTelemetry
       def install_instrumentation
         case @use_mode
         when USE_MODE_ONE
-          OpenTelemetry.instrumentation_registry.install(@adapter_config_map)
+          OpenTelemetry.instrumentation_registry.install(@adapter_names, @adapter_config_map)
         when USE_MODE_ALL
           OpenTelemtry.instrumentation_registry.install_all(@adapter_config_map)
         end

--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -15,17 +15,14 @@ module OpenTelemetry
 
       private_constant :USE_MODE_UNSPECIFIED, :USE_MODE_ONE, :USE_MODE_ALL
 
-      attr_writer :tracer_factory, :logger
+      attr_writer :logger
 
       def initialize
         @adapter_names = []
         @adapter_config_map = {}
         @span_processors = []
         @use_mode = USE_MODE_UNSPECIFIED
-      end
-
-      def tracer_factory
-        @tracer_factory ||= Trace::TracerFactory.new
+        @tracer_factory = Trace::TracerFactory.new
       end
 
       def logger
@@ -79,7 +76,7 @@ module OpenTelemetry
       def configure
         OpenTelemetry.logger = logger
         configure_span_processors
-        OpenTelemetry.tracer_factory = tracer_factory
+        OpenTelemetry.tracer_factory = @tracer_factory
         install_instrumentation
       end
 
@@ -101,7 +98,7 @@ module OpenTelemetry
 
       def configure_span_processors
         processors = @span_processors.empty? ? [default_span_processor] : @span_processors
-        processors.each { |p| tracer_factory.add_span_processor(p) }
+        processors.each { |p| @tracer_factory.add_span_processor(p) }
       end
 
       def default_span_processor

--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -59,6 +59,11 @@ module OpenTelemetry
         @adapter_config_map = adapter_config_map
       end
 
+      # Add a span processor to the export pipeline
+      #
+      # @param [#on_start, #on_finish, #shutdown] span_processor A span_processor
+      #   that satisfies the duck type #on_start, #on_finish, #shutdown. See
+      #   {SimpleSpanProcessor} for an example.
       def add_span_processor(span_processor)
         @span_processors << span_processor
       end

--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -90,7 +90,7 @@ module OpenTelemetry
         when USE_MODE_ONE
           OpenTelemetry.instrumentation_registry.install(@adapter_names, @adapter_config_map)
         when USE_MODE_ALL
-          OpenTelemtry.instrumentation_registry.install_all(@adapter_config_map)
+          OpenTelemetry.instrumentation_registry.install_all(@adapter_config_map)
         end
       end
 

--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -9,12 +9,19 @@ module OpenTelemetry
     # The configurator provides defaults and facilitates configuring the
     # SDK for use.
     class Configurator
+      USE_MODE_UNSPECIFIED = 0
+      USE_MODE_ONE = 1
+      USE_MODE_ALL = 2
+
+      private_constant :USE_MODE_UNSPECIFIED, :USE_MODE_ONE, :USE_MODE_ALL
+
       attr_writer :tracer_factory, :meter_factory, :correlation_context_manager,
                   :propagation, :logger
 
       def initialize
         @adapter_config_map = {}
         @span_processors = []
+        @use_mode = USE_MODE_UNSPECIFIED
       end
 
       def tracer_factory
@@ -39,8 +46,30 @@ module OpenTelemetry
         @logger ||= Logger.new(STDOUT)
       end
 
+      # Install an instrumentation adapter with specificied optional +config+.
+      # Use can be called multiple times to install multiple instrumentation
+      # adapters. Only +use+ or +use_all+, but not both when installing
+      # instrumentation. A call to +use_all+ after +use+ will result in an
+      # exception.
+      #
+      # @param [String] adapter_name The name of the instrumentation adapter
+      # @param [optional Hash] config The config for this adapter
       def use(adapter_name, config = nil)
+        check_use_mode!(USE_MODE_ONE)
         @adapter_config_map[adapter_name] = config
+      end
+
+      # Install all registered instrumentation. Configuration for specific
+      # adapters can be provided with the optional +adapter_config_map+
+      # parameter. Only +use+ or +use_all+, but not both when installing
+      # instrumentation. A call to +use+ after +use_all+ will result in an
+      # exception.
+      #
+      # @param [Hash<String,Hash>] adapter_config_map A map with string keys
+      #   representing the adapter name and values specifying the adapter config
+      def use_all(adapter_config_map = {})
+        check_use_mode!(USE_MODE_ALL)
+        @adapter_config_map = adapter_config_map
       end
 
       def add_span_processor(span_processor)
@@ -50,14 +79,30 @@ module OpenTelemetry
       # @api private
       def configure
         OpenTelemetry.logger = logger
-        span_processors.each { |p| tracer_factory.add_span_processor(p) }
+        @span_processors.each { |p| tracer_factory.add_span_processor(p) }
         OpenTelemetry.tracer_factory = tracer_factory
         # These exist in open or future PRs | | |
         #                                   v v v
         # OpenTelemetry.meter_factory = meter_factory
         # OpenTelemetry.correlation_context_manager = correlation_context_manager
         # OpenTelemetry.propagation = propagation
-        # OpenTelemetry::Instrumentation.registry.install_adapters(@adapter_config_map)
+        # install_instrumentation
+      end
+
+      private
+
+      def check_use_mode!(mode)
+        @use_mode = mode if @use_mode == USE_MODE_UNSPECIFIED
+        raise 'Use either `use_all` or `use`, but not both' unless @use_mode == mode
+      end
+
+      def install_instrumentation
+        case @use_mode
+        when USE_MODE_ONE
+          OpenTelemetry.instrumentation_registry.install(@adapter_config_map)
+        when USE_MODE_ALL
+          OpenTelemtry.instrumentation_registry.install_all(@adapter_config_map)
+        end
       end
     end
   end

--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    # The configurator provides defaults and facilitates configuring the
+    # SDK for use.
+    class Configurator
+      attr_writer :tracer_factory, :meter_factory, :correlation_context_manager,
+                  :propagation, :logger
+
+      def initialize
+        @adapter_config_map = {}
+        @span_processors = []
+      end
+
+      def tracer_factory
+        @tracer_factory ||= Trace::TracerFactory.new
+      end
+
+      # These exist in open or future PRs | | |
+      #                                   v v v
+      # def meter_factory
+      #   @meter_factory ||= Metrics::MeterFactory.new
+      # end
+
+      # def correlation_context_manager
+      #   @correlation_context_manager ||= CorrelationContext::Mangager.new
+      # end
+
+      # def propagation
+      #   @propagation ||= Propagation::Propagation.new
+      # end
+
+      def logger
+        @logger ||= Logger.new(STDOUT)
+      end
+
+      def use(adapter_name, config = nil)
+        @adapter_config_map[adapter_name] = config
+      end
+
+      def add_span_processor(span_processor)
+        @span_processors << span_processor
+      end
+
+      # @api private
+      def configure
+        OpenTelemetry.logger = logger
+        span_processors.each { |p| tracer_factory.add_span_processor(p) }
+        OpenTelemetry.tracer_factory = tracer_factory
+        # These exist in open or future PRs | | |
+        #                                   v v v
+        # OpenTelemetry.meter_factory = meter_factory
+        # OpenTelemetry.correlation_context_manager = correlation_context_manager
+        # OpenTelemetry.propagation = propagation
+        # OpenTelemetry::Instrumentation.registry.install_adapters(@adapter_config_map)
+      end
+    end
+  end
+end

--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -15,8 +15,7 @@ module OpenTelemetry
 
       private_constant :USE_MODE_UNSPECIFIED, :USE_MODE_ONE, :USE_MODE_ALL
 
-      attr_writer :tracer_factory, :meter_factory, :correlation_context_manager,
-                  :propagation, :logger
+      attr_writer :tracer_factory, :logger
 
       def initialize
         @adapter_names = []
@@ -28,20 +27,6 @@ module OpenTelemetry
       def tracer_factory
         @tracer_factory ||= Trace::TracerFactory.new
       end
-
-      # These exist in open or future PRs | | |
-      #                                   v v v
-      # def meter_factory
-      #   @meter_factory ||= Metrics::MeterFactory.new
-      # end
-
-      # def correlation_context_manager
-      #   @correlation_context_manager ||= CorrelationContext::Mangager.new
-      # end
-
-      # def propagation
-      #   @propagation ||= Propagation::Propagation.new
-      # end
 
       def logger
         @logger ||= Logger.new(STDOUT)
@@ -88,16 +73,9 @@ module OpenTelemetry
       #   - install instrumentation
       def configure
         OpenTelemetry.logger = logger
-        # These exist in open or future PRs | | |
-        #                                   v v v
-        # OpenTelemetry.correlation_context_manager = correlation_context_manager
-        # OpenTelemetry.propagation = propagation
         configure_span_processors
         OpenTelemetry.tracer_factory = tracer_factory
-        # These exist in open or future PRs | | |
-        #                                   v v v
-        # OpenTelemetry.meter_factory = meter_factory
-        # install_instrumentation
+        install_instrumentation
       end
 
       private

--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -49,7 +49,7 @@ module OpenTelemetry
       # instrumentation. A call to +use+ after +use_all+ will result in an
       # exception.
       #
-      # @param [Hash<String,Hash>] adapter_config_map A map with string keys
+      # @param [optional Hash<String,Hash>] adapter_config_map A map with string keys
       #   representing the adapter name and values specifying the adapter config
       def use_all(adapter_config_map = {})
         check_use_mode!(USE_MODE_ALL)

--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -79,15 +79,24 @@ module OpenTelemetry
       end
 
       # @api private
+      # The configure method is where we define the setup process. This allows
+      # us to make certain guarantees about which systems and globals are setup
+      # at each stage. Currently, the setup process is roughly:
+      #   - setup logging
+      #   - setup propagation
+      #   - setup tracer_factory and meter_factory
+      #   - install instrumentation
       def configure
         OpenTelemetry.logger = logger
+        # These exist in open or future PRs | | |
+        #                                   v v v
+        # OpenTelemetry.correlation_context_manager = correlation_context_manager
+        # OpenTelemetry.propagation = propagation
         @span_processors.each { |p| tracer_factory.add_span_processor(p) }
         OpenTelemetry.tracer_factory = tracer_factory
         # These exist in open or future PRs | | |
         #                                   v v v
         # OpenTelemetry.meter_factory = meter_factory
-        # OpenTelemetry.correlation_context_manager = correlation_context_manager
-        # OpenTelemetry.propagation = propagation
         # install_instrumentation
       end
 

--- a/sdk/test/opentelemetry/sdk/configurator_test.rb
+++ b/sdk/test/opentelemetry/sdk/configurator_test.rb
@@ -78,6 +78,41 @@ describe OpenTelemetry::SDK::Configurator do
         )
       end
     end
+
+    describe 'instrumentation installation' do
+      before do
+        TestAdapter = Class.new(OpenTelemetry::Instrumentation::Adapter) do
+          install { 1 + 1 }
+          present { true }
+        end
+      end
+
+      after do
+        Object.send(:remove_const, :TestAdapter)
+      end
+
+      it 'installs single adapter' do
+        registry = OpenTelemetry.instrumentation_registry
+        adapter = registry.lookup('TestAdapter')
+        _(adapter).wont_be_nil
+        _(adapter).wont_be(:installed?)
+        configurator.use 'TestAdapter', opt: true
+        configurator.configure
+        _(adapter).must_be(:installed?)
+        _(adapter.config).must_equal(opt: true)
+      end
+
+      it 'installs all' do
+        registry = OpenTelemetry.instrumentation_registry
+        adapter = registry.lookup('TestAdapter')
+        _(adapter).wont_be_nil
+        _(adapter).wont_be(:installed?)
+        configurator.use_all 'TestAdapter' => { opt: true }
+        configurator.configure
+        _(adapter).must_be(:installed?)
+        _(adapter.config).must_equal(opt: true)
+      end
+    end
   end
 
   def active_span_processors

--- a/sdk/test/opentelemetry/sdk/configurator_test.rb
+++ b/sdk/test/opentelemetry/sdk/configurator_test.rb
@@ -22,4 +22,26 @@ describe OpenTelemetry::SDK::Configurator do
       _(configurator.logger).must_be_instance_of(Logger)
     end
   end
+
+  describe '#use' do
+    it 'can be called multiple times' do
+      configurator.use('TestAdapter', enabled: true)
+      configurator.use('TestAdapter1')
+    end
+  end
+
+  describe '#use, #use_all' do
+    describe 'should be used mutually exclusively' do
+      it 'raises when use_all called after use' do
+        configurator.use('TestAdapter', enabled: true)
+        _(-> { configurator.use_all }).must_raise(StandardError)
+      end
+
+      it 'raises when use called after use_all' do
+        configurator.use_all
+        _(-> { configurator.use('TestAdapter', enabled: true) })
+          .must_raise(StandardError)
+      end
+    end
+  end
 end

--- a/sdk/test/opentelemetry/sdk/configurator_test.rb
+++ b/sdk/test/opentelemetry/sdk/configurator_test.rb
@@ -9,14 +9,6 @@ require 'test_helper'
 describe OpenTelemetry::SDK::Configurator do
   let(:configurator) { OpenTelemetry::SDK::Configurator.new }
 
-  describe '#tracer_factory' do
-    it 'defaults to SDK::Trace::TracerFactory' do
-      _(configurator.tracer_factory).must_be_instance_of(
-        OpenTelemetry::SDK::Trace::TracerFactory
-      )
-    end
-  end
-
   describe '#logger' do
     it 'returns a logger instance' do
       _(configurator.logger).must_be_instance_of(Logger)
@@ -48,6 +40,16 @@ describe OpenTelemetry::SDK::Configurator do
   describe '#configure' do
     after do
       reset_globals
+    end
+
+    describe 'tracer_factory' do
+      it 'is an instance of SDK::Trace::TracerFactory' do
+        configurator.configure
+
+        _(OpenTelemetry.tracer_factory).must_be_instance_of(
+          OpenTelemetry::SDK::Trace::TracerFactory
+        )
+      end
     end
 
     describe 'span processors' do

--- a/sdk/test/opentelemetry/sdk/configurator_test.rb
+++ b/sdk/test/opentelemetry/sdk/configurator_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+describe OpenTelemetry::SDK::Configurator do
+  let(:configurator) { OpenTelemetry::SDK::Configurator.new }
+
+  describe '#tracer_factory' do
+    it 'defaults to SDK::Trace::TracerFactory' do
+      _(configurator.tracer_factory).must_be_instance_of(
+        OpenTelemetry::SDK::Trace::TracerFactory
+      )
+    end
+  end
+
+  describe '#logger' do
+    it 'returns a logger instance' do
+      _(configurator.logger).must_be_instance_of(Logger)
+    end
+  end
+end


### PR DESCRIPTION
This PR is an implementation of SDK config for currently implemented features. It's based off of #165, but with speculative, future feature configuration removed. With this implementation you can configure logging, tracer factory, span processors and install instrumentation.

Here are some examples:

### Minimal setup

If a block is not specified it will setup defaults
* STDOUT logging
* SDK::Trace::TracerFactory
* SimpleSpanProcessor with ConsoleSpanExporter
* No instrumentation

```ruby
OpenTelemetry::SDK.configure
```

### Customizing the setup

The following can be customized:
* Logger
* Tracer Factory
* Span Processors
* Instrumentation: installed individually, or all, but not both

Customize the setup and specify instrumentation individually

```ruby
OpenTelemetry::SDK.configure do |c|
  c.tracer_factory = ...
  c.logger = Logger.new('/dev/null')
  c.add_span_processor(...)
  c.use 'OpenTelemetry::Adapters::Sinatra', {enabled: true}
  c.use 'OpenTelemetry::Adapters::Faraday', {ignore_filters: [/domain\.com/]}
  c.use 'SomeCustom::Adapter::Lib'
end
```

Customize the setup and install all instrumentation

```ruby
OpenTelemetry::SDK.configure do |c|
  c.tracer_factory = ...
  c.logger = Logger.new('/dev/null')
  c.add_span_processor(...)
  c.use_all 'OpenTelemetry::Adapters::Something' => {config_opt: true}
end
```