### PR TITLE
Fix gemspec name for resource detector

### DIFF
--- a/resource_detectors/lib/opentelemetry-resource_detectors.rb
+++ b/resource_detectors/lib/opentelemetry-resource_detectors.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require_relative './opentelemetry/resource/detectors'

--- a/resource_detectors/opentelemetry-resource_detectors.gemspec
+++ b/resource_detectors/opentelemetry-resource_detectors.gemspec
@@ -9,7 +9,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'opentelemetry/resource/detectors/version'
 
 Gem::Specification.new do |spec|
-  spec.name        = 'opentelemetry-resource-detectors'
+  spec.name        = 'opentelemetry-resource_detectors'
   spec.version     = OpenTelemetry::Resource::Detectors::VERSION
   spec.authors     = ['OpenTelemetry Authors']
   spec.email       = ['cncf-opentelemetry-contributors@lists.cncf.io']


### PR DESCRIPTION
Missing conventional ruby file matching gem name in the `/lib` folder.