### PR TITLE
Remove Gauges and LabelSet

### DIFF
--- a/api/lib/opentelemetry/metrics/handles.rb
+++ b/api/lib/opentelemetry/metrics/handles.rb
@@ -7,29 +7,19 @@
 module OpenTelemetry
   module Metrics
     # In situations where performance is a requirement and a metric is
-    # repeatedly used with the same set of labels, the developer may elect to
+    # repeatedly used with the same labels, the developer may elect to
     # use instrument {Handles} as an optimization. For handles to be a benefit,
     # it requires that a specific instrument will be re-used with specific
-    # labels. If an instrument will be used with the same label set more than
-    # once, obtaining an instrument handle corresponding to the label set
+    # labels. If an instrument will be used with the same labels more than
+    # once, obtaining an instrument handle corresponding to the labels
     # ensures the highest performance available.
     #
-    # To obtain a handle given an instrument and label set, use the  #handle
-    # method to return an interface that supports the #add, #set, or #record
+    # To obtain a handle given an instrument and labels, use the  #handle
+    # method to return an interface that supports the #add or #record
     # method of the instrument in question.
     #
     # Instrument handles may consume SDK resources indefinitely.
     module Handles
-      # A float gauge handle.
-      class FloatGauge
-        def set(value); end
-      end
-
-      # An integer gauge handle.
-      class IntegerGauge
-        def set(value); end
-      end
-
       # A float counter handle.
       class FloatCounter
         def add(value); end

--- a/api/lib/opentelemetry/metrics/instruments.rb
+++ b/api/lib/opentelemetry/metrics/instruments.rb
@@ -13,67 +13,19 @@ module OpenTelemetry
     # program to record observations about their behavior. Therefore, we use
     # "metric instrument" to refer to a program object, allocated through the
     # API, used for recording metrics. There are three distinct instruments in
-    # the Metrics API, commonly known as Counters, Gauges, and Measures.
+    # the Metrics API, commonly known as Counters, Observers, and Measures.
     module Instruments
-      # A float gauge instrument.
-      class FloatGauge
-        # Set the value of the gauge.
-        #
-        # @param [Float] value The value to set.
-        # @param [optional LabelSet, Hash<String, String>] labels_or_label_set
-        #   A {LabelSet} returned from {Meter#labels} or a Hash of Strings.
-        def set(value, labels_or_label_set = {}); end
-
-        # Obtain a handle from the instrument and label set.
-        #
-        # @param [optional LabelSet, Hash<String, String>] labels_or_label_set
-        #   A {LabelSet} returned from {Meter#labels} or a Hash of Strings.
-        # @return [Handles::FloatGauge]
-        def handle(labels_or_label_set = {})
-          Handles::FloatGauge.new
-        end
-
-        # Return a measurement to be recorded via {Meter#record_batch}.
-        #
-        # @param [Float] value
-        # @return [Object, Measurement]
-        def measurement(value)
-          NOOP_MEASUREMENT
-        end
-      end
-
-      # An integer gauge instrument.
-      class IntegerGauge
-        def set(value, labels_or_label_set = {}); end
-
-        # Obtain a handle from the instrument and label set.
-        #
-        # @param [optional LabelSet, Hash<String, String>] labels_or_label_set
-        #   A {LabelSet} returned from {Meter#labels} or a Hash of Strings.
-        # @return [Handles::IntegerGauge]
-        def handle(labels_or_label_set = {})
-          Handles::IntegerGauge.new
-        end
-
-        # Return a measurement to be recorded via {Meter#record_batch}.
-        #
-        # @param [Integer] value
-        # @return [Object, Measurement]
-        def measurement(value)
-          NOOP_MEASUREMENT
-        end
-      end
+      # TODO: Observers.
 
       # A float counter instrument.
       class FloatCounter
-        def add(value, labels_or_label_set = {}); end
+        def add(value, labels = {}); end
 
-        # Obtain a handle from the instrument and label set.
+        # Obtain a handle from the instrument and labels.
         #
-        # @param [optional LabelSet, Hash<String, String>] labels_or_label_set
-        #   A {LabelSet} returned from {Meter#labels} or a Hash of Strings.
+        # @param [optional Hash<String, String>] labels A Hash of Strings.
         # @return [Handles::FloatCounter]
-        def handle(labels_or_label_set = {})
+        def handle(labels = {})
           Handles::FloatCounter.new
         end
 
@@ -88,14 +40,13 @@ module OpenTelemetry
 
       # An integer counter instrument.
       class IntegerCounter
-        def add(value, labels_or_label_set = {}); end
+        def add(value, labels = {}); end
 
-        # Obtain a handle from the instrument and label set.
+        # Obtain a handle from the instrument and labels.
         #
-        # @param [optional LabelSet, Hash<String, String>] labels_or_label_set
-        #   A {LabelSet} returned from {Meter#labels} or a Hash of Strings.
+        # @param [optional Hash<String, String>] labels A Hash of Strings.
         # @return [Handles::IntegerCounter]
-        def handle(labels_or_label_set = {})
+        def handle(labels = {})
           Handles::IntegerCounter.new
         end
 
@@ -110,14 +61,13 @@ module OpenTelemetry
 
       # A float measure instrument.
       class FloatMeasure
-        def record(value, labels_or_label_set = {}); end
+        def record(value, labels = {}); end
 
-        # Obtain a handle from the instrument and label set.
+        # Obtain a handle from the instrument and labels.
         #
-        # @param [optional LabelSet, Hash<String, String>] labels_or_label_set
-        #   A {LabelSet} returned from {Meter#labels} or a Hash of Strings.
+        # @param [optional Hash<String, String>] labels A Hash of Strings.
         # @return [Handles::FloatMeasure]
-        def handle(labels_or_label_set = {})
+        def handle(labels = {})
           Handles::FloatMeasure.new
         end
 
@@ -132,14 +82,13 @@ module OpenTelemetry
 
       # An integer measure instrument.
       class IntegerMeasure
-        def record(value, labels_or_label_set = {}); end
+        def record(value, labels = {}); end
 
-        # Obtain a handle from the instrument and label set.
+        # Obtain a handle from the instrument and labels.
         #
-        # @param [optional LabelSet, Hash<String, String>] labels_or_label_set
-        #   A {LabelSet} returned from {Meter#labels} or a Hash of Strings.
+        # @param [optional Hash<String, String>] labels A Hash of Strings.
         # @return [Handles::IntegerMeasure]
-        def handle(labels_or_label_set = {})
+        def handle(labels = {})
           Handles::IntegerMeasure.new
         end
 

--- a/api/lib/opentelemetry/metrics/meter.rb
+++ b/api/lib/opentelemetry/metrics/meter.rb
@@ -8,46 +8,9 @@ module OpenTelemetry
   module Metrics
     # No-op implementation of Meter.
     class Meter
-      NOOP_LABEL_SET = Object.new
-      private_constant(:NOOP_LABEL_SET)
+      def record_batch(*measurements, labels: nil); end
 
-      def record_batch(*measurements, label_set: nil); end
-
-      # Canonicalizes labels, returning an opaque {LabelSet} object.
-      #
-      # @param [Hash<String, String>] labels
-      # @return [LabelSet]
-      def labels(labels)
-        NOOP_LABEL_SET
-      end
-
-      # Create and return a floating point gauge.
-      #
-      # @param [String] name Name of the metric. See {Meter} for required metric name syntax.
-      # @param [optional String] description Descriptive text documenting the instrument.
-      # @param [optional String] unit Unit specified according to http://unitsofmeasure.org/ucum.html.
-      # @param [optional Enumerable<String>] recommended_label_keys Recommended grouping keys for this instrument.
-      # @param [optional Boolean] monotonic Whether the gauge accepts only monotonic updates. Defaults to false.
-      # @return [FloatGauge]
-      def create_float_gauge(name, description: nil, unit: nil, recommended_label_keys: nil, monotonic: false)
-        raise ArgumentError if name.nil?
-
-        Instruments::FloatGauge.new
-      end
-
-      # Create and return an integer gauge.
-      #
-      # @param [String] name Name of the metric. See {Meter} for required metric name syntax.
-      # @param [optional String] description Descriptive text documenting the instrument.
-      # @param [optional String] unit Unit specified according to http://unitsofmeasure.org/ucum.html.
-      # @param [optional Enumerable<String>] recommended_label_keys Recommended grouping keys for this instrument.
-      # @param [optional Boolean] monotonic Whether the gauge accepts only monotonic updates. Defaults to false.
-      # @return [IntegerGauge]
-      def create_integer_gauge(name, description: nil, unit: nil, recommended_label_keys: nil, monotonic: false)
-        raise ArgumentError if name.nil?
-
-        Instruments::IntegerGauge.new
-      end
+      # TODO: Observers.
 
       # Create and return a floating point counter.
       #

--- a/api/test/opentelemetry/metrics/meter_test.rb
+++ b/api/test/opentelemetry/metrics/meter_test.rb
@@ -8,22 +8,6 @@ require 'test_helper'
 
 describe OpenTelemetry::Metrics::Meter do
   let(:meter) { OpenTelemetry.meter_provider.meter }
-  describe '.create_float_gauge' do
-    it 'requires a name' do
-      _(-> { meter.create_float_gauge(nil) }).must_raise(ArgumentError)
-    end
-    it 'returns a gauge' do
-      _(meter.create_float_gauge('g')).must_respond_to :set
-    end
-  end
-  describe '.create_integer_gauge' do
-    it 'requires a name' do
-      _(-> { meter.create_integer_gauge(nil) }).must_raise(ArgumentError)
-    end
-    it 'returns a gauge' do
-      _(meter.create_integer_gauge('g')).must_respond_to :set
-    end
-  end
   describe '.create_float_counter' do
     it 'requires a name' do
       _(-> { meter.create_float_counter(nil) }).must_raise(ArgumentError)


### PR DESCRIPTION
Implement [OTEP 90](https://github.com/open-telemetry/oteps/blob/master/text/0090-remove-labelset-from-metrics-api.md) and [OTEP 80](https://github.com/open-telemetry/oteps/blob/master/text/0080-remove-metric-gauge.md).

Observers will be added in a separate PR ([OTEP 72](https://github.com/open-telemetry/oteps/blob/master/text/0072-metric-observer.md)).