### PR TITLE
Remove component attribute from all adapters

### DIFF
--- a/adapters/ethon/lib/opentelemetry/adapters/ethon/patches/easy.rb
+++ b/adapters/ethon/lib/opentelemetry/adapters/ethon/patches/easy.rb
@@ -71,7 +71,6 @@ module OpenTelemetry
             @otel_span = tracer.start_span(
               HTTP_METHODS_TO_SPAN_NAMES[method],
               attributes: {
-                'component' => 'http',
                 'http.method' => method,
                 'http.url' => url
               },

--- a/adapters/ethon/test/opentelemetry/adapters/ethon/adapter_test.rb
+++ b/adapters/ethon/test/opentelemetry/adapters/ethon/adapter_test.rb
@@ -71,7 +71,6 @@ describe OpenTelemetry::Adapters::Ethon::Adapter do
               easy.perform
 
               _(span.name).must_equal 'HTTP N/A'
-              _(span.attributes['component']).must_equal 'http'
               _(span.attributes['http.method']).must_equal 'N/A'
               _(span.attributes['http.status_code']).must_be_nil
               _(span.attributes['http.url']).must_equal 'http://example.com/test'
@@ -94,7 +93,6 @@ describe OpenTelemetry::Adapters::Ethon::Adapter do
         it 'when response is successful' do
           stub_response(response_code: 200) do
             _(span.name).must_equal 'HTTP N/A'
-            _(span.attributes['component']).must_equal 'http'
             _(span.attributes['http.method']).must_equal 'N/A'
             _(span.attributes['http.status_code']).must_equal 200
             _(span.attributes['http.url']).must_equal 'http://example.com/test'
@@ -108,7 +106,6 @@ describe OpenTelemetry::Adapters::Ethon::Adapter do
         it 'when response is not successful' do
           stub_response(response_code: 500) do
             _(span.name).must_equal 'HTTP N/A'
-            _(span.attributes['component']).must_equal 'http'
             _(span.attributes['http.method']).must_equal 'N/A'
             _(span.attributes['http.status_code']).must_equal 500
             _(span.attributes['http.url']).must_equal 'http://example.com/test'
@@ -122,7 +119,6 @@ describe OpenTelemetry::Adapters::Ethon::Adapter do
         it 'when request times out' do
           stub_response(response_code: 0, return_code: :operation_timedout) do
             _(span.name).must_equal 'HTTP N/A'
-            _(span.attributes['component']).must_equal 'http'
             _(span.attributes['http.method']).must_equal 'N/A'
             _(span.attributes['http.status_code']).must_be_nil
             _(span.attributes['http.url']).must_equal 'http://example.com/test'

--- a/adapters/excon/lib/opentelemetry/adapters/excon/middlewares/tracer_middleware.rb
+++ b/adapters/excon/lib/opentelemetry/adapters/excon/middlewares/tracer_middleware.rb
@@ -30,7 +30,6 @@ module OpenTelemetry
                 tracer.start_span(
                   "HTTP #{http_method}",
                   attributes: {
-                    'component' => 'http',
                     'http.host' => datum[:host],
                     'http.method' => http_method,
                     'http.scheme' => datum[:scheme],

--- a/adapters/excon/test/opentelemetry/adapters/excon/adapter_test.rb
+++ b/adapters/excon/test/opentelemetry/adapters/excon/adapter_test.rb
@@ -50,7 +50,6 @@ describe OpenTelemetry::Adapters::Excon::Adapter do
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['component']).must_equal 'http'
       _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.status_code']).must_equal 200
       _(span.attributes['http.scheme']).must_equal 'http'
@@ -68,7 +67,6 @@ describe OpenTelemetry::Adapters::Excon::Adapter do
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['component']).must_equal 'http'
       _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.status_code']).must_equal 500
       _(span.attributes['http.scheme']).must_equal 'http'
@@ -88,7 +86,6 @@ describe OpenTelemetry::Adapters::Excon::Adapter do
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['component']).must_equal 'http'
       _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.scheme']).must_equal 'http'
       _(span.attributes['http.host']).must_equal 'example.com'

--- a/adapters/faraday/lib/opentelemetry/adapters/faraday/middlewares/tracer_middleware.rb
+++ b/adapters/faraday/lib/opentelemetry/adapters/faraday/middlewares/tracer_middleware.rb
@@ -29,7 +29,6 @@ module OpenTelemetry
             tracer.in_span(
               "HTTP #{http_method}",
               attributes: {
-                'component' => 'http',
                 'http.method' => http_method,
                 'http.url' => env.url.to_s
               },

--- a/adapters/faraday/test/opentelemetry/adapters/faraday/middlewares/tracer_middleware_test.rb
+++ b/adapters/faraday/test/opentelemetry/adapters/faraday/middlewares/tracer_middleware_test.rb
@@ -50,7 +50,6 @@ describe OpenTelemetry::Adapters::Faraday::Middlewares::TracerMiddleware do
       response = client.get('/success')
 
       _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['component']).must_equal 'http'
       _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.status_code']).must_equal 200
       _(span.attributes['http.url']).must_equal 'http://example.com/success'
@@ -63,7 +62,6 @@ describe OpenTelemetry::Adapters::Faraday::Middlewares::TracerMiddleware do
       response = client.get('/not_found')
 
       _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['component']).must_equal 'http'
       _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.status_code']).must_equal 404
       _(span.attributes['http.url']).must_equal 'http://example.com/not_found'
@@ -76,7 +74,6 @@ describe OpenTelemetry::Adapters::Faraday::Middlewares::TracerMiddleware do
       response = client.get('/failure')
 
       _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['component']).must_equal 'http'
       _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.status_code']).must_equal 500
       _(span.attributes['http.url']).must_equal 'http://example.com/failure'

--- a/adapters/net_http/lib/opentelemetry/adapters/net/http/patches/instrumentation.rb
+++ b/adapters/net_http/lib/opentelemetry/adapters/net/http/patches/instrumentation.rb
@@ -21,7 +21,6 @@ module OpenTelemetry
               tracer.in_span(
                 HTTP_METHODS_TO_SPAN_NAMES[req.method],
                 attributes: {
-                  'component' => 'http',
                   'http.method' => req.method,
                   'http.scheme' => USE_SSL_TO_SCHEME[use_ssl?],
                   'http.target' => req.path,

--- a/adapters/net_http/test/opentelemetry/adapters/net/http/adapter_test.rb
+++ b/adapters/net_http/test/opentelemetry/adapters/net/http/adapter_test.rb
@@ -50,7 +50,6 @@ describe OpenTelemetry::Adapters::Net::HTTP::Adapter do
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['component']).must_equal 'http'
       _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.scheme']).must_equal 'http'
       _(span.attributes['http.status_code']).must_equal 200
@@ -69,7 +68,6 @@ describe OpenTelemetry::Adapters::Net::HTTP::Adapter do
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP POST'
-      _(span.attributes['component']).must_equal 'http'
       _(span.attributes['http.method']).must_equal 'POST'
       _(span.attributes['http.scheme']).must_equal 'http'
       _(span.attributes['http.status_code']).must_equal 500
@@ -90,7 +88,6 @@ describe OpenTelemetry::Adapters::Net::HTTP::Adapter do
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['component']).must_equal 'http'
       _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.scheme']).must_equal 'https'
       _(span.attributes['http.status_code']).must_be_nil

--- a/adapters/rack/lib/opentelemetry/adapters/rack/middlewares/tracer_middleware.rb
+++ b/adapters/rack/lib/opentelemetry/adapters/rack/middlewares/tracer_middleware.rb
@@ -83,7 +83,6 @@ module OpenTelemetry
             span = tracer.start_span('http_server.proxy',
                                      with_parent_context: extracted_context,
                                      attributes: {
-                                       'component' => 'http',
                                        'start_time' => request_start_time.to_f
                                      },
                                      kind: :server)
@@ -105,7 +104,6 @@ module OpenTelemetry
 
           def request_span_attributes(env:)
             {
-              'component' => 'http',
               'http.method' => env['REQUEST_METHOD'],
               'http.host' => env['HTTP_HOST'] || 'unknown',
               'http.scheme' => env['rack.url_scheme'],

--- a/adapters/rack/test/opentelemetry/adapters/rack/middlewares/tracer_middleware_test.rb
+++ b/adapters/rack/test/opentelemetry/adapters/rack/middlewares/tracer_middleware_test.rb
@@ -57,7 +57,6 @@ describe OpenTelemetry::Adapters::Rack::Middlewares::TracerMiddleware do
     end
 
     it 'records attributes' do
-      _(first_span.attributes['component']).must_equal 'http'
       _(first_span.attributes['http.method']).must_equal 'GET'
       _(first_span.attributes['http.status_code']).must_equal 200
       _(first_span.attributes['http.status_text']).must_equal 'OK'

--- a/adapters/redis/lib/opentelemetry/adapters/redis/patches/client.rb
+++ b/adapters/redis/lib/opentelemetry/adapters/redis/patches/client.rb
@@ -49,7 +49,6 @@ module OpenTelemetry
             port = options[:port]
 
             {
-              'component' => 'redis',
               'db.type' => 'redis',
               'db.instance' => options[:db].to_s,
               'db.url' => "redis://#{host}:#{port}",

--- a/adapters/redis/test/opentelemetry/adapters/redis/adapter_test.rb
+++ b/adapters/redis/test/opentelemetry/adapters/redis/adapter_test.rb
@@ -36,7 +36,6 @@ describe OpenTelemetry::Adapters::Redis::Adapter do
       ::Redis.new.auth('password')
 
       _(span.name).must_equal 'AUTH'
-      _(span.attributes['component']).must_equal 'redis'
       _(span.attributes['db.type']).must_equal 'redis'
       _(span.attributes['db.instance']).must_equal '0'
       _(span.attributes['db.statement']).must_equal 'AUTH ?'
@@ -54,7 +53,6 @@ describe OpenTelemetry::Adapters::Redis::Adapter do
 
       set_span = exporter.finished_spans.first
       _(set_span.name).must_equal 'SET'
-      _(set_span.attributes['component']).must_equal 'redis'
       _(set_span.attributes['db.type']).must_equal 'redis'
       _(set_span.attributes['db.instance']).must_equal '0'
       _(set_span.attributes['db.statement']).must_equal(
@@ -66,7 +64,6 @@ describe OpenTelemetry::Adapters::Redis::Adapter do
 
       get_span = exporter.finished_spans.last
       _(get_span.name).must_equal 'GET'
-      _(get_span.attributes['component']).must_equal 'redis'
       _(get_span.attributes['db.type']).must_equal 'redis'
       _(get_span.attributes['db.instance']).must_equal '0'
       _(get_span.attributes['db.statement']).must_equal 'GET K'
@@ -82,7 +79,6 @@ describe OpenTelemetry::Adapters::Redis::Adapter do
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'THIS_IS_NOT_A_REDIS_FUNC'
-      _(span.attributes['component']).must_equal 'redis'
       _(span.attributes['db.type']).must_equal 'redis'
       _(span.attributes['db.instance']).must_equal '0'
       _(span.attributes['db.statement']).must_equal(
@@ -108,7 +104,6 @@ describe OpenTelemetry::Adapters::Redis::Adapter do
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'pipeline'
-      _(span.attributes['component']).must_equal 'redis'
       _(span.attributes['db.type']).must_equal 'redis'
       _(span.attributes['db.instance']).must_equal '0'
       _(span.attributes['db.statement']).must_equal "SET v1 0\nINCR v1\nGET v1"

--- a/adapters/restclient/lib/opentelemetry/adapters/restclient/patches/request.rb
+++ b/adapters/restclient/lib/opentelemetry/adapters/restclient/patches/request.rb
@@ -23,7 +23,6 @@ module OpenTelemetry
             span = tracer.start_span(
               "HTTP #{http_method}",
               attributes: {
-                'component' => 'http',
                 'http.method' => http_method,
                 'http.url' => url
               },

--- a/adapters/restclient/test/opentelemetry/adapters/restclient/adapter_test.rb
+++ b/adapters/restclient/test/opentelemetry/adapters/restclient/adapter_test.rb
@@ -49,7 +49,6 @@ describe OpenTelemetry::Adapters::RestClient::Adapter do
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['component']).must_equal 'http'
       _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.status_code']).must_equal 200
       _(span.attributes['http.url']).must_equal 'http://example.com/success'
@@ -67,7 +66,6 @@ describe OpenTelemetry::Adapters::RestClient::Adapter do
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['component']).must_equal 'http'
       _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.status_code']).must_equal 500
       _(span.attributes['http.url']).must_equal 'http://example.com/failure'

--- a/adapters/sinatra/lib/opentelemetry/adapters/sinatra/middlewares/tracer_middleware.rb
+++ b/adapters/sinatra/lib/opentelemetry/adapters/sinatra/middlewares/tracer_middleware.rb
@@ -17,8 +17,7 @@ module OpenTelemetry
           def call(env)
             tracer.in_span(
               env['PATH_INFO'],
-              attributes: { 'component' => 'http',
-                            'http.method' => env['REQUEST_METHOD'],
+              attributes: { 'http.method' => env['REQUEST_METHOD'],
                             'http.url' => env['PATH_INFO'] },
               kind: :server,
               with_parent_context: parent_context(env)

--- a/adapters/sinatra/test/opentelemetry/adapters/sinatra_test.rb
+++ b/adapters/sinatra/test/opentelemetry/adapters/sinatra_test.rb
@@ -83,7 +83,6 @@ describe OpenTelemetry::Adapters::Sinatra do
       get '/one/endpoint'
 
       _(exporter.finished_spans.first.attributes).must_equal(
-        'component' => 'http',
         'http.method' => 'GET',
         'http.url' => '/endpoint',
         'http.status_code' => 200,


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-specification/pull/447

Adapters will later be able to specify what instrumentation library they are, and the exporters can then log this however they want: https://github.com/open-telemetry/opentelemetry-ruby/pull/264