### PR TITLE
Fix faraday adapter

### DIFF
--- a/adapters/faraday/lib/opentelemetry/adapters/faraday/adapter.rb
+++ b/adapters/faraday/lib/opentelemetry/adapters/faraday/adapter.rb
@@ -9,9 +9,8 @@ module OpenTelemetry
     module Faraday
       class Adapter < OpenTelemetry::Instrumentation::Adapter
         install do |config|
-          config[:tracer_middleware] ||= Middlewares::TracerMiddleware
-
           require_dependencies
+          config[:tracer_middleware] ||= Middlewares::TracerMiddleware
           register_tracer_middleware
           use_middleware_by_default
         end


### PR DESCRIPTION
In order to remove a hard dependency on Faraday, I had to require the TracerMiddleware during install. While testing #171 I noticed that the middleware will be referenced before it's required during usual startup. Sadly, this was not caught in tests and is hard to test since once a file has been required, it can't exactly be unrequired.