### PR TITLE
Update Semantic Conventions URLs

### DIFF
--- a/api/lib/opentelemetry/trace/span.rb
+++ b/api/lib/opentelemetry/trace/span.rb
@@ -45,7 +45,7 @@ module OpenTelemetry
       # Set attribute
       #
       # Note that the OpenTelemetry project
-      # {https://github.com/open-telemetry/opentelemetry-specification/blob/master/semantic-conventions.md
+      # {https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md
       # documents} certain "standard attributes" that have prescribed semantic
       # meanings.
       #
@@ -71,7 +71,7 @@ module OpenTelemetry
       #   span.add_event { tracer.create_event(name: 'event', attributes: {'eager' => false}) }
       #
       # Note that the OpenTelemetry project
-      # {https://github.com/open-telemetry/opentelemetry-specification/blob/master/semantic-conventions.md
+      # {https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md
       # documents} certain "standard event names and keys" which have
       # prescribed semantic meanings.
       #

--- a/sdk/lib/opentelemetry/sdk/trace/span.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span.rb
@@ -90,7 +90,7 @@ module OpenTelemetry
         #   span.add_event { OpenTelemetry::Trace::Event.new(name: 'event', attributes: {'eager' => false}) }
         #
         # Note that the OpenTelemetry project
-        # {https://github.com/open-telemetry/opentelemetry-specification/blob/master/semantic-conventions.md
+        # {https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md
         # documents} certain "standard event names and keys" which have
         # prescribed semantic meanings.
         #


### PR DESCRIPTION
Just fix documentation URLs of Semantic Conventions which look old.