### PR TITLE
Fix serialized SpanData's span_id and trace_id

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/span.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span.rb
@@ -238,8 +238,8 @@ module OpenTelemetry
             @events,
             @library_resource,
             @instrumentation_library,
-            context.span_id,
-            context.trace_id,
+            context.span_id.unpack1('H*'),
+            context.trace_id.unpack1('H*'),
             context.trace_flags,
             context.tracestate
           )

--- a/sdk/lib/opentelemetry/sdk/trace/span.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span.rb
@@ -226,7 +226,7 @@ module OpenTelemetry
             @name,
             @kind,
             @status,
-            @parent_span_id,
+            @parent_span_id.unpack1('H*'),
             @child_count,
             @total_recorded_attributes,
             @total_recorded_events,


### PR DESCRIPTION
in version 0.5.1 of opentelemetry-ruby we changed the way we generate the `trace_id` and `span_id`
now the correspondent generators return a raw random binary string which not unpacked.
I'm not sure about the effect of this change for the entire system, but its effect at least for some of the SpanExporters which fail to serialize it.
this PR should fix the SpanData serialization by using `unpack1('H*')` for those ids, but we may do it in a higher level (maybe in `SpanContext` initializer?)