### PR TITLE
Use otcorrelations for correlation context header

### DIFF
--- a/api/lib/opentelemetry/correlation_context/propagation.rb
+++ b/api/lib/opentelemetry/correlation_context/propagation.rb
@@ -18,10 +18,10 @@ module OpenTelemetry
       TEXT_EXTRACTOR = TextExtractor.new
       TEXT_INJECTOR = TextInjector.new
       RACK_EXTRACTOR = TextExtractor.new(
-        correlation_context_key: 'HTTP_CORRELATION_CONTEXT'
+        correlation_context_key: 'HTTP_OTCORRELATIONS'
       )
       RACK_INJECTOR = TextInjector.new(
-        correlation_context_key: 'HTTP_CORRELATION_CONTEXT'
+        correlation_context_key: 'HTTP_OTCORRELATIONS'
       )
 
       private_constant :TEXT_INJECTOR, :TEXT_EXTRACTOR, :RACK_INJECTOR,

--- a/api/lib/opentelemetry/correlation_context/propagation/text_extractor.rb
+++ b/api/lib/opentelemetry/correlation_context/propagation/text_extractor.rb
@@ -19,7 +19,7 @@ module OpenTelemetry
         # @param [String] correlation_context_key The correlation context header
         #   key used in the carrier
         # @return [TextExtractor]
-        def initialize(correlation_context_key: 'Correlation-Context')
+        def initialize(correlation_context_key: 'otcorrelations')
           @correlation_context_key = correlation_context_key
         end
 

--- a/api/lib/opentelemetry/correlation_context/propagation/text_injector.rb
+++ b/api/lib/opentelemetry/correlation_context/propagation/text_injector.rb
@@ -19,7 +19,7 @@ module OpenTelemetry
         # @param [String] correlation_context_header_key The correlation context header
         #   key used in the carrier
         # @return [TextInjector]
-        def initialize(correlation_context_key: 'Correlation-Context')
+        def initialize(correlation_context_key: 'otcorrelations')
           @correlation_context_key = correlation_context_key
         end
 

--- a/api/test/opentelemetry/correlation_context/text_extractor_test.rb
+++ b/api/test/opentelemetry/correlation_context/text_extractor_test.rb
@@ -11,7 +11,7 @@ describe OpenTelemetry::CorrelationContext::Propagation::TextExtractor do
     OpenTelemetry::CorrelationContext::Propagation::TextExtractor.new
   end
   let(:header_key) do
-    'Correlation-Context'
+    'otcorrelations'
   end
   let(:context_key) do
     OpenTelemetry::CorrelationContext::Propagation::ContextKeys.correlation_context_key

--- a/api/test/opentelemetry/correlation_context/text_injector_test.rb
+++ b/api/test/opentelemetry/correlation_context/text_injector_test.rb
@@ -11,7 +11,7 @@ describe OpenTelemetry::CorrelationContext::Propagation::TextInjector do
     OpenTelemetry::CorrelationContext::Propagation::TextInjector.new
   end
   let(:header_key) do
-    'Correlation-Context'
+    'otcorrelations'
   end
   let(:context_key) do
     OpenTelemetry::CorrelationContext::Propagation::ContextKeys.correlation_context_key


### PR DESCRIPTION
Fixes #289. OpenTelemetry has decided to use a custom header for propagating correlation context (see: https://github.com/open-telemetry/opentelemetry-specification/pull/517). This PR changes the header name from `Correlation-Context` to `otcorrelations`.