### PR TITLE
Add rubocop to adapters

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -56,6 +56,18 @@ GEM_INFO = {
       require './lib/opentelemetry/exporters/jaeger/version.rb'
       OpenTelemetry::Exporters::Jaeger::VERSION
     }
+  },
+  "opentelemetry-adapters-faraday" => {
+    version_getter: ->() {
+      require './lib/opentelemetry/adapters/faraday/version.rb'
+      OpenTelemetry::Adapters::Faraday::VERSION
+    }
+  },
+  "opentelemetry-adapters-sinatra" => {
+    version_getter: ->() {
+      require './lib/opentelemetry/adapters/sinatra/version.rb'
+      OpenTelemetry::Adapters::Sinatra::VERSION
+    }
   }
 }
 

--- a/adapters/faraday/.rubocop.yml
+++ b/adapters/faraday/.rubocop.yml
@@ -1,0 +1,27 @@
+AllCops:
+  TargetRubyVersion: '2.4.0'
+
+Bundler/OrderedGems:
+  Exclude:
+    - gemfiles/**/*
+Lint/UnusedMethodArgument:
+  Enabled: false
+Metrics/AbcSize:
+  Max: 18
+Metrics/LineLength:
+  Enabled: false
+Metrics/MethodLength:
+  Max: 20
+Metrics/ParameterLists:
+  Enabled: false
+Naming/FileName:
+  Exclude:
+    - "lib/opentelemetry-adapters-faraday.rb"
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - gemfiles/**/*
+Style/ModuleFunction:
+  Enabled: false
+Style/StringLiterals:
+  Exclude:
+    - gemfiles/**/*

--- a/adapters/faraday/Appraisals
+++ b/adapters/faraday/Appraisals
@@ -1,15 +1,21 @@
-appraise "faraday-1.0" do
-  gem "faraday", "~> 1.0.0"
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+appraise 'faraday-1.0' do
+  gem 'faraday', '~> 1.0.0'
 end
 
-appraise "faraday-0.17" do
-  gem "faraday", "0.17.0"
+appraise 'faraday-0.17' do
+  gem 'faraday', '0.17.0'
 end
 
-appraise "faraday-0.16" do
-  gem "faraday", "0.16.2"
+appraise 'faraday-0.16' do
+  gem 'faraday', '0.16.2'
 end
 
-appraise "faraday-0.13" do
-  gem "faraday", "0.13.1"
+appraise 'faraday-0.13' do
+  gem 'faraday', '0.13.1'
 end

--- a/adapters/faraday/Rakefile
+++ b/adapters/faraday/Rakefile
@@ -1,14 +1,29 @@
 # frozen_string_literal: true
 
-# Copyright 2019 OpenTelemetry Authors
+# Copyright 2020 OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
 
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 
+require 'yard'
+
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new
+
 Rake::TestTask.new :test do |t|
   t.libs << 'test'
   t.libs << 'lib'
   t.test_files = FileList['test/**/*_test.rb']
+end
+
+YARD::Rake::YardocTask.new do |t|
+  t.stats_options = ['--list-undoc']
+end
+
+if RUBY_ENGINE == 'truffleruby'
+  task default: %i[test]
+else
+  task default: %i[test rubocop yard]
 end

--- a/adapters/faraday/Rakefile
+++ b/adapters/faraday/Rakefile
@@ -6,10 +6,9 @@
 
 require 'bundler/gem_tasks'
 require 'rake/testtask'
-
 require 'yard'
-
 require 'rubocop/rake_task'
+
 RuboCop::RakeTask.new
 
 Rake::TestTask.new :test do |t|

--- a/adapters/faraday/example/Gemfile
+++ b/adapters/faraday/example/Gemfile
@@ -3,6 +3,6 @@
 source 'https://rubygems.org'
 
 gem 'faraday'
+gem 'opentelemetry-adapters-faraday', path: '../../../adapters/faraday'
 gem 'opentelemetry-api', path: '../../../api'
 gem 'opentelemetry-sdk', path: '../../../sdk'
-gem 'opentelemetry-adapters-faraday', path: '../../../adapters/faraday'

--- a/adapters/faraday/example/faraday.rb
+++ b/adapters/faraday/example/faraday.rb
@@ -1,3 +1,9 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 require 'rubygems'
 require 'bundler/setup'
 

--- a/adapters/faraday/lib/opentelemetry/adapters/faraday.rb
+++ b/adapters/faraday/lib/opentelemetry/adapters/faraday.rb
@@ -8,6 +8,7 @@ require 'opentelemetry'
 
 module OpenTelemetry
   module Adapters
+    # Contains the OpenTelemetry adapter for the Faraday gem
     module Faraday
     end
   end

--- a/adapters/faraday/lib/opentelemetry/adapters/faraday/adapter.rb
+++ b/adapters/faraday/lib/opentelemetry/adapters/faraday/adapter.rb
@@ -7,6 +7,8 @@
 module OpenTelemetry
   module Adapters
     module Faraday
+      # The Adapter class contains logic to detect and install the Faraday
+      # instrumentation adapter
       class Adapter < OpenTelemetry::Instrumentation::Adapter
         install do |config|
           require_dependencies

--- a/adapters/faraday/lib/opentelemetry/adapters/faraday/middlewares/tracer_middleware.rb
+++ b/adapters/faraday/lib/opentelemetry/adapters/faraday/middlewares/tracer_middleware.rb
@@ -8,15 +8,17 @@ module OpenTelemetry
   module Adapters
     module Faraday
       module Middlewares
+        # TracerMiddleware propagates context and instruments Faraday requests
+        # by way of its middlware system
         class TracerMiddleware < ::Faraday::Middleware
           def call(env)
             return app.call(env) if disable_span_reporting?(env)
 
             tracer.in_span(env.url.to_s,
-                          attributes: { 'component' => 'http',
-                                        'http.method' => env.method,
-                                        'http.url' => env.url.to_s },
-                          kind: :client) do |span|
+                           attributes: { 'component' => 'http',
+                                         'http.method' => env.method,
+                                         'http.url' => env.url.to_s },
+                           kind: :client) do |span|
               propagate_context(span, env)
 
               app.call(env).on_complete { |resp| trace_response(span, resp) }

--- a/adapters/faraday/opentelemetry-adapters-faraday.gemspec
+++ b/adapters/faraday/opentelemetry-adapters-faraday.gemspec
@@ -32,6 +32,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'faraday', '~> 0.17.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 0.0'
+  spec.add_development_dependency 'rubocop', '~> 0.73.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
+  spec.add_development_dependency 'yard', '~> 0.9'
+  spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 end

--- a/adapters/faraday/test/.rubocop.yml
+++ b/adapters/faraday/test/.rubocop.yml
@@ -1,0 +1,4 @@
+inherit_from: ../.rubocop.yml
+
+Metrics/BlockLength:
+  Enabled: false

--- a/adapters/sinatra/.rubocop.yml
+++ b/adapters/sinatra/.rubocop.yml
@@ -1,0 +1,27 @@
+AllCops:
+  TargetRubyVersion: '2.4.0'
+
+Bundler/OrderedGems:
+  Exclude:
+    - gemfiles/**/*
+Lint/UnusedMethodArgument:
+  Enabled: false
+Metrics/AbcSize:
+  Max: 18
+Metrics/LineLength:
+  Enabled: false
+Metrics/MethodLength:
+  Max: 20
+Metrics/ParameterLists:
+  Enabled: false
+Naming/FileName:
+  Exclude:
+    - "lib/opentelemetry-adapters-sinatra.rb"
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - gemfiles/**/*
+Style/ModuleFunction:
+  Enabled: false
+Style/StringLiterals:
+  Exclude:
+    - gemfiles/**/*

--- a/adapters/sinatra/Appraisals
+++ b/adapters/sinatra/Appraisals
@@ -1,7 +1,13 @@
-appraise "sinatra-2.0" do
-  gem "sinatra", "2.0.7"
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+appraise 'sinatra-2.0' do
+  gem 'sinatra', '2.0.7'
 end
 
-appraise "sinatra-1.4" do
-  gem "sinatra", "1.4.8"
+appraise 'sinatra-1.4' do
+  gem 'sinatra', '1.4.8'
 end

--- a/adapters/sinatra/Rakefile
+++ b/adapters/sinatra/Rakefile
@@ -1,14 +1,29 @@
 # frozen_string_literal: true
 
-# Copyright 2019 OpenTelemetry Authors
+# Copyright 2020 OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
 
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 
+require 'yard'
+
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new
+
 Rake::TestTask.new :test do |t|
   t.libs << 'test'
   t.libs << 'lib'
   t.test_files = FileList['test/**/*_test.rb']
+end
+
+YARD::Rake::YardocTask.new do |t|
+  t.stats_options = ['--list-undoc']
+end
+
+if RUBY_ENGINE == 'truffleruby'
+  task default: %i[test]
+else
+  task default: %i[test rubocop yard]
 end

--- a/adapters/sinatra/Rakefile
+++ b/adapters/sinatra/Rakefile
@@ -6,10 +6,9 @@
 
 require 'bundler/gem_tasks'
 require 'rake/testtask'
-
 require 'yard'
-
 require 'rubocop/rake_task'
+
 RuboCop::RakeTask.new
 
 Rake::TestTask.new :test do |t|

--- a/adapters/sinatra/example/Gemfile
+++ b/adapters/sinatra/example/Gemfile
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 source 'https://rubygems.org'
 
-gem 'sinatra'
+gem 'opentelemetry-adapters-sinatra', path: '../../../adapters/sinatra'
 gem 'opentelemetry-api', path: '../../../api'
 gem 'opentelemetry-sdk', path: '../../../sdk'
-gem 'opentelemetry-adapters-sinatra', path: '../../../adapters/sinatra'
+gem 'sinatra'

--- a/adapters/sinatra/example/server.rb
+++ b/adapters/sinatra/example/server.rb
@@ -1,4 +1,11 @@
 #!/usr/bin/env ruby
+
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 require 'rubygems'
 require 'bundler/setup'
 
@@ -8,6 +15,7 @@ OpenTelemetry::SDK.configure do |c|
   c.use 'OpenTelemetry::Adapters::Sinatra'
 end
 
+# Example application for the Sinatra instrumentation adapter
 class App < Sinatra::Base
   set :bind, '0.0.0.0'
   set :show_exceptions, false
@@ -29,5 +37,5 @@ class App < Sinatra::Base
     'Thing 1'
   end
 
-  run! if app_file == $0
+  run! if app_file == $PROGRAM_NAME
 end

--- a/adapters/sinatra/example/sinatra.rb
+++ b/adapters/sinatra/example/sinatra.rb
@@ -1,3 +1,9 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 require 'net/http'
 
 response = Net::HTTP.get('0.0.0.0', '/example', '4567')

--- a/adapters/sinatra/lib/opentelemetry/adapters/sinatra.rb
+++ b/adapters/sinatra/lib/opentelemetry/adapters/sinatra.rb
@@ -8,6 +8,7 @@ require 'opentelemetry'
 
 module OpenTelemetry
   module Adapters
+    # Contains the OpenTelemetry instrumentation adapter for the Sinatra gem
     module Sinatra
     end
   end

--- a/adapters/sinatra/lib/opentelemetry/adapters/sinatra/adapter.rb
+++ b/adapters/sinatra/lib/opentelemetry/adapters/sinatra/adapter.rb
@@ -9,6 +9,8 @@ require_relative 'extensions/tracer_extension'
 module OpenTelemetry
   module Adapters
     module Sinatra
+      # The Adapter class contains logic to detect and install the Sinatra
+      # instrumentation adapter
       class Adapter < OpenTelemetry::Instrumentation::Adapter
         install do |_|
           ::Sinatra::Base.register Extensions::TracerExtension

--- a/adapters/sinatra/lib/opentelemetry/adapters/sinatra/extensions/tracer_extension.rb
+++ b/adapters/sinatra/lib/opentelemetry/adapters/sinatra/extensions/tracer_extension.rb
@@ -10,6 +10,8 @@ module OpenTelemetry
   module Adapters
     module Sinatra
       module Extensions
+        # Sinatra extension that installs TracerMiddleware and provides
+        # tracing for template rendering
         module TracerExtension
           # Sinatra hook after extension is registered
           def self.registered(app)

--- a/adapters/sinatra/lib/opentelemetry/adapters/sinatra/middlewares/tracer_middleware.rb
+++ b/adapters/sinatra/lib/opentelemetry/adapters/sinatra/middlewares/tracer_middleware.rb
@@ -8,6 +8,7 @@ module OpenTelemetry
   module Adapters
     module Sinatra
       module Middlewares
+        # Middleware to trace Sinatra requests
         class TracerMiddleware
           def initialize(app)
             @app = app

--- a/adapters/sinatra/opentelemetry-adapters-sinatra.gemspec
+++ b/adapters/sinatra/opentelemetry-adapters-sinatra.gemspec
@@ -32,6 +32,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 0.0'
   spec.add_development_dependency 'rack-test', '~> 1.1.0'
+  spec.add_development_dependency 'rubocop', '~> 0.73.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'sinatra', '~> 2.0.7'
+  spec.add_development_dependency 'webmock', '~> 3.7.6'
+  spec.add_development_dependency 'yard', '~> 0.9'
+  spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 end

--- a/adapters/sinatra/test/.rubocop.yml
+++ b/adapters/sinatra/test/.rubocop.yml
@@ -1,0 +1,4 @@
+inherit_from: ../.rubocop.yml
+
+Metrics/BlockLength:
+  Enabled: false

--- a/adapters/sinatra/test/opentelemetry/adapters/sinatra_test.rb
+++ b/adapters/sinatra/test/opentelemetry/adapters/sinatra_test.rb
@@ -82,26 +82,27 @@ describe OpenTelemetry::Adapters::Sinatra do
     it 'records attributes' do
       get '/one/endpoint'
 
-      _(exporter.finished_spans.first.attributes).must_equal ({
-          "component" => "http",
-          "http.method"=>"GET",
-          "http.url"=>"/endpoint",
-          "http.status_code"=>200,
-          "http.status_text"=>"OK",
-          "http.route"=>"/endpoint" })
+      _(exporter.finished_spans.first.attributes).must_equal(
+        'component' => 'http',
+        'http.method' => 'GET',
+        'http.url' => '/endpoint',
+        'http.status_code' => 200,
+        'http.status_text' => 'OK',
+        'http.route' => '/endpoint'
+      )
     end
 
     it 'traces templates' do
       get '/one/with_template'
 
       _(exporter.finished_spans.size).must_equal 3
-      _(exporter.finished_spans.map(&:name)).
-        must_equal ['sinatra.render_template',
-                    'sinatra.render_template',
-                    '/with_template']
-      _(exporter.finished_spans[0..1].map(&:attributes).
-        map {|h| h['sinatra.template_name']}).
-        must_equal ['layout', 'foo_template']
+      _(exporter.finished_spans.map(&:name))
+        .must_equal %w[sinatra.render_template
+                       sinatra.render_template
+                       /with_template]
+      _(exporter.finished_spans[0..1].map(&:attributes)
+        .map { |h| h['sinatra.template_name'] })
+        .must_equal %w[layout foo_template]
     end
   end
 end


### PR DESCRIPTION
The instrumentation adapters did not have rubocop setup and as a result had a number of violations. This PR sets up rubocop and fixes the violations for the Faraday and Sinatra instrumentation adapters. It also adds them to the top-level Rakefile so that tests are run automatically.