### PR TITLE
Fix Sinatra example in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,7 @@ services:
 
   ex-adapter-sinatra:
     <<: *base
+    command: ./start_server.sh
     working_dir: /app/adapters/sinatra/example
 
   ex-http:


### PR DESCRIPTION
This commit fixes the Sinatra example so that it runs out of the box
like the standard `ex-http` example when called with
`docker-compose run ex-adapter-sinatra`.