### PR TITLE
add tracestate to span data

### DIFF
--- a/exporters/jaeger/.rubocop.yml
+++ b/exporters/jaeger/.rubocop.yml
@@ -10,7 +10,7 @@ Metrics/AbcSize:
 Metrics/LineLength:
   Enabled: false
 Metrics/MethodLength:
-  Max: 20
+  Max: 21
 Metrics/ParameterLists:
   Enabled: false
 Naming/FileName:

--- a/exporters/jaeger/test/opentelemetry/exporters/jaeger/exporter/span_encoder_test.rb
+++ b/exporters/jaeger/test/opentelemetry/exporters/jaeger/exporter/span_encoder_test.rb
@@ -60,7 +60,7 @@ describe OpenTelemetry::Exporters::Jaeger::Exporter::SpanEncoder do
     )
   end
 
-  def create_span_data(attributes: nil, events: nil, links: nil, trace_id: OpenTelemetry::Trace.generate_trace_id, trace_flags: OpenTelemetry::Trace::TraceFlags::DEFAULT)
+  def create_span_data(attributes: nil, events: nil, links: nil, trace_id: OpenTelemetry::Trace.generate_trace_id, trace_flags: OpenTelemetry::Trace::TraceFlags::DEFAULT, tracestate: nil)
     OpenTelemetry::SDK::Trace::SpanData.new(
       '',
       nil,
@@ -79,7 +79,8 @@ describe OpenTelemetry::Exporters::Jaeger::Exporter::SpanEncoder do
       nil,
       OpenTelemetry::Trace.generate_span_id,
       trace_id,
-      trace_flags
+      trace_flags,
+      tracestate
     )
   end
 end

--- a/exporters/jaeger/test/opentelemetry/exporters/jaeger/exporter_test.rb
+++ b/exporters/jaeger/test/opentelemetry/exporters/jaeger/exporter_test.rb
@@ -81,9 +81,9 @@ describe OpenTelemetry::Exporters::Jaeger::Exporter do
                        total_recorded_attributes: 0, total_recorded_events: 0, total_recorded_links: 0, start_timestamp: Time.now,
                        end_timestamp: Time.now, attributes: nil, links: nil, events: nil, library_resource: nil, instrumentation_library: nil,
                        span_id: OpenTelemetry::Trace.generate_span_id, trace_id: OpenTelemetry::Trace.generate_trace_id,
-                       trace_flags: OpenTelemetry::Trace::TraceFlags::DEFAULT)
+                       trace_flags: OpenTelemetry::Trace::TraceFlags::DEFAULT, tracestate: nil)
     OpenTelemetry::SDK::Trace::SpanData.new(name, kind, status, parent_span_id, child_count, total_recorded_attributes,
                                             total_recorded_events, total_recorded_links, start_timestamp, end_timestamp,
-                                            attributes, links, events, library_resource, instrumentation_library, span_id, trace_id, trace_flags)
+                                            attributes, links, events, library_resource, instrumentation_library, span_id, trace_id, trace_flags, tracestate)
   end
 end

--- a/sdk/.rubocop.yml
+++ b/sdk/.rubocop.yml
@@ -8,7 +8,7 @@ Metrics/AbcSize:
 Metrics/LineLength:
   Enabled: false
 Metrics/MethodLength:
-  Max: 20
+  Max: 21
 Metrics/ParameterLists:
   Enabled: false
 Naming/FileName:

--- a/sdk/lib/opentelemetry/sdk/trace/span.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span.rb
@@ -240,7 +240,8 @@ module OpenTelemetry
             @instrumentation_library,
             context.span_id,
             context.trace_id,
-            context.trace_flags
+            context.trace_flags,
+            context.tracestate
           )
         end
 

--- a/sdk/lib/opentelemetry/sdk/trace/span_data.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span_data.rb
@@ -27,7 +27,8 @@ module OpenTelemetry
                             :instrumentation_library,
                             :span_id,
                             :trace_id,
-                            :trace_flags)
+                            :trace_flags,
+                            :tracestate)
     end
   end
 end

--- a/sdk/test/integration/global_tracer_configurations_test.rb
+++ b/sdk/test/integration/global_tracer_configurations_test.rb
@@ -38,6 +38,12 @@ describe OpenTelemetry::SDK, 'global_tracer_configurations' do
       it 'are all SpanData' do
         _(finished_spans.collect(&:class).uniq).must_equal([sdk::Trace::SpanData])
       end
+
+      it 'are all SpanData which have trace_flags and tracestate span context' do
+        finish_span_keys = finished_spans.collect(&:members).flatten.uniq
+        _(finish_span_keys).must_include(:tracestate)
+        _(finish_span_keys).must_include(:trace_flags)
+      end
     end
   end
 

--- a/sdk/test/integration/global_tracer_configurations_test.rb
+++ b/sdk/test/integration/global_tracer_configurations_test.rb
@@ -16,10 +16,11 @@ describe OpenTelemetry::SDK, 'global_tracer_configurations' do
     end
   end
   let(:tracer) { provider.tracer(__FILE__, sdk::VERSION) }
+  let(:parent_context) { nil }
   let(:finished_spans) { exporter.finished_spans }
 
   before do
-    tracer.in_span('root') do
+    tracer.in_span('root', with_parent_context: parent_context) do
       tracer.in_span('child1') {}
       tracer.in_span('child2') {}
     end
@@ -38,12 +39,6 @@ describe OpenTelemetry::SDK, 'global_tracer_configurations' do
       it 'are all SpanData' do
         _(finished_spans.collect(&:class).uniq).must_equal([sdk::Trace::SpanData])
       end
-
-      it 'are all SpanData which have trace_flags and tracestate span context' do
-        finish_span_keys = finished_spans.collect(&:members).flatten.uniq
-        _(finish_span_keys).must_include(:tracestate)
-        _(finish_span_keys).must_include(:trace_flags)
-      end
     end
   end
 
@@ -52,6 +47,27 @@ describe OpenTelemetry::SDK, 'global_tracer_configurations' do
 
     it "doesn't crash" do
       finished_spans
+    end
+  end
+
+  describe 'using tracestate in extracted span context' do
+    let(:mock_tracestate) { 'vendor_key=vendor_value' }
+    let(:parent_span_context) { OpenTelemetry::Trace::SpanContext.new(tracestate: mock_tracestate) }
+    let(:parent_context) do
+      OpenTelemetry::Context.empty.set_value(
+        OpenTelemetry::Trace::Propagation::ContextKeys.extracted_span_context_key,
+        parent_span_context
+      )
+    end
+
+    describe '#finished_spans' do
+      it 'propogates tracestate through span lifecycle into SpanData' do
+        finish_span_keys = finished_spans.collect(&:members).flatten.uniq
+
+        _(finish_span_keys).must_include(:tracestate)
+
+        finished_spans.first.tracestate.must_equal(mock_tracestate)
+      end
     end
   end
 end


### PR DESCRIPTION
#### summary

This PR adds a span's `context.tracestate` to the SpanData Struct which gets created by `to_span_data` and is used in conjunction with trace processors and exporters.  

#### description

The reasoning behind this is that there may be some vendor specific arbitrary metadata which is generally passed via distributed tracing headers and, as far as I understand, would live on the `context.tracestate` when extracted. 

Examples of this could be: 
 - baggage items from open tracing, which can be [extracted/injected via http headers](https://opentracing.io/docs/overview/inject-extract/). although this isn't particularly popular, [it's implemented](https://github.com/lightstep/lightstep-tracer-objc/blob/e7e0b6fd68d05f032970ff0cc548c27b877854ba/Pod/Classes/LSTracer.m#L151) in some different vendors. 
- For vendor specific metadata, which is how [opentelemetry-python is using tracestate](https://github.com/open-telemetry/opentelemetry-python/blob/3fa15aa2ab86a8808406f0bc07c18732bf1bc7b0/ext/opentelemetry-ext-datadog/src/opentelemetry/ext/datadog/propagator.py#L77) 

In opentelemetry-ruby, however, for exporters which encode these traces in a vendor specific format, those details in the tracestate are not available since they are not passed into the SpanData struct. This PR adds them to the SpanData struct and adds a very simple test to validate it.

#### notes

Let me know if I've missed anything here, tried to go through everything, but still getting familiar with the repo, so it's possible i've missed a test or usage somewhere.