### PR TITLE
prepare adapter bugfix release

### DIFF
--- a/adapters/all/lib/opentelemetry/adapters/all/version.rb
+++ b/adapters/all/lib/opentelemetry/adapters/all/version.rb
@@ -7,7 +7,7 @@
 module OpenTelemetry
   module Adapters
     module All
-      VERSION = '0.4.0'
+      VERSION = '0.4.1'
     end
   end
 end

--- a/adapters/all/opentelemetry-adapters-all.gemspec
+++ b/adapters/all/opentelemetry-adapters-all.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-adapters-redis', '~> 0.4.0'
   spec.add_dependency 'opentelemetry-adapters-restclient', '~> 0.4.0'
   spec.add_dependency 'opentelemetry-adapters-sidekiq', '~> 0.4.0'
-  spec.add_dependency 'opentelemetry-adapters-sinatra', '~> 0.4.0'
+  spec.add_dependency 'opentelemetry-adapters-sinatra', '~> 0.4.1'
 
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'minitest', '~> 5.0'

--- a/adapters/sinatra/lib/opentelemetry/adapters/sinatra/version.rb
+++ b/adapters/sinatra/lib/opentelemetry/adapters/sinatra/version.rb
@@ -7,7 +7,7 @@
 module OpenTelemetry
   module Adapters
     module Sinatra
-      VERSION = '0.4.0'
+      VERSION = '0.4.1'
     end
   end
 end


### PR DESCRIPTION
This PR bumps the versions of the sinatra adapter and the adapters-all gem. The bugfix release will include the changes introduced in #275.

cc: @mat-rumian