### PR TITLE
Add SDK configuration for http_injectors / extractors

### DIFF
--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -15,11 +15,13 @@ module OpenTelemetry
 
       private_constant :USE_MODE_UNSPECIFIED, :USE_MODE_ONE, :USE_MODE_ALL
 
-      attr_writer :logger
+      attr_writer :logger, :http_extractors, :http_injectors
 
       def initialize
         @adapter_names = []
         @adapter_config_map = {}
+        @http_extractors = nil
+        @http_injectors = nil
         @span_processors = []
         @use_mode = USE_MODE_UNSPECIFIED
         @tracer_provider = Trace::TracerProvider.new
@@ -68,13 +70,15 @@ module OpenTelemetry
       # @api private
       # The configure method is where we define the setup process. This allows
       # us to make certain guarantees about which systems and globals are setup
-      # at each stage. Currently, the setup process is roughly:
+      # at each stage. The setup process is:
       #   - setup logging
       #   - setup propagation
       #   - setup tracer_provider and meter_provider
       #   - install instrumentation
       def configure
         OpenTelemetry.logger = logger
+        OpenTelemetry.correlations = CorrelationContext::Manager.new
+        configure_propagation
         configure_span_processors
         OpenTelemetry.tracer_provider = @tracer_provider
         install_instrumentation
@@ -105,6 +109,25 @@ module OpenTelemetry
         Trace::Export::SimpleSpanProcessor.new(
           Trace::Export::ConsoleSpanExporter.new
         )
+      end
+
+      def configure_propagation
+        OpenTelemetry.propagation.http_extractors = @http_extractors || default_http_extractors
+        OpenTelemetry.propagation.http_injectors = @http_injectors || default_http_injectors
+      end
+
+      def default_http_injectors
+        [
+          OpenTelemetry::Trace::Propagation.http_trace_context_injector,
+          OpenTelemetry::CorrelationContext::Propagation.http_injector
+        ]
+      end
+
+      def default_http_extractors
+        [
+          OpenTelemetry::Trace::Propagation.rack_http_trace_context_extractor,
+          OpenTelemetry::CorrelationContext::Propagation.rack_http_extractor
+        ]
       end
     end
   end

--- a/sdk/test/opentelemetry/sdk/configurator_test.rb
+++ b/sdk/test/opentelemetry/sdk/configurator_test.rb
@@ -42,6 +42,56 @@ describe OpenTelemetry::SDK::Configurator do
       reset_globals
     end
 
+    describe 'correlations' do
+      it 'is an instance of SDK::CorrelationContext::Manager' do
+        configurator.configure
+
+        _(OpenTelemetry.correlations).must_be_instance_of(
+          OpenTelemetry::SDK::CorrelationContext::Manager
+        )
+      end
+    end
+
+    describe 'http_injectors' do
+      it 'defaults to trace context and correlation context' do
+        configurator.configure
+
+        expected_injectors = [
+          OpenTelemetry::Trace::Propagation.http_trace_context_injector,
+          OpenTelemetry::CorrelationContext::Propagation.http_injector
+        ]
+
+        _(OpenTelemetry.propagation.http_injectors).must_equal(expected_injectors)
+      end
+
+      it 'is user settable' do
+        configurator.http_injectors = []
+        configurator.configure
+
+        _(OpenTelemetry.propagation.http_injectors).must_equal([])
+      end
+    end
+
+    describe '#http_extractors' do
+      it 'defaults to trace context and correlation context' do
+        configurator.configure
+
+        expected_extractors = [
+          OpenTelemetry::Trace::Propagation.rack_http_trace_context_extractor,
+          OpenTelemetry::CorrelationContext::Propagation.rack_http_extractor
+        ]
+
+        _(OpenTelemetry.propagation.http_extractors).must_equal(expected_extractors)
+      end
+
+      it 'is user settable' do
+        configurator.http_extractors = []
+        configurator.configure
+
+        _(OpenTelemetry.propagation.http_extractors).must_equal([])
+      end
+    end
+
     describe 'tracer_provider' do
       it 'is an instance of SDK::Trace::TracerProvider' do
         configurator.configure


### PR DESCRIPTION
This PR adds SDK configuration for `http_injectors / extractors` and sets the `CorrelationContext::Manager` to the operational SDK implementation. Note, that http_injectors and extractors are empty by default in the API, making them effectively a noop. There is not consensus on what they should default to currently, so empty seems like a reasonable option for now. See: https://github.com/open-telemetry/opentelemetry-specification/issues/428. 

This PR makes W3C TraceContext and CorrelationContext the default injectors and extractors when the SDK is configured. They can also be specified by the user.

```ruby
# if unspecified the injectors and extractors will default to: W3C TraceContext and CorrelationContext 
OpenTelemetry::SDK.configure do |c|
  c.use_all
end
```

```ruby
OpenTelemetry::SDK.configure do |c|
  c.http_injectors = [Propagation::TraceContext.http_injector, Propagation::B3.http_injector]
  c.http_extractors = [Propagation::TraceContext.rack_http_extractor, Propagation::B3.rack_http_extractor]
end
```

