### PR TITLE
Bugfix: multiple span processors

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
@@ -75,7 +75,7 @@ module OpenTelemetry
               return
             end
             @registered_span_processors << span_processor
-            @active_span_processor = MultiSpanProcessor.new(@registered_span_processors)
+            @active_span_processor = MultiSpanProcessor.new(@registered_span_processors.dup)
           end
         end
       end

--- a/sdk/test/opentelemetry/sdk/trace/tracer_provider_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/tracer_provider_test.rb
@@ -63,6 +63,18 @@ describe OpenTelemetry::SDK::Trace::TracerProvider do
       tracer_provider.tracer.in_span('span') {}
       mock_span_processor.verify
     end
+
+    it 'adds multiple span processors to the active span processors' do
+      mock_processors = Array.new(2) { MiniTest::Mock.new }
+      mock_processors.each do |p|
+        p.expect(:on_start, nil, [Span])
+        p.expect(:on_finish, nil, [Span])
+        tracer_provider.add_span_processor(p)
+      end
+
+      tracer_provider.tracer.in_span('span') {}
+      mock_processors.each(&:verify)
+    end
   end
 
   describe '.tracer' do


### PR DESCRIPTION
While doing some QA earlier, I noticed that when we attempt to add a second span processor we get a FrozenError like the example below:

```
FrozenError: can't modify frozen Array
  /Users/matthewwear/Repos/opentelemetry-ruby/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb:77:in `block in add_span_processor'
  /Users/matthewwear/Repos/opentelemetry-ruby/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb:72:in `synchronize'
  /Users/matthewwear/Repos/opentelemetry-ruby/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb:72:in `add_span_processor'
  /Users/matthewwear/Repos/opentelemetry-ruby/sdk/lib/opentelemetry/sdk/configurator.rb:105:in `block in configure_span_processors'
  /Users/matthewwear/Repos/opentelemetry-ruby/sdk/lib/opentelemetry/sdk/configurator.rb:105:in `each'
  /Users/matthewwear/Repos/opentelemetry-ruby/sdk/lib/opentelemetry/sdk/configurator.rb:105:in `configure_span_processors'
  /Users/matthewwear/Repos/opentelemetry-ruby/sdk/lib/opentelemetry/sdk/configurator.rb:82:in `configure'
  /Users/matthewwear/Repos/opentelemetry-ruby/sdk/lib/opentelemetry/sdk.rb:58:in `configure'
```

This is because `MultiSpanProcessor` freezes the processors passed to it, which happens to be the `@active_span_processors` that belong to the `TracerProvider`. The fix is to dup the processors while initializing the `MultiSpanProcessor`.