### PR TITLE
opentelemetry-adapters-all gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Only a maintainer may perform a release.
    `{library-name}/v{version}`. For example, to release `opentelemetry-api`
    version `1.2.3`, create the tag `opentelemetry-api/v1.2.3`.
 4. Push the tag directly to Github.
+5. See [here][opentelemetry-adapters-all-publishing] for special instructions
+   for publishing the opentelemetry-adapters-all gem.
 
 After the tag is pushed, CircleCI will run the release workflow. This workflow
 includes one final run of the unit tests, followed by the release script itself.
@@ -178,3 +180,4 @@ Apache 2.0 - See [LICENSE][license-url] for more information.
 [license-image]: https://img.shields.io/badge/license-Apache_2.0-green.svg?style=flat
 [license-url]: https://github.com/open-telemetry/opentelemetry-ruby/blob/master/LICENSE
 [ruby-sig]: https://github.com/open-telemetry/community#ruby-sig
+[opentelemetry-adapters-all-publishing]: https://github.com/open-telemetry/opentelemetry-ruby/tree/master/adapters/all#publishing

--- a/Rakefile
+++ b/Rakefile
@@ -110,6 +110,12 @@ GEM_INFO = {
       require './lib/opentelemetry/adapters/sinatra/version.rb'
       OpenTelemetry::Adapters::Sinatra::VERSION
     }
+  },
+  "opentelemetry-adapters-all" => {
+    version_getter: ->() {
+      require './lib/opentelemetry/adapters/all/version.rb'
+      OpenTelemetry::Adapters::All::VERSION
+    }
   }
 }
 

--- a/adapters/all/.rubocop.yml
+++ b/adapters/all/.rubocop.yml
@@ -1,0 +1,17 @@
+AllCops:
+  TargetRubyVersion: '2.4.0'
+Lint/UnusedMethodArgument:
+  Enabled: false
+Metrics/AbcSize:
+  Max: 18
+Metrics/LineLength:
+  Enabled: false
+Metrics/MethodLength:
+  Max: 20
+Metrics/ParameterLists:
+  Enabled: false
+Naming/FileName:
+  Exclude:
+    - "lib/opentelemetry-adapters-all.rb"
+Style/ModuleFunction:
+  Enabled: false

--- a/adapters/all/Gemfile
+++ b/adapters/all/Gemfile
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source 'https://rubygems.org'
+
+gemspec
+
+gem 'opentelemetry-api', path: '../../api'
+
+group :test do
+  gem 'opentelemetry-sdk', path: '../../sdk'
+end

--- a/adapters/all/Gemfile
+++ b/adapters/all/Gemfile
@@ -7,9 +7,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-gem 'opentelemetry-api', path: '../../api'
-
-group :test do
-  gem 'opentelemetry-sdk', path: '../../sdk'
-end

--- a/adapters/all/LICENSE
+++ b/adapters/all/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2020 OpenTelemetry Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/adapters/all/README.md
+++ b/adapters/all/README.md
@@ -1,6 +1,6 @@
 # opentelemetry-adapters-all
 
-The `opentelemetry-adapters-all` gem is an all-in-one distribution of community maintained instrumentation adapters. Instrumentation adapters are packaged as individual gems for flexibilty and maintainability. Instead of having to require each adapter individually, applications can depend on this all-in-one gem as a convenient alternative.
+The `opentelemetry-adapters-all` gem is an all-in-one distribution of community maintained instrumentation adapters. Instrumentation adapters are packaged as individual gems for flexibility and maintainability. Instead of having to require each adapter individually, applications can depend on this all-in-one gem as a convenient alternative.
 
 ## What is OpenTelemetry?
 
@@ -23,7 +23,7 @@ gem install opentelemetry-adapters-all
 Or, if you use [bundler][bundler-home], include `opentelemetry-adapters-all` in your `Gemfile`.
 
 
-The `opentelemetry-api` has functionality to discover the instrumentation adapters that an application depends on. It maintains an registry of discovered adapters that SDKs can use to automatically install the instrumentation for you. These instructions pertain to the offical `opentelemetry-sdk` implementation. Consult the documentation for your SDK if you are using an alternative implementation.
+The `opentelemetry-api` has functionality to discover the instrumentation adapters that an application depends on. It maintains a registry of discovered adapters that SDKs can use to automatically install the instrumentation for you. These instructions pertain to the offical `opentelemetry-sdk` implementation. Consult the documentation for your SDK if you are using an alternative implementation.
 
 
 ### Use All

--- a/adapters/all/README.md
+++ b/adapters/all/README.md
@@ -49,7 +49,6 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
-
 ### Selective Install
 
 Some users may want more fine grained control over what instrumentation they install for their application. Users can opt to selectively install instrumentation with the `use` method. Call `use` with the name of the instrumentation, and an optional configuration hash.
@@ -63,6 +62,11 @@ OpenTelemetry::SDK.configure do |c|
   c.use 'OpenTelemetry::Adapters::SomeAdapter', { opt: 'value' }
 end
 ```
+
+## Releasing
+
+Releasing opentelemetry-adapters-all currently requires bumping the versions for all instrumentation adapters and pushing them to
+rubygems.org first. Because of this, opentelemetry-adapters-all must be the last gem to be published in the release process.
 
 ## How can I get involved?
 

--- a/adapters/all/README.md
+++ b/adapters/all/README.md
@@ -65,8 +65,7 @@ end
 
 ## Releasing
 
-Releasing opentelemetry-adapters-all currently requires bumping the versions for all instrumentation adapters and pushing them to
-rubygems.org first. Because of this, opentelemetry-adapters-all must be the last gem to be published in the release process.
+Releasing opentelemetry-adapters-all requires that all gems it depends on exist on rubygems.org before publishing it. Because of this, it must be the last gem to be published in the release process.
 
 ## How can I get involved?
 

--- a/adapters/all/README.md
+++ b/adapters/all/README.md
@@ -1,0 +1,84 @@
+# opentelemetry-adapters-all
+
+The `opentelemetry-adapters-all` gem is an all-in-one distribution of community maintained instrumentation adapters. Instrumentation adapters are packaged as individual gems for flexibilty and maintainability. Instead of having to require each adapter individually, applications can depend on this all-in-one gem as a convenient alternative.
+
+## What is OpenTelemetry?
+
+[OpenTelemetry][opentelemetry-home] is an open source observability framework, providing a general-purpose API, SDK, and related tools required for the instrumentation of cloud-native software, frameworks, and libraries.
+
+OpenTelemetry provides a single set of APIs, libraries, agents, and collector services to capture distributed traces and metrics from your application. You can analyze them using Prometheus, Jaeger, and other observability tools.
+
+## How does this gem fit in?
+
+This gem can be used with any OpenTelemetry SDK implementation. This can be the official `opentelemetry-sdk` gem or any other concrete implementation.
+
+## How do I get started?
+
+Install the gem using:
+
+```
+gem install opentelemetry-adapters-all
+```
+
+Or, if you use [bundler][bundler-home], include `opentelemetry-adapters-all` in your `Gemfile`.
+
+
+The `opentelemetry-api` has functionality to discover the instrumentation adapters that an application depends on. It maintains an registry of discovered adapters that SDKs can use to automatically install the instrumentation for you. These instructions pertain to the offical `opentelemetry-sdk` implementation. Consult the documentation for your SDK if you are using an alternative implementation.
+
+
+### Use All
+
+The `use_all` method will install all instrumentation present for an application, where the underlying, instrumented library is also present. Per library configuration can be passed in using an optional hash argument that has the adapter names as keys and configuration hashes as values.
+
+
+```ruby
+require 'opentelemetry/sdk'
+
+# install all compatible instrumentation with default configuration
+OpenTelemetry::SDK.configure do |c|
+  c.use_all
+end
+```
+
+```ruby
+require 'opentelemetry/sdk'
+
+# install all compatible instrumentation with per adapter configuration overrides
+OpenTelemetry::SDK.configure do |c|
+  c.use_all('OpenTelemetry::Adapters::SomeAdapter' => { opt: 'value' })
+end
+```
+
+
+### Selective Install
+
+Some users may want more fine grained control over what instrumentation they install for their application. Users can opt to selectively install instrumentation with the `use` method. Call `use` with the name of the instrumentation, and an optional configuration hash.
+
+```ruby
+require 'opentelemetry/sdk'
+
+# install all compatible instrumentation with default configuration
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Adapters::Sinatra'
+  c.use 'OpenTelemetry::Adapters::SomeAdapter', { opt: 'value' }
+end
+```
+
+## How can I get involved?
+
+The `opentelemetry-adapters-all` gem source is [on github][repo-github], along with related gems including `opentelemetry-api` and `opentelemetry-sdk`.
+
+The OpenTelemetry Ruby gems are maintained by the OpenTelemetry-Ruby special interest group (SIG). You can get involved by joining us on our [gitter channel][ruby-gitter] or attending our weekly meeting. See the [meeting calendar][community-meetings] for dates and times. For more information on this and other language SIGs, see the OpenTelemetry [community page][ruby-sig].
+
+## License
+
+The `opentelemetry-adapters-all` gem is distributed under the Apache 2.0 license. See [LICENSE][license-github] for more information.
+
+
+[opentelemetry-home]: https://opentelemetry.io
+[bundler-home]: https://bundler.io
+[repo-github]: https://github.com/open-telemetry/opentelemetry-ruby
+[license-github]: https://github.com/open-telemetry/opentelemetry-ruby/blob/master/LICENSE
+[ruby-sig]: https://github.com/open-telemetry/community#ruby-sig
+[community-meetings]: https://github.com/open-telemetry/community#community-meetings
+[ruby-gitter]: https://gitter.im/open-telemetry/opentelemetry-ruby

--- a/adapters/all/Rakefile
+++ b/adapters/all/Rakefile
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+require 'yard'
+require 'rubocop/rake_task'
+
+RuboCop::RakeTask.new
+
+Rake::TestTask.new :test do |t|
+  t.libs << 'test'
+  t.libs << 'lib'
+  t.test_files = FileList['test/**/*_test.rb']
+end
+
+YARD::Rake::YardocTask.new do |t|
+  t.stats_options = ['--list-undoc']
+end
+
+if RUBY_ENGINE == 'truffleruby'
+  task default: %i[test]
+else
+  task default: %i[test rubocop yard]
+end

--- a/adapters/all/lib/opentelemetry-adapters-all.rb
+++ b/adapters/all/lib/opentelemetry-adapters-all.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require_relative './opentelemetry/adapters/all'

--- a/adapters/all/lib/opentelemetry/adapters/all.rb
+++ b/adapters/all/lib/opentelemetry/adapters/all.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry-adapters-concurrent-ruby'
+require 'opentelemetry-adapters-ethon'
+require 'opentelemetry-adapters-excon'
+require 'opentelemetry-adapters-faraday'
+require 'opentelemetry-adapters-net-http'
+require 'opentelemetry-adapters-rack'
+require 'opentelemetry-adapters-redis'
+require 'opentelemetry-adapters-rest-client'
+require 'opentelemetry-adapters-sinatra'
+
+module OpenTelemetry
+  module Adapters
+    # Namespace for the Opentelemetry all-in-one gem
+    module All
+    end
+  end
+end
+
+require_relative './all/version'

--- a/adapters/all/lib/opentelemetry/adapters/all/version.rb
+++ b/adapters/all/lib/opentelemetry/adapters/all/version.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Adapters
+    module All
+      VERSION = '0.3.0'
+    end
+  end
+end

--- a/adapters/all/opentelemetry-adapters-all.gemspec
+++ b/adapters/all/opentelemetry-adapters-all.gemspec
@@ -8,7 +8,6 @@ lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'opentelemetry/adapters/all/version'
-version = OpenTelemetry::Adapters::All::VERSION
 
 Gem::Specification.new do |spec|
   spec.name        = 'opentelemetry-adapters-all'
@@ -27,15 +26,15 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.4.0'
 
-  spec.add_dependency 'opentelemetry-adapters-concurrent_ruby', version
-  spec.add_dependency 'opentelemetry-adapters-ethon', version
-  spec.add_dependency 'opentelemetry-adapters-excon', version
-  spec.add_dependency 'opentelemetry-adapters-faraday', version
-  spec.add_dependency 'opentelemetry-adapters-net_http', version
-  spec.add_dependency 'opentelemetry-adapters-rack', version
-  spec.add_dependency 'opentelemetry-adapters-redis', version
-  spec.add_dependency 'opentelemetry-adapters-restclient', version
-  spec.add_dependency 'opentelemetry-adapters-sinatra', version
+  spec.add_dependency 'opentelemetry-adapters-concurrent_ruby', '~> 0.3.0'
+  spec.add_dependency 'opentelemetry-adapters-ethon', '~> 0.3.0'
+  spec.add_dependency 'opentelemetry-adapters-excon', '~> 0.3.0'
+  spec.add_dependency 'opentelemetry-adapters-faraday', '~> 0.3.0'
+  spec.add_dependency 'opentelemetry-adapters-net_http', '~> 0.3.0'
+  spec.add_dependency 'opentelemetry-adapters-rack', '~> 0.3.0'
+  spec.add_dependency 'opentelemetry-adapters-redis', '~> 0.3.0'
+  spec.add_dependency 'opentelemetry-adapters-restclient', '~> 0.3.0'
+  spec.add_dependency 'opentelemetry-adapters-sinatra', '~> 0.3.0'
 
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'minitest', '~> 5.0'

--- a/adapters/all/opentelemetry-adapters-faraday.gemspec
+++ b/adapters/all/opentelemetry-adapters-faraday.gemspec
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require 'opentelemetry/adapters/all/version'
+version = OpenTelemetry::Adapters::All::VERSION
+
+Gem::Specification.new do |spec|
+  spec.name        = 'opentelemetry-adapters-all'
+  spec.version     = OpenTelemetry::Adapters::All::VERSION
+  spec.authors     = ['OpenTelemetry Authors']
+  spec.email       = ['cncf-opentelemetry-contributors@lists.cncf.io']
+
+  spec.summary     = 'All-in-one instrumentation adapter bundle for the OpenTelemetry framework'
+  spec.description = 'All-in-one instrumentation adapter bundle for the OpenTelemetry framework'
+  spec.homepage    = 'https://github.com/open-telemetry/opentelemetry-ruby'
+  spec.license     = 'Apache-2.0'
+
+  spec.files = ::Dir.glob('lib/**/*.rb') +
+               ::Dir.glob('*.md') +
+               ['LICENSE']
+  spec.require_paths = ['lib']
+  spec.required_ruby_version = '>= 2.4.0'
+
+  spec.add_dependency 'opentelemetry-adapters-concurrent_ruby', version
+  spec.add_dependency 'opentelemetry-adapters-ethon', version
+  spec.add_dependency 'opentelemetry-adapters-excon', version
+  spec.add_dependency 'opentelemetry-adapters-faraday', version
+  spec.add_dependency 'opentelemetry-adapters-net_http', version
+  spec.add_dependency 'opentelemetry-adapters-rack', version
+  spec.add_dependency 'opentelemetry-adapters-redis', version
+  spec.add_dependency 'opentelemetry-adapters-restclient', version
+  spec.add_dependency 'opentelemetry-adapters-sinatra', version
+
+  spec.add_development_dependency 'bundler', '>= 1.17'
+  spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'rake', '~> 12.0'
+  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'simplecov', '~> 0.17.1'
+  spec.add_development_dependency 'yard', '~> 0.9'
+  spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+end

--- a/adapters/all/test/.rubocop.yml
+++ b/adapters/all/test/.rubocop.yml
@@ -1,0 +1,4 @@
+inherit_from: ../.rubocop.yml
+
+Metrics/BlockLength:
+  Enabled: false

--- a/adapters/all/test/test_helper.rb
+++ b/adapters/all/test/test_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'minitest/autorun'
+require 'webmock/minitest'


### PR DESCRIPTION
This gem is an all-in-one distribution of all of the officially supported instrumentation adapters. This will likely be the go-to method that users will use to add instrumentation dependencies to their application. With this package users will only need the following to get off the ground with opentelemetry.

Gemfile

```ruby
source `https://rubygems.org`

gem `opentelemetry-sdk`
gem `opentelemetry-adapters-all`
```
App
```ruby
OpenTelemetry::SDK.configure do |c|
  c.use_all
end

# ...
```