### PR TITLE
add sampler to SpanData

### DIFF
--- a/exporters/jaeger/.rubocop.yml
+++ b/exporters/jaeger/.rubocop.yml
@@ -10,7 +10,7 @@ Metrics/AbcSize:
 Metrics/LineLength:
   Enabled: false
 Metrics/MethodLength:
-  Max: 21
+  Max: 22
 Metrics/ParameterLists:
   Enabled: false
 Naming/FileName:

--- a/exporters/jaeger/test/opentelemetry/exporters/jaeger/exporter/span_encoder_test.rb
+++ b/exporters/jaeger/test/opentelemetry/exporters/jaeger/exporter/span_encoder_test.rb
@@ -60,7 +60,7 @@ describe OpenTelemetry::Exporters::Jaeger::Exporter::SpanEncoder do
     )
   end
 
-  def create_span_data(attributes: nil, events: nil, links: nil, trace_id: OpenTelemetry::Trace.generate_trace_id, trace_flags: OpenTelemetry::Trace::TraceFlags::DEFAULT, tracestate: nil)
+  def create_span_data(attributes: nil, events: nil, links: nil, trace_id: OpenTelemetry::Trace.generate_trace_id, trace_flags: OpenTelemetry::Trace::TraceFlags::DEFAULT, tracestate: nil, sampler: OpenTelemetry::SDK::Trace::Config::TraceConfig::DEFAULT.sampler)
     OpenTelemetry::SDK::Trace::SpanData.new(
       '',
       nil,
@@ -80,7 +80,8 @@ describe OpenTelemetry::Exporters::Jaeger::Exporter::SpanEncoder do
       OpenTelemetry::Trace.generate_span_id,
       trace_id,
       trace_flags,
-      tracestate
+      tracestate,
+      sampler
     )
   end
 end

--- a/exporters/jaeger/test/opentelemetry/exporters/jaeger/exporter_test.rb
+++ b/exporters/jaeger/test/opentelemetry/exporters/jaeger/exporter_test.rb
@@ -80,9 +80,9 @@ describe OpenTelemetry::Exporters::Jaeger::Exporter do
                        total_recorded_attributes: 0, total_recorded_events: 0, total_recorded_links: 0, start_timestamp: Time.now,
                        end_timestamp: Time.now, attributes: nil, links: nil, events: nil, library_resource: nil, instrumentation_library: nil,
                        span_id: OpenTelemetry::Trace.generate_span_id, trace_id: OpenTelemetry::Trace.generate_trace_id,
-                       trace_flags: OpenTelemetry::Trace::TraceFlags::DEFAULT, tracestate: nil)
+                       trace_flags: OpenTelemetry::Trace::TraceFlags::DEFAULT, tracestate: nil, sampler: OpenTelemetry::SDK::Trace::Config::TraceConfig::DEFAULT.sampler)
     OpenTelemetry::SDK::Trace::SpanData.new(name, kind, status, parent_span_id, child_count, total_recorded_attributes,
                                             total_recorded_events, total_recorded_links, start_timestamp, end_timestamp,
-                                            attributes, links, events, library_resource, instrumentation_library, span_id, trace_id, trace_flags, tracestate)
+                                            attributes, links, events, library_resource, instrumentation_library, span_id, trace_id, trace_flags, tracestate, sampler)
   end
 end

--- a/sdk/.rubocop.yml
+++ b/sdk/.rubocop.yml
@@ -8,7 +8,7 @@ Metrics/AbcSize:
 Metrics/LineLength:
   Enabled: false
 Metrics/MethodLength:
-  Max: 21
+  Max: 22
 Metrics/ParameterLists:
   Enabled: false
 Naming/FileName:

--- a/sdk/lib/opentelemetry/sdk/trace/span.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span.rb
@@ -241,12 +241,13 @@ module OpenTelemetry
             context.span_id,
             context.trace_id,
             context.trace_flags,
-            context.tracestate
+            context.tracestate,
+            @trace_config.sampler
           )
         end
 
         # @api private
-        def initialize(context, name, kind, parent_span_id, trace_config, span_processor, attributes, links, start_timestamp, library_resource, instrumentation_library) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+        def initialize(context, name, kind, parent_span_id, trace_config, span_processor, attributes, links, start_timestamp, library_resource, instrumentation_library) # rubocop:disable Metrics/AbcSize
           super(span_context: context)
           @mutex = Mutex.new
           @name = name

--- a/sdk/lib/opentelemetry/sdk/trace/span_data.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span_data.rb
@@ -28,7 +28,8 @@ module OpenTelemetry
                             :span_id,
                             :trace_id,
                             :trace_flags,
-                            :tracestate)
+                            :tracestate,
+                            :sampler)
     end
   end
 end


### PR DESCRIPTION
### Summary

This PR adds the span's `trace_config.sampler` to the SpanData struct. The motivation behind this is that an exporter may be required to know the type of sampling that has been applied to span's to be exported, as some sampler's will choose to neither sample nor record certain spans, and those spans will not be passed to a span processor (and, by extension, the exporter). By making the sampler available to the SpanData struct, this information can be read/parsed from the `sampler.description`.

Specifically, the ProbabilitySampler [does not record span's it does not sample](https://github.com/open-telemetry/opentelemetry-ruby/blob/a76c4285729caee021fb5557b21f696f62ba4c6d/sdk/lib/opentelemetry/sdk/trace/samplers/probability_sampler.rb#L35). So knowing the `probability` rate which of spans it did choose to sample, [contained in the description](https://github.com/open-telemetry/opentelemetry-ruby/blob/a76c4285729caee021fb5557b21f696f62ba4c6d/sdk/lib/opentelemetry/sdk/trace/samplers/probability_sampler.rb#L23), can help vendor specific exporter's convey information so that they can then more accurately "upscale" metrics related to the exported span's, such as "hits" or "errors".

This PR relates to a conversation in a related PR, found here: https://github.com/open-telemetry/opentelemetry-ruby/pull/273#issuecomment-647854791

### Notes

- If there is some alternative way to access the sampler description in a span processor or exporter I would be open to using that approach, this was the only way I could think of. I would prefer to avoid bloating the SpanData struct with unnecessary info, but do believe that information about the sampler's logic which created the span could be useful at export time.



