### PR TITLE
Rename excon component attribute from http to excon

### DIFF
--- a/adapters/excon/lib/opentelemetry/adapters/excon/middlewares/tracer_middleware.rb
+++ b/adapters/excon/lib/opentelemetry/adapters/excon/middlewares/tracer_middleware.rb
@@ -30,7 +30,7 @@ module OpenTelemetry
                 tracer.start_span(
                   "HTTP #{http_method}",
                   attributes: {
-                    'component' => 'http',
+                    'component' => 'excon',
                     'http.host' => datum[:host],
                     'http.method' => http_method,
                     'http.scheme' => datum[:scheme],

--- a/adapters/excon/test/opentelemetry/adapters/excon/adapter_test.rb
+++ b/adapters/excon/test/opentelemetry/adapters/excon/adapter_test.rb
@@ -50,7 +50,7 @@ describe OpenTelemetry::Adapters::Excon::Adapter do
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['component']).must_equal 'http'
+      _(span.attributes['component']).must_equal 'excon'
       _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.status_code']).must_equal 200
       _(span.attributes['http.scheme']).must_equal 'http'
@@ -68,7 +68,7 @@ describe OpenTelemetry::Adapters::Excon::Adapter do
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['component']).must_equal 'http'
+      _(span.attributes['component']).must_equal 'excon'
       _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.status_code']).must_equal 500
       _(span.attributes['http.scheme']).must_equal 'http'
@@ -88,7 +88,7 @@ describe OpenTelemetry::Adapters::Excon::Adapter do
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['component']).must_equal 'http'
+      _(span.attributes['component']).must_equal 'excon'
       _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.scheme']).must_equal 'http'
       _(span.attributes['http.host']).must_equal 'example.com'


### PR DESCRIPTION
The rack middleware uses the same component value. So excon and rack
requests are currently impossible to differenciate.

The value `excon` seems like the most explicit one to me. I'm open to any alternative though.