### PR TITLE
Refactor approvers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @fbogsany @mwear @robertlaurin @dazuma
+* @fbogsany @mwear @robertlaurin @dazuma @ericmustin

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @fbogsany @bai @luvtechno @mwear @elskwid @dazuma
+* @fbogsany @mwear @robertlaurin @dazuma


### PR DESCRIPTION
This adds @robertlaurin to the list of Approvers for OpenTelemetry Ruby. Robert contributed the Resource auto-detectors. He also maintains Shopify's wrapper gem for OpenTelemetry.

This also proposes removing @bai, @luvtechno and @elskwid from the Approvers list. They have not been active in this project for many months, at least. We're very grateful for @elskwid's early contributions, in particular, however Approver status requires continued active involvement in the project.

