### PR TITLE
Implement force_flush

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/export/simple_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/simple_span_processor.rb
@@ -52,6 +52,15 @@ module OpenTelemetry
             OpenTelemetry.logger.error("unexpected error in span.on_finish - #{e}")
           end
 
+          # Export all ended spans to the configured `Exporter` that have not yet
+          # been exported.
+          #
+          # This method should only be called in cases where it is absolutely
+          # necessary, such as when using some FaaS providers that may suspend
+          # the process after an invocation, but before the `Processor` exports
+          # the completed spans.
+          def force_flush; end
+
           # Called when {TracerProvider#shutdown} is called.
           def shutdown
             @span_exporter&.shutdown

--- a/sdk/lib/opentelemetry/sdk/trace/multi_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/multi_span_processor.rb
@@ -49,7 +49,7 @@ module OpenTelemetry
         # the process after an invocation, but before the `Processor` exports
         # the completed spans.
         def force_flush
-          @span_processors.each &:force_flush
+          @span_processors.each(&:force_flush)
         end
 
         # Called when {TracerProvider#shutdown} is called.

--- a/sdk/lib/opentelemetry/sdk/trace/multi_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/multi_span_processor.rb
@@ -41,6 +41,17 @@ module OpenTelemetry
           @span_processors.each { |processor| processor.on_finish(span) }
         end
 
+        # Export all ended spans to the configured `Exporter` that have not yet
+        # been exported.
+        #
+        # This method should only be called in cases where it is absolutely
+        # necessary, such as when using some FaaS providers that may suspend
+        # the process after an invocation, but before the `Processor` exports
+        # the completed spans.
+        def force_flush
+          @span_processors.each &:force_flush
+        end
+
         # Called when {TracerProvider#shutdown} is called.
         def shutdown
           @span_processors.each(&:shutdown)

--- a/sdk/lib/opentelemetry/sdk/trace/noop_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/noop_span_processor.rb
@@ -33,6 +33,15 @@ module OpenTelemetry
         # @param [Span] span the {Span} that just ended.
         def on_finish(span); end
 
+        # Export all ended spans to the configured `Exporter` that have not yet
+        # been exported.
+        #
+        # This method should only be called in cases where it is absolutely
+        # necessary, such as when using some FaaS providers that may suspend
+        # the process after an invocation, but before the `Processor` exports
+        # the completed spans.
+        def force_flush; end
+
         # Called when {TracerProvider#shutdown} is called.
         def shutdown; end
       end

--- a/sdk/test/opentelemetry/sdk/trace/export/simple_span_processor_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/export/simple_span_processor_test.rb
@@ -36,6 +36,10 @@ describe OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor do
     processor.on_start(stub_span_recorded)
   end
 
+  it 'accepts calls to #force_flush' do
+    processor.force_flush
+  end
+
   it 'forwards recorded spans from #on_finish' do
     mock_span_exporter.expect :export, export::SUCCESS, [Array]
 

--- a/sdk/test/opentelemetry/sdk/trace/multi_span_processor_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/multi_span_processor_test.rb
@@ -37,6 +37,16 @@ describe OpenTelemetry::SDK::Trace::MultiSpanProcessor do
     mock_processor2.verify
   end
 
+  it 'implements #force_flush' do
+    mock_processor1.expect :force_flush, nil
+    mock_processor2.expect :force_flush, nil
+
+    processor.force_flush
+
+    mock_processor1.verify
+    mock_processor2.verify
+  end
+
   it 'implements #shutdown' do
     mock_processor1.expect :shutdown, nil
     mock_processor2.expect :shutdown, nil

--- a/sdk/test/opentelemetry/sdk/trace/noop_span_processor_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/noop_span_processor_test.rb
@@ -18,6 +18,10 @@ describe OpenTelemetry::SDK::Trace::NoopSpanProcessor do
     processor.on_finish(span)
   end
 
+  it 'implements #force_flush' do
+    processor.force_flush
+  end
+
   it 'implements #shutdown' do
     processor.shutdown
   end


### PR DESCRIPTION
Fixes #195 

Conveniently, we already had this implemented as a private method `flush` in `BatchSpanProcessor`.