### PR TITLE
Fix ProbabilitySampler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 **/*.gem
 **/.bundle
 **/.DS_Store
+**/.byebug_history
 
 # Appraisals
 instrumentation/**/*.gemfile.lock

--- a/sdk/lib/opentelemetry/sdk/trace/samplers/probability_sampler.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/samplers/probability_sampler.rb
@@ -14,12 +14,9 @@ module OpenTelemetry
         class ProbabilitySampler
           attr_reader :description
 
-          def initialize(probability, ignore_parent:, apply_to_remote_parent:, apply_to_all_spans:)
+          def initialize(probability)
             @probability = probability
             @id_upper_bound = (probability * (2**64 - 1)).ceil
-            @use_parent_sampled_flag = !ignore_parent
-            @apply_to_remote_parent = apply_to_remote_parent
-            @apply_to_all_spans = apply_to_all_spans
             @description = format('ProbabilitySampler{%.6f}', probability)
           end
 
@@ -27,9 +24,9 @@ module OpenTelemetry
           #
           # See {Samplers}.
           def should_sample?(trace_id:, parent_context:, links:, name:, kind:, attributes:)
-            # Ignored for sampling decision: links, name, kind, attributes.
+            # Ignored for sampling decision: parent_context:, links, name, kind, attributes.
 
-            if sample?(trace_id, parent_context)
+            if sample?(trace_id)
               RECORD_AND_SAMPLED
             else
               NOT_RECORD
@@ -38,23 +35,7 @@ module OpenTelemetry
 
           private
 
-          def sample?(trace_id, parent_context)
-            if parent_context.nil?
-              sample_trace_id?(trace_id)
-            else
-              parent_sampled?(parent_context) || sample_trace_id_for_child?(parent_context, trace_id)
-            end
-          end
-
-          def parent_sampled?(parent_context)
-            @use_parent_sampled_flag && parent_context.trace_flags.sampled?
-          end
-
-          def sample_trace_id_for_child?(parent_context, trace_id)
-            (@apply_to_all_spans || (@apply_to_remote_parent && parent_context.remote?)) && sample_trace_id?(trace_id)
-          end
-
-          def sample_trace_id?(trace_id)
+          def sample?(trace_id)
             @probability == 1.0 || trace_id[8, 8].unpack1('Q>') < @id_upper_bound
           end
         end

--- a/sdk/test/opentelemetry/sdk/trace/samplers_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/samplers_test.rb
@@ -50,6 +50,72 @@ describe OpenTelemetry::SDK::Trace::Samplers do
     end
   end
 
+  describe '.parent_or_always_on' do
+    let(:sampler) { Samplers.parent_or_always_on }
+
+    it 'samples if parent is sampled' do
+      context = OpenTelemetry::Trace::SpanContext.new(
+        trace_flags: OpenTelemetry::Trace::TraceFlags.from_byte(1)
+      )
+      _(call_sampler(sampler, parent_context: context)).must_be :sampled?
+    end
+
+    it 'does not sample if parent is not sampled' do
+      context = OpenTelemetry::Trace::SpanContext.new(
+        trace_flags: OpenTelemetry::Trace::TraceFlags.from_byte(0)
+      )
+      _(call_sampler(sampler, parent_context: context)).wont_be :sampled?
+    end
+
+    it 'delegates sampling of root spans' do
+      _(call_sampler(sampler)).must_be :sampled?
+    end
+  end
+
+  describe '.parent_or_always_off' do
+    let(:sampler) { Samplers.parent_or_always_off }
+
+    it 'samples if parent is sampled' do
+      context = OpenTelemetry::Trace::SpanContext.new(
+        trace_flags: OpenTelemetry::Trace::TraceFlags.from_byte(1)
+      )
+      _(call_sampler(sampler, parent_context: context)).must_be :sampled?
+    end
+
+    it 'does not sample if parent is not sampled' do
+      context = OpenTelemetry::Trace::SpanContext.new(
+        trace_flags: OpenTelemetry::Trace::TraceFlags.from_byte(0)
+      )
+      _(call_sampler(sampler, parent_context: context)).wont_be :sampled?
+    end
+
+    it 'delegates sampling of root spans' do
+      _(call_sampler(sampler)).wont_be :sampled?
+    end
+  end
+
+  describe '.parent_or_probability' do
+    let(:sampler) { Samplers.parent_or_probability(2.0 / (2**64 - 1)) }
+
+    it 'samples if parent is sampled' do
+      context = OpenTelemetry::Trace::SpanContext.new(
+        trace_flags: OpenTelemetry::Trace::TraceFlags.from_byte(1)
+      )
+      _(call_sampler(sampler, parent_context: context)).must_be :sampled?
+    end
+
+    it 'does not sample if parent is not sampled' do
+      context = OpenTelemetry::Trace::SpanContext.new(
+        trace_flags: OpenTelemetry::Trace::TraceFlags.from_byte(0)
+      )
+      _(call_sampler(sampler, parent_context: context)).wont_be :sampled?
+    end
+
+    it 'delegates sampling of root spans' do
+      _(call_sampler(sampler, trace_id: trace_id(1))).must_be :sampled?
+    end
+  end
+
   describe '.probability' do
     let(:sampler) { Samplers.probability(Float::MIN) }
     let(:context) do
@@ -58,13 +124,8 @@ describe OpenTelemetry::SDK::Trace::Samplers do
       )
     end
 
-    it 'respects parent sampling' do
-      result = call_sampler(sampler, parent_context: context)
-      _(result).must_be :sampled?
-    end
-
-    it 'ignores parent sampling if ignore_parent' do
-      sampler = Samplers.probability(Float::MIN, ignore_parent: true)
+    it 'ignores parent sampling' do
+      sampler = Samplers.probability(Float::MIN)
       result = call_sampler(sampler, parent_context: context, trace_id: trace_id(123))
       _(result).wont_be :sampled?
     end
@@ -84,50 +145,6 @@ describe OpenTelemetry::SDK::Trace::Samplers do
       sampler = Samplers.probability(0)
       result = call_sampler(sampler, trace_id: trace_id(1))
       _(result).wont_be :sampled?
-    end
-
-    it 'does not sample a remote parent if apply_probability_to == :root_spans' do
-      context = OpenTelemetry::Trace::SpanContext.new(
-        trace_flags: OpenTelemetry::Trace::TraceFlags.from_byte(0),
-        remote: true
-      )
-      sampler = Samplers.probability(1, apply_probability_to: :root_spans)
-      result = call_sampler(sampler, parent_context: context)
-      _(result).wont_be :sampled?
-    end
-
-    it 'samples a local child span if apply_probability_to == :all_spans' do
-      sampler = Samplers.probability(1, apply_probability_to: :all_spans)
-      result = call_sampler(sampler, parent_context: context, trace_id: trace_id(1))
-      _(result).must_be :sampled?
-    end
-
-    it 'samples a remote parent if apply_probability_to == :root_spans_and_remote_parent' do
-      context = OpenTelemetry::Trace::SpanContext.new(
-        trace_flags: OpenTelemetry::Trace::TraceFlags.from_byte(0),
-        remote: true
-      )
-      sampler = Samplers.probability(1, apply_probability_to: :root_spans_and_remote_parent)
-      result = call_sampler(sampler, parent_context: context)
-      _(result).must_be :sampled?
-    end
-
-    it 'does not sample a local child span if apply_probability_to == :root_spans_and_remote_parent' do
-      context = OpenTelemetry::Trace::SpanContext.new(trace_flags: OpenTelemetry::Trace::TraceFlags.from_byte(0))
-      sampler = Samplers.probability(1, apply_probability_to: :root_spans_and_remote_parent)
-      result = call_sampler(sampler, parent_context: context, trace_id: trace_id(1))
-      _(result).wont_be :sampled?
-    end
-
-    it 'does not sample a local child span if apply_probability_to == :root_spans' do
-      context = OpenTelemetry::Trace::SpanContext.new(trace_flags: OpenTelemetry::Trace::TraceFlags.from_byte(0))
-      sampler = Samplers.probability(1, apply_probability_to: :root_spans)
-      result = call_sampler(sampler, parent_context: context, trace_id: trace_id(1))
-      _(result).wont_be :sampled?
-    end
-
-    it 'does not allow invalid symbols in apply_probability_to' do
-      _(proc { Samplers.probability(1, apply_probability_to: :foo) }).must_raise(ArgumentError)
     end
 
     it 'samples the smallest probability larger than the smallest trace_id' do


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-specification/pull/704 simplified the probability sampler, relying on `parent_or_else` to respect the parent context's sampled flag, if required. This PR updates the probability sampler accordingly.

#321 highlighted that actually setting the sampler to something other than the default is cumbersome. There are 2 levels of complexity here:
1. indirection through the TracerProvider's active trace config
2. deep nesting of modules.

This also fixes 2. above by adding a few helpers for the common cases of `parent_or_else` delegating to one of the standard samplers. E.g.
```ruby
delegate = OpenTelemetry::SDK::Trace::Samplers.probability(0.001)
OpenTelemetry::SDK::Trace::Samplers.parent_or_else(delegate)
```
becomes:
```ruby
OpenTelemetry::SDK::Trace::Samplers.parent_or_probability(0.001)
```