### PR TITLE
prepare for 0.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## Alpha v0.5.1
+
+### Bug Fix
+
+* [#299](https://github.com/open-telemetry/opentelemetry-ruby/pull/299) Fix probabilility sampler. ([@fbogsany](https://github.com/fbogsany))
+
+* [#301](https://github.com/open-telemetry/opentelemetry-ruby/pull/301) Fix require 'opentelemetry/instrumentation'. ([@fbogsany](https://github.com/fbogsany))
+
 ## Alpha v0.5.0
 
 ### Breaking Change

--- a/api/lib/opentelemetry/version.rb
+++ b/api/lib/opentelemetry/version.rb
@@ -6,5 +6,5 @@
 
 module OpenTelemetry
   ## Current OpenTelemetry version
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end

--- a/sdk/lib/opentelemetry/sdk/version.rb
+++ b/sdk/lib/opentelemetry/sdk/version.rb
@@ -7,6 +7,6 @@
 module OpenTelemetry
   module SDK
     ## Current OpenTelemetry version
-    VERSION = '0.5.0'
+    VERSION = '0.5.1'
   end
 end


### PR DESCRIPTION
This PR bumps the API and SDK versions and adds changelog entires in preparation for a patch release that will address #298 and #300. After this merges I can cut a new gem versions for opentelemetry-api and opentelemetry-sdk.