### PR TITLE
Fix Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -69,7 +69,7 @@ GEM_INFO = {
       OpenTelemetry::Adapters::Faraday::VERSION
     }
   },
-  "opentelemetry-adapters-rest-client" => {
+  "opentelemetry-adapters-restclient" => {
     version_getter: ->() {
       require './lib/opentelemetry/adapters/restclient/version.rb'
       OpenTelemetry::Adapters::RestClient::VERSION


### PR DESCRIPTION
There was a `-` that was causing the following error when trying to change into the restclient directory to run tests:

```
**** Entering adapters/rest/client
rake aborted!
Errno::ENOENT: No such file or directory @ dir_chdir - adapters/rest/client
```