### PR TITLE
Remove span_id from samplers

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/samplers.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/samplers.rb
@@ -53,19 +53,14 @@ module OpenTelemetry
         # Returns a {Result} with {Decision::NOT_RECORD}.
         ALWAYS_OFF = ConstantSampler.new(result: NOT_RECORD, description: 'AlwaysOffSampler')
 
-        # Returns a {Result} with {Decision::RECORD_AND_SAMPLED} if the parent
-        # context is sampled or {Decision::NOT_RECORD} otherwise, or if there
-        # is no parent context.
-        # rubocop:disable Style/Lambda
-        ALWAYS_PARENT = ->(trace_id:, parent_context:, links:, name:, kind:, attributes:) do
-          if parent_context&.trace_flags&.sampled?
-            RECORD_AND_SAMPLED
-          else
-            NOT_RECORD
-          end
+        # Returns a new sampler. It either respects the parent span's sampling
+        # decision or delegates to delegate_sampler for root spans.
+        #
+        # @param [Sampler] delegate_sampler The sampler to which the sampling
+        #   decision is delegated for root spans.
+        def self.parent_or_else(delegate_sampler)
+          ParentOrElse.new(delegate_sampler)
         end
-        # rubocop:enable Style/Lambda
-        # rubocop:enable Lint/UnusedBlockArgument
 
         # Returns a new sampler. The probability of sampling a trace is equal
         # to that of the specified probability.

--- a/sdk/lib/opentelemetry/sdk/trace/samplers.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/samplers.rb
@@ -45,8 +45,6 @@ module OpenTelemetry
 
         private_constant(:RECORD_AND_SAMPLED, :NOT_RECORD, :RECORD, :SAMPLING_HINTS, :APPLY_PROBABILITY_TO_SYMBOLS)
 
-        # rubocop:disable Lint/UnusedBlockArgument
-
         # Returns a {Result} with {Decision::RECORD_AND_SAMPLED}.
         ALWAYS_ON = ConstantSampler.new(result: RECORD_AND_SAMPLED, description: 'AlwaysOnSampler')
 

--- a/sdk/lib/opentelemetry/sdk/trace/samplers.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/samplers.rb
@@ -13,17 +13,16 @@ module OpenTelemetry
     module Trace
       # The Samplers module contains the sampling logic for OpenTelemetry. The
       # reference implementation provides a {ProbabilitySampler}, {ALWAYS_ON},
-      # {ALWAYS_OFF}, and {ALWAYS_PARENT}.
+      # {ALWAYS_OFF}, and {ParentOrElse}.
       #
       # Custom samplers can be provided by SDK users. The required interface is
       # a callable with the signature:
       #
-      #   (trace_id:, span_id:, parent_context:, links:, name:, kind:, attributes:) -> Result
+      #   (trace_id:, parent_context:, links:, name:, kind:, attributes:) -> Result
       #
       # Where:
       #
       # @param [String] trace_id The trace_id of the {Span} to be created.
-      # @param [String] span_id The span_id of the {Span} to be created.
       # @param [OpenTelemetry::Trace::SpanContext] parent_context The
       #   {OpenTelemetry::Trace::SpanContext} of a parent span, typically
       #   extracted from the wire. Can be nil for a root span.
@@ -47,16 +46,16 @@ module OpenTelemetry
         # rubocop:disable Lint/UnusedBlockArgument
 
         # Returns a {Result} with {Decision::RECORD_AND_SAMPLED}.
-        ALWAYS_ON = ->(trace_id:, span_id:, parent_context:, links:, name:, kind:, attributes:) { RECORD_AND_SAMPLED }
+        ALWAYS_ON = ->(trace_id:, parent_context:, links:, name:, kind:, attributes:) { RECORD_AND_SAMPLED }
 
         # Returns a {Result} with {Decision::NOT_RECORD}.
-        ALWAYS_OFF = ->(trace_id:, span_id:, parent_context:, links:, name:, kind:, attributes:) { NOT_RECORD }
+        ALWAYS_OFF = ->(trace_id:, parent_context:, links:, name:, kind:, attributes:) { NOT_RECORD }
 
         # Returns a {Result} with {Decision::RECORD_AND_SAMPLED} if the parent
         # context is sampled or {Decision::NOT_RECORD} otherwise, or if there
         # is no parent context.
         # rubocop:disable Style/Lambda
-        ALWAYS_PARENT = ->(trace_id:, span_id:, parent_context:, links:, name:, kind:, attributes:) do
+        ALWAYS_PARENT = ->(trace_id:, parent_context:, links:, name:, kind:, attributes:) do
           if parent_context&.trace_flags&.sampled?
             RECORD_AND_SAMPLED
           else

--- a/sdk/lib/opentelemetry/sdk/trace/samplers.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/samplers.rb
@@ -6,6 +6,8 @@
 
 require 'opentelemetry/sdk/trace/samplers/decision'
 require 'opentelemetry/sdk/trace/samplers/result'
+require 'opentelemetry/sdk/trace/samplers/constant_sampler'
+require 'opentelemetry/sdk/trace/samplers/parent_or_else'
 require 'opentelemetry/sdk/trace/samplers/probability_sampler'
 
 module OpenTelemetry
@@ -15,10 +17,10 @@ module OpenTelemetry
       # reference implementation provides a {ProbabilitySampler}, {ALWAYS_ON},
       # {ALWAYS_OFF}, and {ParentOrElse}.
       #
-      # Custom samplers can be provided by SDK users. The required interface is
-      # a callable with the signature:
+      # Custom samplers can be provided by SDK users. The required interface is:
       #
-      #   (trace_id:, parent_context:, links:, name:, kind:, attributes:) -> Result
+      #   should_sample?(trace_id:, parent_context:, links:, name:, kind:, attributes:) -> Result
+      #   description -> String
       #
       # Where:
       #
@@ -46,10 +48,10 @@ module OpenTelemetry
         # rubocop:disable Lint/UnusedBlockArgument
 
         # Returns a {Result} with {Decision::RECORD_AND_SAMPLED}.
-        ALWAYS_ON = ->(trace_id:, parent_context:, links:, name:, kind:, attributes:) { RECORD_AND_SAMPLED }
+        ALWAYS_ON = ConstantSampler.new(result: RECORD_AND_SAMPLED, description: 'AlwaysOnSampler')
 
         # Returns a {Result} with {Decision::NOT_RECORD}.
-        ALWAYS_OFF = ->(trace_id:, parent_context:, links:, name:, kind:, attributes:) { NOT_RECORD }
+        ALWAYS_OFF = ConstantSampler.new(result: NOT_RECORD, description: 'AlwaysOffSampler')
 
         # Returns a {Result} with {Decision::RECORD_AND_SAMPLED} if the parent
         # context is sampled or {Decision::NOT_RECORD} otherwise, or if there

--- a/sdk/lib/opentelemetry/sdk/trace/samplers/constant_sampler.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/samplers/constant_sampler.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Trace
+      module Samplers
+        # @api private
+        #
+        # Implements a sampler returning a constant result.
+        class ConstantSampler
+          attr_reader :description
+
+          def initialize(result:, description:)
+            @result = result
+            @description = description
+          end
+
+          # @api private
+          #
+          # See {Samplers#should_sample?}.
+          def should_sample?(trace_id:, parent_context:, links:, name:, kind:, attributes:)
+            # All arguments ignored for sampling decision.
+            @result
+          end
+        end
+      end
+    end
+  end
+end

--- a/sdk/lib/opentelemetry/sdk/trace/samplers/constant_sampler.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/samplers/constant_sampler.rb
@@ -21,7 +21,7 @@ module OpenTelemetry
 
           # @api private
           #
-          # See {Samplers#should_sample?}.
+          # See {Samplers}.
           def should_sample?(trace_id:, parent_context:, links:, name:, kind:, attributes:)
             # All arguments ignored for sampling decision.
             @result

--- a/sdk/lib/opentelemetry/sdk/trace/samplers/constant_sampler.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/samplers/constant_sampler.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2019 OpenTelemetry Authors
+# Copyright The OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/lib/opentelemetry/sdk/trace/samplers/parent_or_else.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/samplers/parent_or_else.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2019 OpenTelemetry Authors
+# Copyright The OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/sdk/lib/opentelemetry/sdk/trace/samplers/parent_or_else.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/samplers/parent_or_else.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Trace
+      module Samplers
+        # @api private
+        #
+        # This is a composite sampler. It either respects the parent span's sampling
+        # decision or delegates to delegate_sampler for root spans.
+        class ParentOrElse
+          def initialize(delegate_sampler)
+            @delegate_sampler = delegate_sampler
+          end
+
+          # @api private
+          #
+          # See {Samplers}.
+          def description
+            "ParentOrElse{#{@delegate_sampler.description}}"
+          end
+
+          # @api private
+          #
+          # See {Samplers}.
+          def should_sample?(trace_id:, parent_context:, links:, name:, kind:, attributes:)
+            if parent_context.nil?
+              @delegate_sampler.should_sample?(trace_id: trace_id, parent_context: parent_context, links: links, name: name, kind: kind, attributes: attributes)
+            elsif parent_context.trace_flags.sampled?
+              RECORD_AND_SAMPLED
+            else
+              NOT_RECORD
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/sdk/lib/opentelemetry/sdk/trace/samplers/probability_sampler.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/samplers/probability_sampler.rb
@@ -25,7 +25,7 @@ module OpenTelemetry
 
           # @api private
           #
-          # See {Samplers#should_sample?}.
+          # See {Samplers}.
           def should_sample?(trace_id:, parent_context:, links:, name:, kind:, attributes:)
             # Ignored for sampling decision: links, name, kind, attributes.
 

--- a/sdk/lib/opentelemetry/sdk/trace/samplers/probability_sampler.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/samplers/probability_sampler.rb
@@ -12,18 +12,21 @@ module OpenTelemetry
         #
         # Implements sampling based on a probability.
         class ProbabilitySampler
+          attr_reader :description
+
           def initialize(probability, ignore_parent:, apply_to_remote_parent:, apply_to_all_spans:)
             @probability = probability
             @id_upper_bound = format('%016x', (probability * (2**64 - 1)).ceil)
             @use_parent_sampled_flag = !ignore_parent
             @apply_to_remote_parent = apply_to_remote_parent
             @apply_to_all_spans = apply_to_all_spans
+            @description = format('ProbabilitySampler{%.6f}', probability)
           end
 
           # @api private
           #
-          # Callable interface for probability sampler. See {Samplers}.
-          def call(trace_id:, span_id:, parent_context:, links:, name:, kind:, attributes:)
+          # See {Samplers#should_sample?}.
+          def should_sample?(trace_id:, parent_context:, links:, name:, kind:, attributes:)
             # Ignored for sampling decision: links, name, kind, attributes.
 
             if sample?(trace_id, parent_context)

--- a/sdk/lib/opentelemetry/sdk/trace/tracer.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/tracer.rb
@@ -42,7 +42,7 @@ module OpenTelemetry
           trace_id ||= OpenTelemetry::Trace.generate_trace_id
           span_id = OpenTelemetry::Trace.generate_span_id
           sampler = OpenTelemetry.tracer_provider.active_trace_config.sampler
-          result = sampler.should_sample?(trace_id: trace_id, span_id: span_id, parent_context: parent_span_context, links: links, name: name, kind: kind, attributes: attributes)
+          result = sampler.should_sample?(trace_id: trace_id, parent_context: parent_span_context, links: links, name: name, kind: kind, attributes: attributes)
 
           internal_create_span(result, name, kind, trace_id, span_id, parent_span_id, attributes, links, start_timestamp, tracestate)
         end

--- a/sdk/lib/opentelemetry/sdk/trace/tracer.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/tracer.rb
@@ -42,7 +42,7 @@ module OpenTelemetry
           trace_id ||= OpenTelemetry::Trace.generate_trace_id
           span_id = OpenTelemetry::Trace.generate_span_id
           sampler = OpenTelemetry.tracer_provider.active_trace_config.sampler
-          result = sampler.call(trace_id: trace_id, span_id: span_id, parent_context: parent_span_context, links: links, name: name, kind: kind, attributes: attributes)
+          result = sampler.should_sample?(trace_id: trace_id, span_id: span_id, parent_context: parent_span_context, links: links, name: name, kind: kind, attributes: attributes)
 
           internal_create_span(result, name, kind, trace_id, span_id, parent_span_id, attributes, links, start_timestamp, tracestate)
         end

--- a/sdk/test/opentelemetry/sdk/trace/samplers_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/samplers_test.rb
@@ -43,7 +43,9 @@ describe OpenTelemetry::SDK::Trace::Samplers do
       result = Result.new(decision: Decision::NOT_RECORD)
       mock_sampler = Minitest::Mock.new
       mock_sampler.expect(:should_sample?, result, [{ trace_id: trace_id, parent_context: nil, links: nil, name: nil, kind: nil, attributes: nil }])
-      _(call_sampler(Samplers.parent_or_else(mock_sampler), parent_context: nil)).wont_be :sampled?
+      OpenTelemetry::Trace.stub :generate_trace_id, trace_id do
+        _(call_sampler(Samplers.parent_or_else(mock_sampler), parent_context: nil)).wont_be :sampled?
+      end
       mock_sampler.verify
     end
   end

--- a/sdk/test/opentelemetry/sdk/trace/samplers_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/samplers_test.rb
@@ -154,10 +154,9 @@ describe OpenTelemetry::SDK::Trace::Samplers do
     format('%032x', id)
   end
 
-  def call_sampler(sampler, trace_id: nil, span_id: nil, parent_context: nil, links: nil, name: nil, kind: nil, attributes: nil)
+  def call_sampler(sampler, trace_id: nil, parent_context: nil, links: nil, name: nil, kind: nil, attributes: nil)
     sampler.call(
       trace_id: trace_id || OpenTelemetry::Trace.generate_trace_id,
-      span_id: span_id || OpenTelemetry::Trace.generate_span_id,
       parent_context: parent_context,
       links: links,
       name: name,

--- a/sdk/test/opentelemetry/sdk/trace/samplers_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/samplers_test.rb
@@ -155,7 +155,7 @@ describe OpenTelemetry::SDK::Trace::Samplers do
   end
 
   def call_sampler(sampler, trace_id: nil, parent_context: nil, links: nil, name: nil, kind: nil, attributes: nil)
-    sampler.call(
+    sampler.should_sample?(
       trace_id: trace_id || OpenTelemetry::Trace.generate_trace_id,
       parent_context: parent_context,
       links: links,

--- a/sdk/test/opentelemetry/sdk/trace/samplers_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/samplers_test.rb
@@ -21,23 +21,30 @@ describe OpenTelemetry::SDK::Trace::Samplers do
     end
   end
 
-  describe '.ALWAYS_PARENT' do
+  describe '.parent_or_else' do
+    let(:sampler) { Samplers.parent_or_else(Samplers::ALWAYS_OFF) }
+
     it 'samples if parent is sampled' do
       context = OpenTelemetry::Trace::SpanContext.new(
         trace_flags: OpenTelemetry::Trace::TraceFlags.from_byte(1)
       )
-      _(call_sampler(Samplers::ALWAYS_PARENT, parent_context: context)).must_be :sampled?
+      _(call_sampler(sampler, parent_context: context)).must_be :sampled?
     end
 
     it 'does not sample if parent is not sampled' do
       context = OpenTelemetry::Trace::SpanContext.new(
         trace_flags: OpenTelemetry::Trace::TraceFlags.from_byte(0)
       )
-      _(call_sampler(Samplers::ALWAYS_PARENT, parent_context: context)).wont_be :sampled?
+      _(call_sampler(sampler, parent_context: context)).wont_be :sampled?
     end
 
-    it 'does not sample root spans' do
-      _(call_sampler(Samplers::ALWAYS_PARENT, parent_context: nil)).wont_be :sampled?
+    it 'delegates sampling of root spans' do
+      trace_id = OpenTelemetry::Trace.generate_trace_id
+      result = Result.new(decision: Decision::NOT_RECORD)
+      mock_sampler = Minitest::Mock.new
+      mock_sampler.expect(:should_sample?, result, [{ trace_id: trace_id, parent_context: nil, links: nil, name: nil, kind: nil, attributes: nil }])
+      _(call_sampler(Samplers.parent_or_else(mock_sampler), parent_context: nil)).wont_be :sampled?
+      mock_sampler.verify
     end
   end
 

--- a/sdk/test/opentelemetry/sdk/trace/tracer_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/tracer_test.rb
@@ -15,7 +15,7 @@ describe OpenTelemetry::SDK::Trace::Tracer do
     OpenTelemetry.tracer_provider.tracer('component-tracer', '1.0.0')
   end
   let(:record_sampler) do
-    ->(trace_id:, span_id:, parent_context:, links:, name:, kind:, attributes:) { Result.new(decision: Decision::RECORD) } # rubocop:disable Lint/UnusedBlockArgument
+    Samplers::ConstantSampler.new(result: Result.new(decision: Decision::RECORD), description: 'RecordSampler')
   end
 
   describe '#name' do
@@ -70,7 +70,7 @@ describe OpenTelemetry::SDK::Trace::Tracer do
       attributes = Minitest::Mock.new
       result = Result.new(decision: Decision::NOT_RECORD)
       mock_sampler = Minitest::Mock.new
-      mock_sampler.expect(:call, result, [{ trace_id: trace_id, span_id: span_id, parent_context: nil, links: links, name: name, kind: kind, attributes: attributes }])
+      mock_sampler.expect(:should_sample?, result, [{ trace_id: trace_id, parent_context: nil, links: links, name: name, kind: kind, attributes: attributes }])
       activate_trace_config TraceConfig.new(sampler: mock_sampler)
       OpenTelemetry::Trace.stub :generate_trace_id, trace_id do
         OpenTelemetry::Trace.stub :generate_span_id, span_id do
@@ -106,7 +106,7 @@ describe OpenTelemetry::SDK::Trace::Tracer do
       sampler_attributes = { '1' => 1 }
       mock_sampler = Minitest::Mock.new
       result = Result.new(decision: Decision::RECORD, attributes: sampler_attributes)
-      mock_sampler.expect(:call, result, [Hash])
+      mock_sampler.expect(:should_sample?, result, [Hash])
       activate_trace_config TraceConfig.new(sampler: mock_sampler)
       span = tracer.start_root_span('op', attributes: { '1' => 0, '2' => 2 })
       _(span.attributes).must_equal('1' => 1, '2' => 2)
@@ -204,7 +204,7 @@ describe OpenTelemetry::SDK::Trace::Tracer do
       attributes = Minitest::Mock.new
       result = Result.new(decision: Decision::NOT_RECORD)
       mock_sampler = Minitest::Mock.new
-      mock_sampler.expect(:call, result, [{ trace_id: span_context.trace_id, span_id: span_id, parent_context: span_context, links: links, name: name, kind: kind, attributes: attributes }])
+      mock_sampler.expect(:should_sample?, result, [{ trace_id: span_context.trace_id, parent_context: span_context, links: links, name: name, kind: kind, attributes: attributes }])
       activate_trace_config TraceConfig.new(sampler: mock_sampler)
       OpenTelemetry::Trace.stub :generate_span_id, span_id do
         tracer.start_span(name, with_parent_context: context, attributes: attributes, links: links, kind: kind)
@@ -246,7 +246,7 @@ describe OpenTelemetry::SDK::Trace::Tracer do
       sampler_attributes = { '1' => 1 }
       mock_sampler = Minitest::Mock.new
       result = Result.new(decision: Decision::RECORD, attributes: sampler_attributes)
-      mock_sampler.expect(:call, result, [Hash])
+      mock_sampler.expect(:should_sample?, result, [Hash])
       activate_trace_config TraceConfig.new(sampler: mock_sampler)
       span = tracer.start_span('op', with_parent_context: context, attributes: { '1' => 0, '2' => 2 })
       _(span.attributes).must_equal('1' => 1, '2' => 2)

--- a/sdk/test/opentelemetry/sdk/trace/tracer_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/tracer_test.rb
@@ -64,7 +64,6 @@ describe OpenTelemetry::SDK::Trace::Tracer do
     it 'calls the sampler with all parameters except parent_context' do
       links = Minitest::Mock.new
       name = 'span'
-      span_id = OpenTelemetry::Trace.generate_span_id
       trace_id = OpenTelemetry::Trace.generate_trace_id
       kind = Minitest::Mock.new
       attributes = Minitest::Mock.new
@@ -73,9 +72,7 @@ describe OpenTelemetry::SDK::Trace::Tracer do
       mock_sampler.expect(:should_sample?, result, [{ trace_id: trace_id, parent_context: nil, links: links, name: name, kind: kind, attributes: attributes }])
       activate_trace_config TraceConfig.new(sampler: mock_sampler)
       OpenTelemetry::Trace.stub :generate_trace_id, trace_id do
-        OpenTelemetry::Trace.stub :generate_span_id, span_id do
-          tracer.start_root_span(name, attributes: attributes, links: links, kind: kind)
-        end
+        tracer.start_root_span(name, attributes: attributes, links: links, kind: kind)
       end
       mock_sampler.verify
     end
@@ -199,16 +196,13 @@ describe OpenTelemetry::SDK::Trace::Tracer do
     it 'calls the sampler with all parameters' do
       links = Minitest::Mock.new
       name = 'span'
-      span_id = OpenTelemetry::Trace.generate_span_id
       kind = Minitest::Mock.new
       attributes = Minitest::Mock.new
       result = Result.new(decision: Decision::NOT_RECORD)
       mock_sampler = Minitest::Mock.new
       mock_sampler.expect(:should_sample?, result, [{ trace_id: span_context.trace_id, parent_context: span_context, links: links, name: name, kind: kind, attributes: attributes }])
       activate_trace_config TraceConfig.new(sampler: mock_sampler)
-      OpenTelemetry::Trace.stub :generate_span_id, span_id do
-        tracer.start_span(name, with_parent_context: context, attributes: attributes, links: links, kind: kind)
-      end
+      tracer.start_span(name, with_parent_context: context, attributes: attributes, links: links, kind: kind)
       mock_sampler.verify
     end
 


### PR DESCRIPTION
Fixes #269 
Fixes #267 

This also changes the `Sampler` interface to match the spec. Specifically, we did not provide a `description` method, and the requirement to add it removes much of the value of providing a `Callable` interface, so this also renames the `call` method to `should_sample?` to match the spec.