### PR TITLE
Remove Ruby 2.4 support (EOL)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,6 @@
 
 version: 2.1
 executors:
-  ruby24:
-    docker:
-      - image: "circleci/ruby:2.4-buster"
   ruby25:
     docker:
       - image: "circleci/ruby:2.5-buster"
@@ -140,11 +137,6 @@ commands:
           name: Release
           command: "rake push_release"
 jobs:
-  test-ruby24:
-    executor: ruby24
-    steps:
-      - rake-test
-      - rake-test-appraisal
   test-ruby25:
     executor: ruby25
     steps:
@@ -177,10 +169,6 @@ workflows:
   version: 2
   builds:
     jobs:
-      - test-ruby24:
-          filters:
-            tags:
-              only: /^opentelemetry-.+\/v\d.*$/
       - test-ruby25:
           filters:
             tags:
@@ -203,7 +191,6 @@ workflows:
               only: /^opentelemetry-.+\/v\d.*$/
       - release:
           requires:
-            - test-ruby24
             - test-ruby25
             - test-ruby26
             - test-ruby27

--- a/adapters/concurrent_ruby/.rubocop.yml
+++ b/adapters/concurrent_ruby/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: '2.4.0'
+  TargetRubyVersion: "2.5.0"
 
 Bundler/OrderedGems:
   Exclude:

--- a/adapters/concurrent_ruby/opentelemetry-adapters-concurrent_ruby.gemspec
+++ b/adapters/concurrent_ruby/opentelemetry-adapters-concurrent_ruby.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                ::Dir.glob('*.md') +
                ['LICENSE']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 0.3.0'
 

--- a/adapters/ethon/.rubocop.yml
+++ b/adapters/ethon/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: '2.4.0'
+  TargetRubyVersion: "2.5.0"
 
 Bundler/OrderedGems:
   Exclude:

--- a/adapters/ethon/opentelemetry-adapters-ethon.gemspec
+++ b/adapters/ethon/opentelemetry-adapters-ethon.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                ::Dir.glob('*.md') +
                ['LICENSE']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 0.3.0'
 

--- a/adapters/excon/.rubocop.yml
+++ b/adapters/excon/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: '2.4.0'
+  TargetRubyVersion: "2.5.0"
 
 Bundler/OrderedGems:
   Exclude:

--- a/adapters/excon/opentelemetry-adapters-excon.gemspec
+++ b/adapters/excon/opentelemetry-adapters-excon.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                ::Dir.glob('*.md') +
                ['LICENSE']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 0.3.0'
 

--- a/adapters/faraday/.rubocop.yml
+++ b/adapters/faraday/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: '2.4.0'
+  TargetRubyVersion: "2.5.0"
 
 Bundler/OrderedGems:
   Exclude:

--- a/adapters/faraday/opentelemetry-adapters-faraday.gemspec
+++ b/adapters/faraday/opentelemetry-adapters-faraday.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                ::Dir.glob('*.md') +
                ['LICENSE']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 0.3.0'
 

--- a/adapters/net_http/.rubocop.yml
+++ b/adapters/net_http/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: '2.4.0'
+  TargetRubyVersion: "2.5.0"
 
 Bundler/OrderedGems:
   Exclude:

--- a/adapters/net_http/opentelemetry-adapters-net_http.gemspec
+++ b/adapters/net_http/opentelemetry-adapters-net_http.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                ::Dir.glob('*.md') +
                ['LICENSE']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 0.3.0'
 

--- a/adapters/rack/.rubocop.yml
+++ b/adapters/rack/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: '2.4.0'
+  TargetRubyVersion: "2.5.0"
 
 Bundler/OrderedGems:
   Exclude:

--- a/adapters/rack/opentelemetry-adapters-rack.gemspec
+++ b/adapters/rack/opentelemetry-adapters-rack.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                ::Dir.glob('*.md') +
                ['LICENSE']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 0.3.0'
 

--- a/adapters/redis/.rubocop.yml
+++ b/adapters/redis/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: '2.4.0'
+  TargetRubyVersion: "2.5.0"
 
 Bundler/OrderedGems:
   Exclude:

--- a/adapters/redis/opentelemetry-adapters-redis.gemspec
+++ b/adapters/redis/opentelemetry-adapters-redis.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                ::Dir.glob('*.md') +
                ['LICENSE']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 0.3.0'
 

--- a/adapters/restclient/.rubocop.yml
+++ b/adapters/restclient/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: '2.4.0'
+  TargetRubyVersion: "2.5.0"
 
 Bundler/OrderedGems:
   Exclude:

--- a/adapters/restclient/opentelemetry-adapters-restclient.gemspec
+++ b/adapters/restclient/opentelemetry-adapters-restclient.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                ::Dir.glob('*.md') +
                ['LICENSE']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 0.3.0'
 

--- a/adapters/sinatra/.rubocop.yml
+++ b/adapters/sinatra/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: '2.4.0'
+  TargetRubyVersion: "2.5.0"
 
 Bundler/OrderedGems:
   Exclude:

--- a/adapters/sinatra/opentelemetry-adapters-sinatra.gemspec
+++ b/adapters/sinatra/opentelemetry-adapters-sinatra.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                ::Dir.glob('*.md') +
                ['LICENSE']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 0.3.0'
 

--- a/api/.rubocop.yml
+++ b/api/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: '2.4.0'
+  TargetRubyVersion: "2.5.0"
 
 Lint/UnusedMethodArgument:
   Enabled: false

--- a/api/lib/opentelemetry/context/propagation/composite_propagator.rb
+++ b/api/lib/opentelemetry/context/propagation/composite_propagator.rb
@@ -61,12 +61,10 @@ module OpenTelemetry
         #   carrier
         def extract(carrier, context = Context.current, &getter)
           @extractors.inject(context) do |ctx, extractor|
-            begin
-              extractor.extract(carrier, ctx, &getter)
-            rescue => e # rubocop:disable Style/RescueStandardError
-              OpenTelemetry.logger.warn "Error in CompositePropagator#extract #{e.message}"
-              ctx
-            end
+            extractor.extract(carrier, ctx, &getter)
+          rescue => e # rubocop:disable Style/RescueStandardError
+            OpenTelemetry.logger.warn "Error in CompositePropagator#extract #{e.message}"
+            ctx
           end
         end
       end

--- a/api/lib/opentelemetry/context/propagation/composite_propagator.rb
+++ b/api/lib/opentelemetry/context/propagation/composite_propagator.rb
@@ -38,12 +38,10 @@ module OpenTelemetry
         # @return [Object] carrier
         def inject(carrier, context = Context.current, &setter)
           @injectors.inject(carrier) do |memo, injector|
-            begin
-              injector.inject(memo, context, &setter)
-            rescue => e # rubocop:disable Style/RescueStandardError
-              OpenTelemetry.logger.warn "Error in CompositePropagator#inject #{e.message}"
-              carrier
-            end
+            injector.inject(memo, context, &setter)
+          rescue => e # rubocop:disable Style/RescueStandardError
+            OpenTelemetry.logger.warn "Error in CompositePropagator#inject #{e.message}"
+            carrier
           end
         end
 

--- a/api/opentelemetry-api.gemspec
+++ b/api/opentelemetry-api.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                ::Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_development_dependency 'benchmark-ipsa', '~> 0.2.0'
   spec.add_development_dependency 'bundler', '>= 1.17'

--- a/exporters/jaeger/.rubocop.yml
+++ b/exporters/jaeger/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: "2.4.0"
+  TargetRubyVersion: "2.5.0"
   Exclude:
     - "thrift/**/*"
 

--- a/exporters/jaeger/opentelemetry-exporters-jaeger.gemspec
+++ b/exporters/jaeger/opentelemetry-exporters-jaeger.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
                ::Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 0.3.0'
   spec.add_dependency 'thrift'

--- a/sdk/.rubocop.yml
+++ b/sdk/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: '2.4.0'
+  TargetRubyVersion: "2.5.0"
 
 Lint/UnusedMethodArgument:
   Enabled: false

--- a/sdk/lib/opentelemetry/sdk/trace/export/multi_span_exporter.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/multi_span_exporter.rb
@@ -26,12 +26,10 @@ module OpenTelemetry
           # @return [Integer] the result of the export.
           def export(spans)
             @span_exporters.inject(SUCCESS) do |result_code, span_exporter|
-              begin
-                merge_result_code(result_code, span_exporter.export(spans))
-              rescue => e # rubocop:disable Style/RescueStandardError
-                OpenTelemetry.logger.warn("exception raised by export - #{e}")
-                FAILED_NOT_RETRYABLE
-              end
+              merge_result_code(result_code, span_exporter.export(spans))
+            rescue => e # rubocop:disable Style/RescueStandardError
+              OpenTelemetry.logger.warn("exception raised by export - #{e}")
+              FAILED_NOT_RETRYABLE
             end
           end
 

--- a/sdk/opentelemetry-sdk.gemspec
+++ b/sdk/opentelemetry-sdk.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                ::Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 0.3.0'
 

--- a/sdk/test/opentelemetry/sdk/trace/span_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/span_test.rb
@@ -191,11 +191,9 @@ describe OpenTelemetry::SDK::Trace::Span do
     end
 
     let(:error) do
-      begin
-        raise 'oops'
-      rescue StandardError => e
-        e
-      end
+      raise 'oops'
+    rescue StandardError => e
+      e
     end
 
     it 'records error as an event' do


### PR DESCRIPTION
Ruby 2.4 has reached EOL and is no longer supported. See https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/