### PR TITLE
Fix ::Rack::Utils namespace resolution

### DIFF
--- a/adapters/sinatra/lib/opentelemetry/adapters/sinatra/middlewares/tracer_middleware.rb
+++ b/adapters/sinatra/lib/opentelemetry/adapters/sinatra/middlewares/tracer_middleware.rb
@@ -43,7 +43,7 @@ module OpenTelemetry
             status, _headers, _response_body = resp
 
             span.set_attribute('http.status_code', status)
-            span.set_attribute('http.status_text', Rack::Utils::HTTP_STATUS_CODES[status])
+            span.set_attribute('http.status_text', ::Rack::Utils::HTTP_STATUS_CODES[status])
             span.set_attribute('http.route', env['sinatra.route'].split.last)
             span.status = OpenTelemetry::Trace::Status.http_to_status(status)
           end


### PR DESCRIPTION
# Overview

Fixes `Rack::Utils` resolution is conflicted when using rack instrumentation, since it includes Rack::Utils as well.

Problem is mentioned here: https://github.com/open-telemetry/opentelemetry-ruby/pull/166#pullrequestreview-363831738