### PR TITLE
Add `ethon` instrumentation adapter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,15 @@ commands:
   rake-test-appraisal:
     steps:
       - run:
+          name: Bundle + CI (Adapters - ethon)
+          command: |
+            cd adapters/ethon
+            gem uninstall -aIx bundler
+            gem install --no-document bundler -v '~> 2.0.2'
+            bundle install --jobs=3 --retry=3
+            bundle exec appraisal install
+            bundle exec appraisal rake test
+      - run:
           name: Bundle + CI (Adapters - excon)
           command: |
             cd adapters/excon

--- a/Rakefile
+++ b/Rakefile
@@ -57,6 +57,12 @@ GEM_INFO = {
       OpenTelemetry::Exporters::Jaeger::VERSION
     }
   },
+  "opentelemetry-adapters-ethon" => {
+    version_getter: ->() {
+      require './lib/opentelemetry/adapters/ethon/version.rb'
+      OpenTelemetry::Adapters::Ethon::VERSION
+    }
+  },
   "opentelemetry-adapters-excon" => {
     version_getter: ->() {
       require './lib/opentelemetry/adapters/excon/version.rb'

--- a/adapters/ethon/.rubocop.yml
+++ b/adapters/ethon/.rubocop.yml
@@ -1,0 +1,27 @@
+AllCops:
+  TargetRubyVersion: '2.4.0'
+
+Bundler/OrderedGems:
+  Exclude:
+    - gemfiles/**/*
+Lint/UnusedMethodArgument:
+  Enabled: false
+Metrics/AbcSize:
+  Max: 18
+Metrics/LineLength:
+  Enabled: false
+Metrics/MethodLength:
+  Max: 20
+Metrics/ParameterLists:
+  Enabled: false
+Naming/FileName:
+  Exclude:
+    - "lib/opentelemetry-adapters-ethon.rb"
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - gemfiles/**/*
+Style/ModuleFunction:
+  Enabled: false
+Style/StringLiterals:
+  Exclude:
+    - gemfiles/**/*

--- a/adapters/ethon/Appraisals
+++ b/adapters/ethon/Appraisals
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+appraise 'ethon-0.12' do
+  gem 'ethon', '~> 0.12.0'
+end
+
+appraise 'ethon-0.11' do
+  gem 'ethon', '~> 0.11.0'
+end

--- a/adapters/ethon/Gemfile
+++ b/adapters/ethon/Gemfile
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source 'https://rubygems.org'
+
+gemspec
+
+gem 'opentelemetry-api', path: '../../api'
+
+group :test do
+  gem 'opentelemetry-sdk', path: '../../sdk'
+end

--- a/adapters/ethon/Rakefile
+++ b/adapters/ethon/Rakefile
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+require 'yard'
+require 'rubocop/rake_task'
+
+RuboCop::RakeTask.new
+
+Rake::TestTask.new :test do |t|
+  t.libs << 'test'
+  t.libs << 'lib'
+  t.test_files = FileList['test/**/*_test.rb']
+end
+
+YARD::Rake::YardocTask.new do |t|
+  t.stats_options = ['--list-undoc']
+end
+
+if RUBY_ENGINE == 'truffleruby'
+  task default: %i[test]
+else
+  task default: %i[test rubocop yard]
+end

--- a/adapters/ethon/example/Gemfile
+++ b/adapters/ethon/example/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'ethon'
+gem 'opentelemetry-adapters-ethon', path: '../../../adapters/ethon'
+gem 'opentelemetry-api', path: '../../../api'
+gem 'opentelemetry-sdk', path: '../../../sdk'

--- a/adapters/ethon/example/ethon.rb
+++ b/adapters/ethon/example/ethon.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rubygems'
+require 'bundler/setup'
+
+Bundler.require
+
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Adapters::Ethon'
+end
+
+Ethon::Easy.new(url: 'http://example.com').perform

--- a/adapters/ethon/lib/opentelemetry-adapters-ethon.rb
+++ b/adapters/ethon/lib/opentelemetry-adapters-ethon.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require_relative './opentelemetry/adapters'

--- a/adapters/ethon/lib/opentelemetry/adapters.rb
+++ b/adapters/ethon/lib/opentelemetry/adapters.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  # "Instrumentation adapters" are specified by
+  # https://github.com/open-telemetry/opentelemetry-specification/blob/57714f7547fe4dcb342ad0ad10a80d86118431c7/specification/overview.md#instrumentation-adapters
+  #
+  # Adapters should be able to handle the case when the library is not installed on a user's system.
+  module Adapters
+  end
+end
+
+require_relative './adapters/ethon'

--- a/adapters/ethon/lib/opentelemetry/adapters/ethon.rb
+++ b/adapters/ethon/lib/opentelemetry/adapters/ethon.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry'
+
+module OpenTelemetry
+  module Adapters
+    # Contains the OpenTelemetry adapter for the Ethon gem
+    module Ethon
+    end
+  end
+end
+
+require_relative './ethon/adapter'
+require_relative './ethon/version'

--- a/adapters/ethon/lib/opentelemetry/adapters/ethon/adapter.rb
+++ b/adapters/ethon/lib/opentelemetry/adapters/ethon/adapter.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Adapters
+    module Ethon
+      # The Adapter class contains logic to detect and install the Ethon
+      # instrumentation adapter
+      class Adapter < OpenTelemetry::Instrumentation::Adapter
+        install do |_config|
+          require_dependencies
+          add_patches
+        end
+
+        present do
+          defined?(::Ethon::Easy)
+        end
+
+        private
+
+        def require_dependencies
+          require_relative 'patches/easy'
+          require_relative 'patches/multi'
+        end
+
+        def add_patches
+          ::Ethon::Easy.prepend(Patches::Easy)
+          ::Ethon::Multi.prepend(Patches::Multi)
+        end
+      end
+    end
+  end
+end

--- a/adapters/ethon/lib/opentelemetry/adapters/ethon/patches/easy.rb
+++ b/adapters/ethon/lib/opentelemetry/adapters/ethon/patches/easy.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Adapters
+    module Ethon
+      module Patches
+        # Ethon::Easy patch for instrumentation
+        module Easy
+          ACTION_NAMES_TO_HTTP_METHODS = Hash.new do |h, k|
+            # #to_s is required because user input could be symbol or string
+            h[k] = k.to_s.upcase
+          end
+          HTTP_METHODS_TO_SPAN_NAMES = Hash.new { |h, k| h[k] = "HTTP #{k}" }
+
+          def http_request(url, action_name, options = {})
+            @otel_method = ACTION_NAMES_TO_HTTP_METHODS[action_name]
+            super
+          end
+
+          def headers=(headers)
+            # Store headers to call this method again when span is ready
+            @otel_original_headers = headers
+            super
+          end
+
+          def perform
+            otel_before_request
+            super
+          end
+
+          def complete # rubocop:disable Metrics/MethodLength
+            begin
+              response_options = mirror.options
+              response_code = (response_options[:response_code] || response_options[:code]).to_i
+              if response_code.zero?
+                return_code = response_options[:return_code]
+                message = return_code ? ::Ethon::Curl.easy_strerror(return_code) : 'unknown reason'
+                @otel_span.status = OpenTelemetry::Trace::Status.new(
+                  OpenTelemetry::Trace::Status::UNKNOWN_ERROR,
+                  description: "Request has failed: #{message}"
+                )
+              else
+                @otel_span.set_attribute('http.status_code', response_code)
+                @otel_span.status = OpenTelemetry::Trace::Status.http_to_status(
+                  response_code
+                )
+              end
+            ensure
+              @otel_span.finish
+              @otel_span = nil
+            end
+            super
+          end
+
+          def reset
+            super
+          ensure
+            @otel_span = nil
+            @otel_method = nil
+            @otel_original_headers = nil
+          end
+
+          def otel_before_request
+            method = 'N/A' # Could be GET or not HTTP at all
+            method = @otel_method if instance_variable_defined?(:@otel_method) && !@otel_method.nil?
+
+            @otel_span = tracer.start_span(
+              HTTP_METHODS_TO_SPAN_NAMES[method],
+              attributes: {
+                'component' => 'http',
+                'http.method' => method,
+                'http.url' => url
+              },
+              kind: :client
+            )
+
+            @otel_original_headers ||= {}
+            tracer.with_span(@otel_span) do
+              OpenTelemetry.propagation.inject(@otel_original_headers)
+            end
+            self.headers = @otel_original_headers
+          end
+
+          def otel_span_started?
+            instance_variable_defined?(:@otel_span) && !@otel_span.nil?
+          end
+
+          private
+
+          def tracer
+            Ethon::Adapter.instance.tracer
+          end
+        end
+      end
+    end
+  end
+end

--- a/adapters/ethon/lib/opentelemetry/adapters/ethon/patches/multi.rb
+++ b/adapters/ethon/lib/opentelemetry/adapters/ethon/patches/multi.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Adapters
+    module Ethon
+      module Patches
+        # Ethon::Multi patch for instrumentation
+        module Multi
+          def perform
+            easy_handles.each do |easy|
+              easy.otel_before_request unless easy.otel_span_started?
+            end
+
+            super
+          end
+        end
+      end
+    end
+  end
+end

--- a/adapters/ethon/lib/opentelemetry/adapters/ethon/version.rb
+++ b/adapters/ethon/lib/opentelemetry/adapters/ethon/version.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Adapters
+    module Ethon
+      VERSION = '0.0.0'
+    end
+  end
+end

--- a/adapters/ethon/opentelemetry-adapters-ethon.gemspec
+++ b/adapters/ethon/opentelemetry-adapters-ethon.gemspec
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'opentelemetry/adapters/ethon/version'
+
+Gem::Specification.new do |spec|
+  spec.name        = 'opentelemetry-adapters-ethon'
+  spec.version     = OpenTelemetry::Adapters::Ethon::VERSION
+  spec.authors     = ['OpenTelemetry Authors']
+  spec.email       = ['cncf-opentelemetry-contributors@lists.cncf.io']
+
+  spec.summary     = 'Ethon instrumentation adapter for the OpenTelemetry framework'
+  spec.description = 'Ethon instrumentation adapter for the OpenTelemetry framework'
+  spec.homepage    = 'https://github.com/open-telemetry/opentelemetry-ruby'
+  spec.license     = 'Apache-2.0'
+
+  spec.files = ::Dir.glob('lib/**/*.rb') +
+               ::Dir.glob('*.md') +
+               ['LICENSE']
+  spec.require_paths = ['lib']
+  spec.required_ruby_version = '>= 2.4.0'
+
+  spec.add_dependency 'opentelemetry-api', '~> 0.0'
+
+  spec.add_development_dependency 'appraisal', '~> 2.2.0'
+  spec.add_development_dependency 'bundler', '>= 1.17'
+  spec.add_development_dependency 'ethon', '~> 0.12.0'
+  spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'opentelemetry-sdk', '~> 0.0'
+  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'simplecov', '~> 0.17.1'
+  spec.add_development_dependency 'yard', '~> 0.9'
+  spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+end

--- a/adapters/ethon/test/.rubocop.yml
+++ b/adapters/ethon/test/.rubocop.yml
@@ -1,0 +1,4 @@
+inherit_from: ../.rubocop.yml
+
+Metrics/BlockLength:
+  Enabled: false

--- a/adapters/ethon/test/opentelemetry/adapters/ethon/adapter_test.rb
+++ b/adapters/ethon/test/opentelemetry/adapters/ethon/adapter_test.rb
@@ -1,0 +1,236 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+require_relative '../../../../lib/opentelemetry/adapters/ethon'
+require_relative '../../../../lib/opentelemetry/adapters/ethon/patches/easy'
+
+describe OpenTelemetry::Adapters::Ethon::Adapter do
+  let(:adapter) { OpenTelemetry::Adapters::Ethon::Adapter.instance }
+  let(:exporter) { EXPORTER }
+  let(:span) { exporter.finished_spans.first }
+
+  before do
+    exporter.reset
+
+    # these are currently empty, but this will future proof the test
+    @orig_injectors = OpenTelemetry.propagation.http_injectors
+    OpenTelemetry.propagation.http_injectors = [
+      OpenTelemetry::Trace::Propagation.http_trace_context_injector
+    ]
+  end
+
+  after do
+    # Force re-install of instrumentation
+    adapter.instance_variable_set(:@installed, false)
+
+    OpenTelemetry.propagation.http_injectors = @orig_injectors
+  end
+
+  describe 'tracing' do
+    before do
+      adapter.install
+    end
+
+    it 'before request' do
+      _(exporter.finished_spans.size).must_equal 0
+    end
+
+    describe 'easy' do
+      let(:easy) { ::Ethon::Easy.new(url: 'http://example.com/test') }
+
+      describe '#http_request' do
+        it 'preserves HTTP request method on easy instance' do
+          easy.http_request('example.com', 'POST')
+          _(easy.instance_eval { @otel_method }).must_equal 'POST'
+        end
+      end
+
+      describe '#headers=' do
+        it 'preserves HTTP headers on easy instance' do
+          easy.headers = { key: 'value' }
+          _(easy.instance_eval { @otel_original_headers }).must_equal(
+            key: 'value'
+          )
+        end
+      end
+
+      describe '#perform' do
+        let(:span) { easy.instance_eval { @otel_span } }
+
+        it 'creates a span' do
+          ::Ethon::Curl.stub(:easy_perform, 0) do
+            # Note: suppress call to #complete to isolate #perform functionality
+            easy.stub(:complete, nil) do
+              easy.perform
+
+              _(span.name).must_equal 'HTTP N/A'
+              _(span.attributes['component']).must_equal 'http'
+              _(span.attributes['http.method']).must_equal 'N/A'
+              _(span.attributes['http.status_code']).must_be_nil
+              _(span.attributes['http.url']).must_equal 'http://example.com/test'
+            end
+          end
+        end
+      end
+
+      describe '#complete' do
+        def stub_response(options)
+          easy.stub(:mirror, ::Ethon::Easy::Mirror.new(options)) do
+            easy.otel_before_request
+            # Note: perform calls complete
+            easy.complete
+
+            yield
+          end
+        end
+
+        it 'when response is successful' do
+          stub_response(response_code: 200) do
+            _(span.name).must_equal 'HTTP N/A'
+            _(span.attributes['component']).must_equal 'http'
+            _(span.attributes['http.method']).must_equal 'N/A'
+            _(span.attributes['http.status_code']).must_equal 200
+            _(span.attributes['http.url']).must_equal 'http://example.com/test'
+            _(easy.instance_eval { @otel_span }).must_be_nil
+            _(
+              easy.instance_eval { @otel_original_headers['traceparent'] }
+            ).must_equal "00-#{span.trace_id}-#{span.span_id}-01"
+          end
+        end
+
+        it 'when response is not successful' do
+          stub_response(response_code: 500) do
+            _(span.name).must_equal 'HTTP N/A'
+            _(span.attributes['component']).must_equal 'http'
+            _(span.attributes['http.method']).must_equal 'N/A'
+            _(span.attributes['http.status_code']).must_equal 500
+            _(span.attributes['http.url']).must_equal 'http://example.com/test'
+            _(easy.instance_eval { @otel_span }).must_be_nil
+            _(
+              easy.instance_eval { @otel_original_headers['traceparent'] }
+            ).must_equal "00-#{span.trace_id}-#{span.span_id}-01"
+          end
+        end
+
+        it 'when request times out' do
+          stub_response(response_code: 0, return_code: :operation_timedout) do
+            _(span.name).must_equal 'HTTP N/A'
+            _(span.attributes['component']).must_equal 'http'
+            _(span.attributes['http.method']).must_equal 'N/A'
+            _(span.attributes['http.status_code']).must_be_nil
+            _(span.attributes['http.url']).must_equal 'http://example.com/test'
+            _(span.status.canonical_code).must_equal(
+              OpenTelemetry::Trace::Status::UNKNOWN_ERROR
+            )
+            _(span.status.description).must_equal(
+              'Request has failed: Timeout was reached'
+            )
+            _(easy.instance_eval { @otel_span }).must_be_nil
+            _(
+              easy.instance_eval { @otel_original_headers['traceparent'] }
+            ).must_equal "00-#{span.trace_id}-#{span.span_id}-01"
+          end
+        end
+      end
+
+      describe '#reset' do
+        describe 'with headers set up' do
+          before do
+            easy.headers = { key: 'value' }
+          end
+
+          it 'cleans up @otel_original_headers' do
+            _(easy.instance_eval { @otel_original_headers }).must_equal(
+              key: 'value'
+            )
+
+            easy.reset
+
+            _(easy.instance_eval { @otel_original_headers }).must_be_nil
+          end
+        end
+
+        describe 'with HTTP method set up' do
+          before do
+            easy.http_request('example.com', :put)
+          end
+
+          it 'cleans up @otel_method' do
+            _(easy.instance_eval { @otel_method }).must_equal 'PUT'
+
+            easy.reset
+
+            _(easy.instance_eval { @otel_method }).must_be_nil
+          end
+        end
+
+        describe 'with span initialized' do
+          before do
+            easy.otel_before_request
+          end
+
+          it 'cleans up @otel_span' do
+            _(easy.instance_eval { @otel_span }).must_be_instance_of(
+              OpenTelemetry::SDK::Trace::Span
+            )
+
+            easy.reset
+
+            _(easy.instance_eval { @otel_span }).must_be_nil
+          end
+        end
+      end
+    end
+
+    describe 'multi' do
+      let(:easy) { ::Ethon::Easy.new }
+      let(:multi) { ::Ethon::Multi.new }
+
+      describe '#perform' do
+        describe 'with no easy added to multi' do
+          it 'does not trace' do
+            multi.perform
+
+            _(exporter.finished_spans.size).must_equal 0
+          end
+        end
+
+        describe 'with easy added to multi' do
+          before { multi.add(easy) }
+
+          it 'creates a span' do
+            multi.perform
+
+            _(exporter.finished_spans.size).must_equal 1
+          end
+        end
+
+        describe 'with multiple calls to perform' do
+          it 'does not create extra calls to perform without new easies' do
+            expect do
+              multi.add(easy)
+              multi.perform
+              multi.perform
+
+              _(exporter.finished_spans.size).must_equal 1
+            end
+          end
+
+          it 'creates extra traces for each extra valid call to perform' do
+            multi.add(easy)
+            multi.perform
+            multi.add(easy)
+            multi.perform
+
+            _(exporter.finished_spans.size).must_equal 2
+          end
+        end
+      end
+    end
+  end
+end

--- a/adapters/ethon/test/test_helper.rb
+++ b/adapters/ethon/test/test_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'ethon'
+
+require 'opentelemetry/sdk'
+
+require 'minitest/autorun'
+
+# global opentelemetry-sdk setup:
+EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
+span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
+
+OpenTelemetry::SDK.configure do |c|
+  c.add_span_processor span_processor
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,10 @@ services:
       context: .
     working_dir: /app
 
+  ex-adapter-ethon:
+    <<: *base
+    working_dir: /app/adapters/ethon/example
+
   ex-adapter-excon:
     <<: *base
     working_dir: /app/adapters/excon/example


### PR DESCRIPTION
# Overview

Add `ethon` instrumentation adapter based on the adapter for `rest-client` and `ddtrace` code for `ethon`.

While the purpose of this adapter is to instrument HTTP requests in particular, it is my understanding that the protocol could be something else without being able to detect and there are also times where the HTTP method/verb is unknowable.

`ddtrace` also had a parent span for `Ethon::Multi`, but that is currently not provided here because I do not think the those spans could be compliant with the specification.

Related to #67