### PR TITLE
Add hex_trace_id and hex_span_id helpers

### DIFF
--- a/api/lib/opentelemetry/trace.rb
+++ b/api/lib/opentelemetry/trace.rb
@@ -41,11 +41,11 @@ end
 
 require 'opentelemetry/trace/event'
 require 'opentelemetry/trace/link'
-require 'opentelemetry/trace/propagation'
 require 'opentelemetry/trace/trace_flags'
 require 'opentelemetry/trace/span_context'
 require 'opentelemetry/trace/span_kind'
 require 'opentelemetry/trace/span'
 require 'opentelemetry/trace/status'
+require 'opentelemetry/trace/propagation'
 require 'opentelemetry/trace/tracer'
 require 'opentelemetry/trace/tracer_provider'

--- a/api/lib/opentelemetry/trace/propagation/trace_context/trace_parent.rb
+++ b/api/lib/opentelemetry/trace/propagation/trace_context/trace_parent.rb
@@ -25,8 +25,8 @@ module OpenTelemetry
           REGEXP = /^(?<version>[A-Fa-f0-9]{2})-(?<trace_id>[A-Fa-f0-9]{32})-(?<span_id>[A-Fa-f0-9]{16})-(?<flags>[A-Fa-f0-9]{2})(?<ignored>-.*)?$/.freeze
           private_constant :REGEXP
 
-          INVALID_TRACE_ID = OpenTelemetry::Trace::INVALID_TRACE_ID.unpack1('H*')
-          INVALID_SPAN_ID = OpenTelemetry::Trace::INVALID_SPAN_ID.unpack1('H*')
+          INVALID_TRACE_ID = OpenTelemetry::Trace::SpanContext::INVALID.hex_trace_id
+          INVALID_SPAN_ID = OpenTelemetry::Trace::SpanContext::INVALID.hex_span_id
           private_constant :INVALID_TRACE_ID, :INVALID_SPAN_ID
 
           class << self

--- a/api/lib/opentelemetry/trace/span_context.rb
+++ b/api/lib/opentelemetry/trace/span_context.rb
@@ -11,7 +11,7 @@ module OpenTelemetry
     # {TraceFlags}, a system-specific tracestate, and a boolean indicating that the SpanContext was
     # extracted from the wire.
     class SpanContext
-      attr_reader :trace_id, :span_id, :trace_flags, :tracestate
+      attr_reader :trace_flags, :tracestate
 
       # Returns a new {SpanContext}.
       #
@@ -33,6 +33,34 @@ module OpenTelemetry
         @trace_flags = trace_flags
         @tracestate = tracestate
         @remote = remote
+      end
+
+      # Returns the lowercase [hex encoded](https://tools.ietf.org/html/rfc4648#section-8) trace ID.
+      #
+      # @return [String] A 32-hex-character lowercase string.
+      def hex_trace_id
+        @trace_id.unpack1('H*')
+      end
+
+      # Returns the lowercase [hex encoded](https://tools.ietf.org/html/rfc4648#section-8) span ID.
+      #
+      # @return [String] A 16-hex-character lowercase string.
+      def hex_span_id
+        @span_id.unpack1('H*')
+      end
+
+      # Returns the binary representation of the trace ID.
+      #
+      # @return [String] A 16-byte binary string.
+      def trace_id
+        @trace_id
+      end
+
+      # Returns the binary representation of the span ID.
+      #
+      # @return [String] An 8-byte binary string.
+      def span_id
+        @span_id
       end
 
       # Returns true if the {SpanContext} has a non-zero trace ID and non-zero span ID.

--- a/api/lib/opentelemetry/trace/span_context.rb
+++ b/api/lib/opentelemetry/trace/span_context.rb
@@ -52,16 +52,12 @@ module OpenTelemetry
       # Returns the binary representation of the trace ID.
       #
       # @return [String] A 16-byte binary string.
-      def trace_id
-        @trace_id
-      end
+      attr_reader :trace_id
 
       # Returns the binary representation of the span ID.
       #
       # @return [String] An 8-byte binary string.
-      def span_id
-        @span_id
-      end
+      attr_reader :span_id
 
       # Returns true if the {SpanContext} has a non-zero trace ID and non-zero span ID.
       #

--- a/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/instrumentation_test.rb
+++ b/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/instrumentation_test.rb
@@ -99,7 +99,7 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
             _(easy.instance_eval { @otel_span }).must_be_nil
             _(
               easy.instance_eval { @otel_original_headers['traceparent'] }
-            ).must_equal "00-#{span.trace_id.unpack1('H*')}-#{span.span_id.unpack1('H*')}-01"
+            ).must_equal "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
           end
         end
 
@@ -112,7 +112,7 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
             _(easy.instance_eval { @otel_span }).must_be_nil
             _(
               easy.instance_eval { @otel_original_headers['traceparent'] }
-            ).must_equal "00-#{span.trace_id.unpack1('H*')}-#{span.span_id.unpack1('H*')}-01"
+            ).must_equal "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
           end
         end
 
@@ -131,7 +131,7 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
             _(easy.instance_eval { @otel_span }).must_be_nil
             _(
               easy.instance_eval { @otel_original_headers['traceparent'] }
-            ).must_equal "00-#{span.trace_id.unpack1('H*')}-#{span.span_id.unpack1('H*')}-01"
+            ).must_equal "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
           end
         end
       end

--- a/instrumentation/excon/test/opentelemetry/instrumentation/excon/instrumentation_test.rb
+++ b/instrumentation/excon/test/opentelemetry/instrumentation/excon/instrumentation_test.rb
@@ -58,7 +58,7 @@ describe OpenTelemetry::Instrumentation::Excon::Instrumentation do
       assert_requested(
         :get,
         'http://example.com/success',
-        headers: { 'Traceparent' => "00-#{span.trace_id.unpack1('H*')}-#{span.span_id.unpack1('H*')}-01" }
+        headers: { 'Traceparent' => "00-#{span.hex_trace_id}-#{span.hex_span_id}-01" }
       )
     end
 
@@ -75,7 +75,7 @@ describe OpenTelemetry::Instrumentation::Excon::Instrumentation do
       assert_requested(
         :get,
         'http://example.com/failure',
-        headers: { 'Traceparent' => "00-#{span.trace_id.unpack1('H*')}-#{span.span_id.unpack1('H*')}-01" }
+        headers: { 'Traceparent' => "00-#{span.hex_trace_id}-#{span.hex_span_id}-01" }
       )
     end
 
@@ -99,7 +99,7 @@ describe OpenTelemetry::Instrumentation::Excon::Instrumentation do
       assert_requested(
         :get,
         'http://example.com/timeout',
-        headers: { 'Traceparent' => "00-#{span.trace_id.unpack1('H*')}-#{span.span_id.unpack1('H*')}-01" }
+        headers: { 'Traceparent' => "00-#{span.hex_trace_id}-#{span.hex_span_id}-01" }
       )
     end
   end

--- a/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
+++ b/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
@@ -54,7 +54,7 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
       _(span.attributes['http.status_code']).must_equal 200
       _(span.attributes['http.url']).must_equal 'http://example.com/success'
       _(response.env.request_headers['Traceparent']).must_equal(
-        "00-#{span.trace_id.unpack1('H*')}-#{span.span_id.unpack1('H*')}-01"
+        "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
       )
     end
 
@@ -66,7 +66,7 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
       _(span.attributes['http.status_code']).must_equal 404
       _(span.attributes['http.url']).must_equal 'http://example.com/not_found'
       _(response.env.request_headers['Traceparent']).must_equal(
-        "00-#{span.trace_id.unpack1('H*')}-#{span.span_id.unpack1('H*')}-01"
+        "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
       )
     end
 
@@ -78,7 +78,7 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
       _(span.attributes['http.status_code']).must_equal 500
       _(span.attributes['http.url']).must_equal 'http://example.com/failure'
       _(response.env.request_headers['Traceparent']).must_equal(
-        "00-#{span.trace_id.unpack1('H*')}-#{span.span_id.unpack1('H*')}-01"
+        "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
       )
     end
   end

--- a/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/instrumentation_test.rb
+++ b/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/instrumentation_test.rb
@@ -59,7 +59,7 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
       assert_requested(
         :get,
         'http://example.com/success',
-        headers: { 'Traceparent' => "00-#{span.trace_id.unpack1('H*')}-#{span.span_id.unpack1('H*')}-01" }
+        headers: { 'Traceparent' => "00-#{span.hex_trace_id}-#{span.hex_span_id}-01" }
       )
     end
 
@@ -77,7 +77,7 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
       assert_requested(
         :post,
         'http://example.com/failure',
-        headers: { 'Traceparent' => "00-#{span.trace_id.unpack1('H*')}-#{span.span_id.unpack1('H*')}-01" }
+        headers: { 'Traceparent' => "00-#{span.hex_trace_id}-#{span.hex_span_id}-01" }
       )
     end
 
@@ -103,7 +103,7 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
       assert_requested(
         :get,
         'https://example.com/timeout',
-        headers: { 'Traceparent' => "00-#{span.trace_id.unpack1('H*')}-#{span.span_id.unpack1('H*')}-01" }
+        headers: { 'Traceparent' => "00-#{span.hex_trace_id}-#{span.hex_span_id}-01" }
       )
     end
   end

--- a/instrumentation/restclient/test/opentelemetry/instrumentation/restclient/instrumentation_test.rb
+++ b/instrumentation/restclient/test/opentelemetry/instrumentation/restclient/instrumentation_test.rb
@@ -55,7 +55,7 @@ describe OpenTelemetry::Instrumentation::RestClient::Instrumentation do
       assert_requested(
         :get,
         'http://example.com/success',
-        headers: { 'Traceparent' => "00-#{span.trace_id.unpack1('H*')}-#{span.span_id.unpack1('H*')}-01" }
+        headers: { 'Traceparent' => "00-#{span.hex_trace_id}-#{span.hex_span_id}-01" }
       )
     end
 
@@ -72,7 +72,7 @@ describe OpenTelemetry::Instrumentation::RestClient::Instrumentation do
       assert_requested(
         :get,
         'http://example.com/failure',
-        headers: { 'Traceparent' => "00-#{span.trace_id.unpack1('H*')}-#{span.span_id.unpack1('H*')}-01" }
+        headers: { 'Traceparent' => "00-#{span.hex_trace_id}-#{span.hex_span_id}-01" }
       )
     end
   end

--- a/sdk/lib/opentelemetry/sdk/trace/span_data.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span_data.rb
@@ -33,14 +33,14 @@ module OpenTelemetry
                               #
                               # @return [String] A 16-hex-character lowercase string.
                               def hex_span_id
-                                @span_id.unpack1('H*')
+                                span_id.unpack1('H*')
                               end
 
                               # Returns the lowercase [hex encoded](https://tools.ietf.org/html/rfc4648#section-8) trace ID.
                               #
                               # @return [String] A 32-hex-character lowercase string.
                               def hex_trace_id
-                                @trace_id.unpack1('H*')
+                                trace_id.unpack1('H*')
                               end
                             end
     end

--- a/sdk/lib/opentelemetry/sdk/trace/span_data.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span_data.rb
@@ -28,7 +28,21 @@ module OpenTelemetry
                             :span_id,
                             :trace_id,
                             :trace_flags,
-                            :tracestate)
+                            :tracestate) do
+                              # Returns the lowercase [hex encoded](https://tools.ietf.org/html/rfc4648#section-8) span ID.
+                              #
+                              # @return [String] A 16-hex-character lowercase string.
+                              def hex_span_id
+                                @span_id.unpack1('H*')
+                              end
+
+                              # Returns the lowercase [hex encoded](https://tools.ietf.org/html/rfc4648#section-8) trace ID.
+                              #
+                              # @return [String] A 32-hex-character lowercase string.
+                              def hex_trace_id
+                                @trace_id.unpack1('H*')
+                              end
+                            end
     end
   end
 end


### PR DESCRIPTION
Implements https://github.com/open-telemetry/opentelemetry-specification/pull/836.

Rather than rename `trace_id` and `span_id` to `binary_trace_id` and `binary_span_id`, I've left them as is and added documentation describing their format.