### PR TITLE
feat!: add timeout for force_flush and shutdown

### DIFF
--- a/common/lib/opentelemetry/common.rb
+++ b/common/lib/opentelemetry/common.rb
@@ -6,6 +6,7 @@
 
 require 'opentelemetry'
 require 'opentelemetry/common/http'
+require 'opentelemetry/common/utilities'
 require 'opentelemetry/common/version'
 
 # OpenTelemetry is an open source observability framework, providing a

--- a/common/lib/opentelemetry/common/utilities.rb
+++ b/common/lib/opentelemetry/common/utilities.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Common
+    # Utilities contains common helpers.
+    module Utilities
+      extend self
+
+      # @api private
+      #
+      # Returns nil if timeout is nil, 0 if timeout has expired, or the remaining (positive) time left in seconds.
+      def maybe_timeout(timeout, start_time)
+        return nil if timeout.nil?
+
+        timeout -= (Time.now - start_time)
+        timeout.positive? ? timeout : 0
+      end
+    end
+  end
+end
+
+require_relative './http/client_context'

--- a/exporter/jaeger/Gemfile
+++ b/exporter/jaeger/Gemfile
@@ -10,3 +10,4 @@ gemspec
 
 # Use the opentelemetry-api gem from source
 gem 'opentelemetry-api', path: '../../api'
+gem 'opentelemetry-common', path: '../../common'

--- a/exporter/jaeger/lib/opentelemetry/exporter/jaeger.rb
+++ b/exporter/jaeger/lib/opentelemetry/exporter/jaeger.rb
@@ -23,6 +23,7 @@ $LOAD_PATH.push(File.dirname(__FILE__) + '/../../../thrift/gen-rb')
 require 'agent'
 require 'collector'
 require 'opentelemetry/sdk'
+require 'opentelemetry/common'
 require 'socket'
 require 'opentelemetry/exporter/jaeger/encoder'
 require 'opentelemetry/exporter/jaeger/transport'

--- a/exporter/jaeger/lib/opentelemetry/exporter/jaeger/agent_exporter.rb
+++ b/exporter/jaeger/lib/opentelemetry/exporter/jaeger/agent_exporter.rb
@@ -37,7 +37,7 @@ module OpenTelemetry
 
           start_time = Time.now
           encoded_batches(span_data) do |batch|
-            return FAILURE if @shutdown || OpenTelemetry::SDK::Internal.maybe_timeout(timeout, start_time)&.zero?
+            return FAILURE if @shutdown || OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time)&.zero?
 
             @client.emitBatch(batch)
           end

--- a/exporter/jaeger/lib/opentelemetry/exporter/jaeger/collector_exporter.rb
+++ b/exporter/jaeger/lib/opentelemetry/exporter/jaeger/collector_exporter.rb
@@ -36,8 +36,9 @@ module OpenTelemetry
         # @param [Enumerable<OpenTelemetry::SDK::Trace::SpanData>] span_data the
         #   list of recorded {OpenTelemetry::SDK::Trace::SpanData} structs to be
         #   exported.
+        # @param [optional Numeric] timeout An optional timeout in seconds.
         # @return [Integer] the result of the export.
-        def export(span_data)
+        def export(span_data, timeout: nil)
           return FAILURE if @shutdown
 
           encoded_batches(span_data).each do |batch|
@@ -56,7 +57,9 @@ module OpenTelemetry
         # Called when {OpenTelemetry::SDK::Trace::Tracer#shutdown} is called, if
         # this exporter is registered to a {OpenTelemetry::SDK::Trace::Tracer}
         # object.
-        def shutdown
+        #
+        # @param [optional Numeric] timeout An optional timeout in seconds.
+        def shutdown(timeout: nil)
           @shutdown = true
         end
 

--- a/exporter/jaeger/opentelemetry-exporter-jaeger.gemspec
+++ b/exporter/jaeger/opentelemetry-exporter-jaeger.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 0.8.0'
+  spec.add_dependency 'opentelemetry-common', '~> 0.8.0'
   spec.add_dependency 'thrift'
 
   spec.add_development_dependency 'bundler', '>= 1.17'

--- a/exporter/otlp/Gemfile
+++ b/exporter/otlp/Gemfile
@@ -10,3 +10,4 @@ gemspec
 
 # Use the opentelemetry-api gem from source
 gem 'opentelemetry-api', path: '../../api'
+gem 'opentelemetry-common', path: '../../common'

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -4,6 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require 'opentelemetry/common'
 require 'opentelemetry/sdk'
 require 'net/http'
 require 'csv'
@@ -124,7 +125,7 @@ module OpenTelemetry
             request.add_field('Content-Type', 'application/x-protobuf')
             @headers&.each { |key, value| request.add_field(key, value) }
 
-            remaining_timeout = OpenTelemetry::SDK::Internal.maybe_timeout(timeout, start_time)
+            remaining_timeout = OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time)
             return TIMEOUT if remaining_timeout.zero?
 
             @http.open_timeout = remaining_timeout

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -21,7 +21,8 @@ module OpenTelemetry
       class Exporter # rubocop:disable Metrics/ClassLength
         SUCCESS = OpenTelemetry::SDK::Trace::Export::SUCCESS
         FAILURE = OpenTelemetry::SDK::Trace::Export::FAILURE
-        private_constant(:SUCCESS, :FAILURE)
+        TIMEOUT = OpenTelemetry::SDK::Trace::Export::TIMEOUT
+        private_constant(:SUCCESS, :FAILURE, :TIMEOUT)
 
         # Default timeouts in seconds.
         KEEP_ALIVE_TIMEOUT = 30
@@ -124,7 +125,7 @@ module OpenTelemetry
             @headers&.each { |key, value| request.add_field(key, value) }
 
             remaining_timeout = OpenTelemetry::SDK::Internal.maybe_timeout(timeout, start_time)
-            return FAILURE if remaining_timeout.zero?
+            return TIMEOUT if remaining_timeout.zero?
 
             @http.open_timeout = remaining_timeout
             @http.read_timeout = remaining_timeout

--- a/exporter/otlp/opentelemetry-exporter-otlp.gemspec
+++ b/exporter/otlp/opentelemetry-exporter-otlp.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'google-protobuf', '>= 3.4.1.1', '< 4'
   spec.add_dependency 'opentelemetry-api', '~> 0.8.0'
+  spec.add_dependency 'opentelemetry-common', '~> 0.8.0'
 
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'faraday', '~> 0.13'

--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -8,6 +8,7 @@ require 'test_helper'
 describe OpenTelemetry::Exporter::OTLP::Exporter do
   SUCCESS = OpenTelemetry::SDK::Trace::Export::SUCCESS
   FAILURE = OpenTelemetry::SDK::Trace::Export::FAILURE
+  TIMEOUT = OpenTelemetry::SDK::Trace::Export::TIMEOUT
 
   describe '#initialize' do
     it 'initializes with defaults' do
@@ -119,7 +120,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       stub_request(:post, 'https://localhost:55681/v1/trace').to_return(status: 200)
       span_data = create_span_data
       result = exporter.export([span_data], timeout: 0)
-      _(result).must_equal(FAILURE)
+      _(result).must_equal(TIMEOUT)
     end
 
     it 'returns FAILURE on timeout after retrying' do
@@ -134,7 +135,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       end
 
       exporter.stub(:backoff?, backoff_stubbed_call) do
-        _(exporter.export([span_data], timeout: 0.1)).must_equal(FAILURE)
+        _(exporter.export([span_data], timeout: 0.1)).must_equal(TIMEOUT)
       end
     ensure
       @retry_count = 0

--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -116,14 +116,14 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       _(result).must_equal(SUCCESS)
     end
 
-    it 'returns FAILURE on timeout' do
+    it 'returns TIMEOUT on timeout' do
       stub_request(:post, 'https://localhost:55681/v1/trace').to_return(status: 200)
       span_data = create_span_data
       result = exporter.export([span_data], timeout: 0)
       _(result).must_equal(TIMEOUT)
     end
 
-    it 'returns FAILURE on timeout after retrying' do
+    it 'returns TIMEOUT on timeout after retrying' do
       stub_request(:post, 'https://localhost:55681/v1/trace').to_timeout.then.to_raise('this should not be reached')
       span_data = create_span_data
 

--- a/instrumentation/active_model_serializers/Gemfile
+++ b/instrumentation/active_model_serializers/Gemfile
@@ -11,5 +11,6 @@ gemspec
 gem 'opentelemetry-api', path: '../../api'
 
 group :test do
+  gem 'opentelemetry-common', path: '../../common'
   gem 'opentelemetry-sdk', path: '../../sdk'
 end

--- a/instrumentation/all/Gemfile
+++ b/instrumentation/all/Gemfile
@@ -25,4 +25,5 @@ gem 'opentelemetry-instrumentation-sinatra', path: '../sinatra'
 
 group :test do
   gem 'opentelemetry-sdk', path: '../../sdk'
+  gem 'opentelemetry-common', path: '../../common'
 end

--- a/instrumentation/all/Gemfile
+++ b/instrumentation/all/Gemfile
@@ -25,5 +25,4 @@ gem 'opentelemetry-instrumentation-sinatra', path: '../sinatra'
 
 group :test do
   gem 'opentelemetry-sdk', path: '../../sdk'
-  gem 'opentelemetry-common', path: '../../common'
 end

--- a/instrumentation/concurrent_ruby/Gemfile
+++ b/instrumentation/concurrent_ruby/Gemfile
@@ -11,6 +11,6 @@ gemspec
 gem 'opentelemetry-api', path: '../../api'
 
 group :test do
-  gem 'opentelemetry-sdk', path: '../../sdk'
   gem 'opentelemetry-common', path: '../../common'
+  gem 'opentelemetry-sdk', path: '../../sdk'
 end

--- a/instrumentation/concurrent_ruby/Gemfile
+++ b/instrumentation/concurrent_ruby/Gemfile
@@ -12,4 +12,5 @@ gem 'opentelemetry-api', path: '../../api'
 
 group :test do
   gem 'opentelemetry-sdk', path: '../../sdk'
+  gem 'opentelemetry-common', path: '../../common'
 end

--- a/instrumentation/dalli/Gemfile
+++ b/instrumentation/dalli/Gemfile
@@ -11,7 +11,7 @@ gemspec
 gem 'opentelemetry-api', path: '../../api'
 
 group :test do
-  gem 'opentelemetry-sdk', path: '../../sdk'
   gem 'opentelemetry-common', path: '../../common'
+  gem 'opentelemetry-sdk', path: '../../sdk'
   gem 'pry'
 end

--- a/instrumentation/dalli/Gemfile
+++ b/instrumentation/dalli/Gemfile
@@ -12,5 +12,6 @@ gem 'opentelemetry-api', path: '../../api'
 
 group :test do
   gem 'opentelemetry-sdk', path: '../../sdk'
+  gem 'opentelemetry-common', path: '../../common'
   gem 'pry'
 end

--- a/instrumentation/delayed_job/Gemfile
+++ b/instrumentation/delayed_job/Gemfile
@@ -11,6 +11,6 @@ gemspec
 gem 'opentelemetry-api', path: '../../api'
 
 group :test do
-  gem 'opentelemetry-sdk', path: '../../sdk'
   gem 'opentelemetry-common', path: '../../common'
+  gem 'opentelemetry-sdk', path: '../../sdk'
 end

--- a/instrumentation/delayed_job/Gemfile
+++ b/instrumentation/delayed_job/Gemfile
@@ -12,4 +12,5 @@ gem 'opentelemetry-api', path: '../../api'
 
 group :test do
   gem 'opentelemetry-sdk', path: '../../sdk'
+  gem 'opentelemetry-common', path: '../../common'
 end

--- a/instrumentation/ethon/Gemfile
+++ b/instrumentation/ethon/Gemfile
@@ -11,6 +11,6 @@ gemspec
 gem 'opentelemetry-api', path: '../../api'
 
 group :test do
-  gem 'opentelemetry-sdk', path: '../../sdk'
   gem 'opentelemetry-common', path: '../../common'
+  gem 'opentelemetry-sdk', path: '../../sdk'
 end

--- a/instrumentation/ethon/Gemfile
+++ b/instrumentation/ethon/Gemfile
@@ -12,4 +12,5 @@ gem 'opentelemetry-api', path: '../../api'
 
 group :test do
   gem 'opentelemetry-sdk', path: '../../sdk'
+  gem 'opentelemetry-common', path: '../../common'
 end

--- a/instrumentation/excon/Gemfile
+++ b/instrumentation/excon/Gemfile
@@ -11,6 +11,6 @@ gemspec
 gem 'opentelemetry-api', path: '../../api'
 
 group :test do
-  gem 'opentelemetry-sdk', path: '../../sdk'
   gem 'opentelemetry-common', path: '../../common'
+  gem 'opentelemetry-sdk', path: '../../sdk'
 end

--- a/instrumentation/excon/Gemfile
+++ b/instrumentation/excon/Gemfile
@@ -12,4 +12,5 @@ gem 'opentelemetry-api', path: '../../api'
 
 group :test do
   gem 'opentelemetry-sdk', path: '../../sdk'
+  gem 'opentelemetry-common', path: '../../common'
 end

--- a/instrumentation/faraday/Gemfile
+++ b/instrumentation/faraday/Gemfile
@@ -11,6 +11,6 @@ gemspec
 gem 'opentelemetry-api', path: '../../api'
 
 group :test do
-  gem 'opentelemetry-sdk', path: '../../sdk'
   gem 'opentelemetry-common', path: '../../common'
+  gem 'opentelemetry-sdk', path: '../../sdk'
 end

--- a/instrumentation/faraday/Gemfile
+++ b/instrumentation/faraday/Gemfile
@@ -12,4 +12,5 @@ gem 'opentelemetry-api', path: '../../api'
 
 group :test do
   gem 'opentelemetry-sdk', path: '../../sdk'
+  gem 'opentelemetry-common', path: '../../common'
 end

--- a/instrumentation/mongo/Gemfile
+++ b/instrumentation/mongo/Gemfile
@@ -11,6 +11,6 @@ gemspec
 gem 'opentelemetry-api', path: '../../api'
 
 group :test do
-  gem 'opentelemetry-sdk', path: '../../sdk'
   gem 'opentelemetry-common', path: '../../common'
+  gem 'opentelemetry-sdk', path: '../../sdk'
 end

--- a/instrumentation/mongo/Gemfile
+++ b/instrumentation/mongo/Gemfile
@@ -12,4 +12,5 @@ gem 'opentelemetry-api', path: '../../api'
 
 group :test do
   gem 'opentelemetry-sdk', path: '../../sdk'
+  gem 'opentelemetry-common', path: '../../common'
 end

--- a/instrumentation/mysql2/Gemfile
+++ b/instrumentation/mysql2/Gemfile
@@ -11,6 +11,6 @@ gemspec
 gem 'opentelemetry-api', path: '../../api'
 
 group :test do
-  gem 'opentelemetry-sdk', path: '../../sdk'
   gem 'opentelemetry-common', path: '../../common'
+  gem 'opentelemetry-sdk', path: '../../sdk'
 end

--- a/instrumentation/mysql2/Gemfile
+++ b/instrumentation/mysql2/Gemfile
@@ -12,4 +12,5 @@ gem 'opentelemetry-api', path: '../../api'
 
 group :test do
   gem 'opentelemetry-sdk', path: '../../sdk'
+  gem 'opentelemetry-common', path: '../../common'
 end

--- a/instrumentation/rack/Gemfile
+++ b/instrumentation/rack/Gemfile
@@ -11,6 +11,6 @@ gemspec
 gem 'opentelemetry-api', path: '../../api'
 
 group :test do
-  gem 'opentelemetry-sdk', path: '../../sdk'
   gem 'opentelemetry-common', path: '../../common'
+  gem 'opentelemetry-sdk', path: '../../sdk'
 end

--- a/instrumentation/rack/Gemfile
+++ b/instrumentation/rack/Gemfile
@@ -12,4 +12,5 @@ gem 'opentelemetry-api', path: '../../api'
 
 group :test do
   gem 'opentelemetry-sdk', path: '../../sdk'
+  gem 'opentelemetry-common', path: '../../common'
 end

--- a/instrumentation/rails/Gemfile
+++ b/instrumentation/rails/Gemfile
@@ -12,7 +12,8 @@ gem 'opentelemetry-api', path: '../../api'
 
 group :test do
   gem 'byebug'
+  gem 'pry-byebug'
   gem 'opentelemetry-instrumentation-rack', path: '../../instrumentation/rack'
   gem 'opentelemetry-sdk', path: '../../sdk'
-  gem 'pry-byebug'
+  gem 'opentelemetry-common', path: '../../common'
 end

--- a/instrumentation/rails/Gemfile
+++ b/instrumentation/rails/Gemfile
@@ -12,8 +12,8 @@ gem 'opentelemetry-api', path: '../../api'
 
 group :test do
   gem 'byebug'
-  gem 'pry-byebug'
+  gem 'opentelemetry-common', path: '../../common'
   gem 'opentelemetry-instrumentation-rack', path: '../../instrumentation/rack'
   gem 'opentelemetry-sdk', path: '../../sdk'
-  gem 'opentelemetry-common', path: '../../common'
+  gem 'pry-byebug'
 end

--- a/instrumentation/redis/Gemfile
+++ b/instrumentation/redis/Gemfile
@@ -12,6 +12,6 @@ gem 'opentelemetry-api', path: '../../api'
 
 group :test do
   gem 'fakeredis', require: 'fakeredis/minitest'
-  gem 'opentelemetry-sdk', path: '../../sdk'
   gem 'opentelemetry-common', path: '../../common'
+  gem 'opentelemetry-sdk', path: '../../sdk'
 end

--- a/instrumentation/redis/Gemfile
+++ b/instrumentation/redis/Gemfile
@@ -13,4 +13,5 @@ gem 'opentelemetry-api', path: '../../api'
 group :test do
   gem 'fakeredis', require: 'fakeredis/minitest'
   gem 'opentelemetry-sdk', path: '../../sdk'
+  gem 'opentelemetry-common', path: '../../common'
 end

--- a/instrumentation/restclient/Gemfile
+++ b/instrumentation/restclient/Gemfile
@@ -11,6 +11,6 @@ gemspec
 gem 'opentelemetry-api', path: '../../api'
 
 group :test do
-  gem 'opentelemetry-sdk', path: '../../sdk'
   gem 'opentelemetry-common', path: '../../common'
+  gem 'opentelemetry-sdk', path: '../../sdk'
 end

--- a/instrumentation/restclient/Gemfile
+++ b/instrumentation/restclient/Gemfile
@@ -12,4 +12,5 @@ gem 'opentelemetry-api', path: '../../api'
 
 group :test do
   gem 'opentelemetry-sdk', path: '../../sdk'
+  gem 'opentelemetry-common', path: '../../common'
 end

--- a/instrumentation/sidekiq/Gemfile
+++ b/instrumentation/sidekiq/Gemfile
@@ -11,6 +11,6 @@ gemspec
 gem 'opentelemetry-api', path: '../../api'
 
 group :test do
-  gem 'opentelemetry-sdk', path: '../../sdk'
   gem 'opentelemetry-common', path: '../../common'
+  gem 'opentelemetry-sdk', path: '../../sdk'
 end

--- a/instrumentation/sidekiq/Gemfile
+++ b/instrumentation/sidekiq/Gemfile
@@ -12,4 +12,5 @@ gem 'opentelemetry-api', path: '../../api'
 
 group :test do
   gem 'opentelemetry-sdk', path: '../../sdk'
+  gem 'opentelemetry-common', path: '../../common'
 end

--- a/instrumentation/sinatra/Gemfile
+++ b/instrumentation/sinatra/Gemfile
@@ -11,6 +11,6 @@ gemspec
 gem 'opentelemetry-api', path: '../../api'
 
 group :test do
-  gem 'opentelemetry-sdk', path: '../../sdk'
   gem 'opentelemetry-common', path: '../../common'
+  gem 'opentelemetry-sdk', path: '../../sdk'
 end

--- a/instrumentation/sinatra/Gemfile
+++ b/instrumentation/sinatra/Gemfile
@@ -12,4 +12,5 @@ gem 'opentelemetry-api', path: '../../api'
 
 group :test do
   gem 'opentelemetry-sdk', path: '../../sdk'
+  gem 'opentelemetry-common', path: '../../common'
 end

--- a/resource_detectors/Rakefile
+++ b/resource_detectors/Rakefile
@@ -14,6 +14,7 @@ RuboCop::RakeTask.new
 Rake::TestTask.new :test do |t|
   t.libs << '../sdk/lib'
   t.libs << '../api/lib'
+  t.libs << '../common/lib'
   t.libs << 'test'
   t.libs << 'lib'
   t.test_files = FileList['test/**/*_test.rb']

--- a/sdk/Gemfile
+++ b/sdk/Gemfile
@@ -10,3 +10,4 @@ gemspec
 
 # Use the opentelemetry-api gem from source
 gem 'opentelemetry-api', path: '../api'
+gem 'opentelemetry-common', path: '../common'

--- a/sdk/lib/opentelemetry/sdk.rb
+++ b/sdk/lib/opentelemetry/sdk.rb
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require 'opentelemetry'
+require 'opentelemetry/common'
 
 # OpenTelemetry is an open source observability framework, providing a
 # general-purpose API, SDK, and related tools required for the instrumentation

--- a/sdk/lib/opentelemetry/sdk/internal.rb
+++ b/sdk/lib/opentelemetry/sdk/internal.rb
@@ -47,6 +47,16 @@ module OpenTelemetry
       def valid_attributes?(attrs)
         attrs.nil? || attrs.all? { |k, v| valid_key?(k) && valid_value?(v) }
       end
+
+      # @api private
+      #
+      # Returns nil if timeout is nil, 0 if timeout has expired, or the remaining (positive) time left in seconds.
+      def maybe_timeout(timeout, start_time)
+        return nil if timeout.nil?
+
+        timeout -= (Time.now - start_time)
+        timeout.positive? ? timeout : 0
+      end
     end
   end
 end

--- a/sdk/lib/opentelemetry/sdk/internal.rb
+++ b/sdk/lib/opentelemetry/sdk/internal.rb
@@ -47,16 +47,6 @@ module OpenTelemetry
       def valid_attributes?(attrs)
         attrs.nil? || attrs.all? { |k, v| valid_key?(k) && valid_value?(v) }
       end
-
-      # @api private
-      #
-      # Returns nil if timeout is nil, 0 if timeout has expired, or the remaining (positive) time left in seconds.
-      def maybe_timeout(timeout, start_time)
-        return nil if timeout.nil?
-
-        timeout -= (Time.now - start_time)
-        timeout.positive? ? timeout : 0
-      end
     end
   end
 end

--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -92,7 +92,7 @@ module OpenTelemetry
           # the process after an invocation, but before the `Processor` exports
           # the completed spans.
           #
-          # @param [optional Numeric] timeout An optional timeout in seconds. 
+          # @param [optional Numeric] timeout An optional timeout in seconds.
           # @return [Integer] SUCCESS if no error occurred, FAILURE if a
           #   non-specific failure occurred, TIMEOUT if a timeout occurred.
           def force_flush(timeout: nil)
@@ -122,7 +122,7 @@ module OpenTelemetry
           # shuts the consumer thread down and flushes the current accumulated buffer
           # will block until the thread is finished
           #
-          # @param [optional Numeric] timeout An optional timeout in seconds. 
+          # @param [optional Numeric] timeout An optional timeout in seconds.
           # @return [Integer] SUCCESS if no error occurred, FAILURE if a
           #   non-specific failure occurred, TIMEOUT if a timeout occurred.
           def shutdown(timeout: nil)

--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -132,10 +132,10 @@ module OpenTelemetry
           attr_reader :spans, :max_queue_size, :batch_size
 
           def maybe_timeout(timeout, start_time)
-            unless timeout.nil?
-              timeout = timeout - (Time.now - start_time)
-              timeout.positive? ? timeout : 0
-            end
+            return nil if timeout.nil?
+
+            timeout -= (Time.now - start_time)
+            timeout.positive? ? timeout : 0
           end
 
           def work

--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -25,7 +25,7 @@ module OpenTelemetry
         # If the queue gets half full a preemptive notification is sent to the
         # worker thread that exports the spans to wake up and start a new
         # export cycle.
-        class BatchSpanProcessor
+        class BatchSpanProcessor # rubocop:disable Metrics/ClassLength
           # Returns a new instance of the {BatchSpanProcessor}.
           #
           # @param [SpanExporter] exporter
@@ -54,6 +54,7 @@ module OpenTelemetry
             @exporter = exporter
             @exporter_timeout_seconds = exporter_timeout_millis / 1000.0
             @mutex = Mutex.new
+            @export_mutex = Mutex.new
             @condition = ConditionVariable.new
             @keep_running = true
             @delay_seconds = schedule_delay_millis / 1000.0
@@ -70,7 +71,7 @@ module OpenTelemetry
             # noop
           end
 
-          # adds a span to the batcher, threadsafe may block on lock
+          # Adds a span to the batch. Thread-safe; may block on lock.
           def on_finish(span) # rubocop:disable Metrics/AbcSize
             return unless span.context.trace_flags.sampled?
 
@@ -95,18 +96,23 @@ module OpenTelemetry
           # @param [optional Numeric] timeout An optional timeout in seconds.
           # @return [Integer] SUCCESS if no error occurred, FAILURE if a
           #   non-specific failure occurred, TIMEOUT if a timeout occurred.
-          def force_flush(timeout: nil)
+          def force_flush(timeout: nil) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
             start_time = Time.now
             snapshot = lock do
               reset_on_fork(restart_thread: false) if @keep_running
               spans.shift(spans.size)
             end
-            until snapshot.empty? || Internal.maybe_timeout(timeout, start_time)&.zero?
+            until snapshot.empty?
+              remaining_timeout = Internal.maybe_timeout(timeout, start_time)
+              return TIMEOUT if remaining_timeout&.zero?
+
               batch = snapshot.shift(@batch_size).map!(&:to_span_data)
-              result_code = @exporter.export(batch)
-              report_result(result_code, batch)
+              result_code = export_batch(batch, timeout: remaining_timeout)
+              return result_code unless result_code == SUCCESS
             end
 
+            SUCCESS
+          ensure
             # Unshift the remaining spans if we timed out. We drop excess spans from
             # the snapshot because they're older than any spans in the spans buffer.
             lock do
@@ -115,8 +121,6 @@ module OpenTelemetry
               spans.unshift(snapshot) unless snapshot.empty?
               @condition.signal if spans.size > max_queue_size / 2
             end
-
-            SUCCESS
           end
 
           # shuts the consumer thread down and flushes the current accumulated buffer
@@ -165,15 +169,10 @@ module OpenTelemetry
             @thread = Thread.new { work } if restart_thread
           end
 
-          def export_batch(batch)
-            result_code = export_with_timeout(batch)
+          def export_batch(batch, timeout: @exporter_timeout_seconds)
+            result_code = @export_mutex.synchronize { @exporter.export(batch, timeout: timeout) }
             report_result(result_code, batch)
-          end
-
-          def export_with_timeout(batch)
-            Timeout.timeout(@exporter_timeout_seconds) { @exporter.export(batch) }
-          rescue Timeout::Error
-            FAILURE
+            result_code
           end
 
           def report_result(result_code, batch)

--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -100,7 +100,7 @@ module OpenTelemetry
               spans.shift(spans.size)
             end
             until snapshot.empty?
-              remaining_timeout = Internal.maybe_timeout(timeout, start_time)
+              remaining_timeout = OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time)
               return TIMEOUT if remaining_timeout&.zero?
 
               batch = snapshot.shift(@batch_size).map!(&:to_span_data)
@@ -134,8 +134,8 @@ module OpenTelemetry
             end
 
             @thread.join(timeout)
-            force_flush(timeout: Internal.maybe_timeout(timeout, start_time))
-            @exporter.shutdown(timeout: Internal.maybe_timeout(timeout, start_time))
+            force_flush(timeout: OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time))
+            @exporter.shutdown(timeout: OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time))
           end
 
           private

--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -66,10 +66,8 @@ module OpenTelemetry
             reset_on_fork(restart_thread: start_thread_on_boot)
           end
 
-          # does nothing for this processor
-          def on_start(span, parent_context)
-            # noop
-          end
+          # Does nothing for this processor
+          def on_start(_span, _parent_context); end
 
           # Adds a span to the batch. Thread-safe; may block on lock.
           def on_finish(span) # rubocop:disable Metrics/AbcSize
@@ -84,7 +82,6 @@ module OpenTelemetry
             end
           end
 
-          # TODO: test this explicitly.
           # Export all ended spans to the configured `Exporter` that have not yet
           # been exported.
           #
@@ -123,8 +120,8 @@ module OpenTelemetry
             end
           end
 
-          # shuts the consumer thread down and flushes the current accumulated buffer
-          # will block until the thread is finished
+          # Shuts the consumer thread down and flushes the current accumulated buffer
+          # will block until the thread is finished.
           #
           # @param [optional Numeric] timeout An optional timeout in seconds.
           # @return [Integer] SUCCESS if no error occurred, FAILURE if a

--- a/sdk/lib/opentelemetry/sdk/trace/export/console_span_exporter.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/console_span_exporter.rb
@@ -18,7 +18,7 @@ module OpenTelemetry
             @stopped = false
           end
 
-          def export(spans)
+          def export(spans, timeout: nil)
             return FAILURE if @stopped
 
             Array(spans).each { |s| pp s }

--- a/sdk/lib/opentelemetry/sdk/trace/export/console_span_exporter.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/console_span_exporter.rb
@@ -26,7 +26,7 @@ module OpenTelemetry
             SUCCESS
           end
 
-          def shutdown
+          def shutdown(timeout: nil)
             @stopped = true
             SUCCESS
           end

--- a/sdk/lib/opentelemetry/sdk/trace/export/in_memory_span_exporter.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/in_memory_span_exporter.rb
@@ -74,9 +74,10 @@ module OpenTelemetry
           # Called when {TracerProvider#shutdown} is called, if this exporter is
           # registered to a {TracerProvider} object.
           #
+          # @param [optional Numeric] timeout An optional timeout in seconds. 
           # @return [Integer] SUCCESS if no error occurred, FAILURE if a
           #   non-specific failure occurred, TIMEOUT if a timeout occurred.
-          def shutdown
+          def shutdown(timeout: nil)
             @mutex.synchronize do
               @finished_spans.clear
               @stopped = true

--- a/sdk/lib/opentelemetry/sdk/trace/export/in_memory_span_exporter.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/in_memory_span_exporter.rb
@@ -62,7 +62,7 @@ module OpenTelemetry
           #   exported.
           # @return [Integer] the result of the export, SUCCESS or
           #   FAILURE
-          def export(span_datas)
+          def export(span_datas, timeout: nil)
             @mutex.synchronize do
               return FAILURE if @stopped
 

--- a/sdk/lib/opentelemetry/sdk/trace/export/in_memory_span_exporter.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/in_memory_span_exporter.rb
@@ -60,6 +60,7 @@ module OpenTelemetry
           #
           # @param [Enumerable<SpanData>] span_datas the list of sampled {SpanData}s to be
           #   exported.
+          # @param [optional Numeric] timeout An optional timeout in seconds.
           # @return [Integer] the result of the export, SUCCESS or
           #   FAILURE
           def export(span_datas, timeout: nil)

--- a/sdk/lib/opentelemetry/sdk/trace/export/in_memory_span_exporter.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/in_memory_span_exporter.rb
@@ -74,7 +74,7 @@ module OpenTelemetry
           # Called when {TracerProvider#shutdown} is called, if this exporter is
           # registered to a {TracerProvider} object.
           #
-          # @param [optional Numeric] timeout An optional timeout in seconds. 
+          # @param [optional Numeric] timeout An optional timeout in seconds.
           # @return [Integer] SUCCESS if no error occurred, FAILURE if a
           #   non-specific failure occurred, TIMEOUT if a timeout occurred.
           def shutdown(timeout: nil)

--- a/sdk/lib/opentelemetry/sdk/trace/export/multi_span_exporter.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/multi_span_exporter.rb
@@ -47,6 +47,7 @@ module OpenTelemetry
               @span_exporters.map do |processor|
                 remaining_timeout = timeout - (Time.now - start_time)
                 return TIMEOUT unless remaining_timeout.positive?
+
                 processor.shutdown(timeout: timeout)
               end.uniq.max
             end

--- a/sdk/lib/opentelemetry/sdk/trace/export/multi_span_exporter.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/multi_span_exporter.rb
@@ -36,7 +36,7 @@ module OpenTelemetry
           # Called when {TracerProvider#shutdown} is called, if this exporter is
           # registered to a {TracerProvider} object.
           #
-          # @param [optional Numeric] timeout An optional timeout in seconds. 
+          # @param [optional Numeric] timeout An optional timeout in seconds.
           # @return [Integer] SUCCESS if no error occurred, FAILURE if a
           #   non-specific failure occurred, TIMEOUT if a timeout occurred.
           def shutdown(timeout: nil)

--- a/sdk/lib/opentelemetry/sdk/trace/export/multi_span_exporter.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/multi_span_exporter.rb
@@ -48,7 +48,7 @@ module OpenTelemetry
                 remaining_timeout = timeout - (Time.now - start_time)
                 return TIMEOUT unless remaining_timeout.positive?
 
-                processor.shutdown(timeout: timeout)
+                processor.shutdown(timeout: Internal.maybe_timeout(timeout, start_time))
               end.uniq.max
             end
           end

--- a/sdk/lib/opentelemetry/sdk/trace/export/multi_span_exporter.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/multi_span_exporter.rb
@@ -28,7 +28,7 @@ module OpenTelemetry
           def export(spans, timeout: nil)
             start_time = Time.now
             results = @span_exporters.map do |span_exporter|
-              span_exporter.export(spans, timeout: Internal.maybe_timeout(timeout, start_time))
+              span_exporter.export(spans, timeout: OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time))
             rescue => e # rubocop:disable Style/RescueStandardError
               OpenTelemetry.logger.warn("exception raised by export - #{e}")
               FAILURE
@@ -45,7 +45,7 @@ module OpenTelemetry
           def shutdown(timeout: nil)
             start_time = Time.now
             results = @span_exporters.map do |processor|
-              remaining_timeout = Internal.maybe_timeout(timeout, start_time)
+              remaining_timeout = OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time)
               return TIMEOUT if remaining_timeout&.zero?
 
               processor.shutdown(timeout: remaining_timeout)

--- a/sdk/lib/opentelemetry/sdk/trace/export/multi_span_exporter.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/multi_span_exporter.rb
@@ -50,7 +50,7 @@ module OpenTelemetry
 
               processor.shutdown(timeout: remaining_timeout)
             end
-            results.uniq.max
+            results.uniq.max || SUCCESS
           end
         end
       end

--- a/sdk/lib/opentelemetry/sdk/trace/export/noop_span_exporter.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/noop_span_exporter.rb
@@ -23,8 +23,9 @@ module OpenTelemetry
           #
           # @param [Enumerable<Span>] spans the list of sampled {Span}s to be
           #   exported.
+          # @param [optional Numeric] timeout An optional timeout in seconds.
           # @return [Integer] the result of the export.
-          def export(spans)
+          def export(spans, timeout: nil)
             return SUCCESS unless @stopped
 
             FAILURE

--- a/sdk/lib/opentelemetry/sdk/trace/export/noop_span_exporter.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/noop_span_exporter.rb
@@ -32,7 +32,9 @@ module OpenTelemetry
 
           # Called when {TracerProvider#shutdown} is called, if this exporter is
           # registered to a {TracerProvider} object.
-          def shutdown
+          #
+          # @param [optional Numeric] timeout An optional timeout in seconds. 
+          def shutdown(timeout: nil)
             @stopped = true
             SUCCESS
           end

--- a/sdk/lib/opentelemetry/sdk/trace/export/noop_span_exporter.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/noop_span_exporter.rb
@@ -33,7 +33,7 @@ module OpenTelemetry
           # Called when {TracerProvider#shutdown} is called, if this exporter is
           # registered to a {TracerProvider} object.
           #
-          # @param [optional Numeric] timeout An optional timeout in seconds. 
+          # @param [optional Numeric] timeout An optional timeout in seconds.
           def shutdown(timeout: nil)
             @stopped = true
             SUCCESS

--- a/sdk/lib/opentelemetry/sdk/trace/export/simple_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/simple_span_processor.rb
@@ -68,7 +68,7 @@ module OpenTelemetry
           # the process after an invocation, but before the `Processor` exports
           # the completed spans.
           #
-          # @param [optional Numeric] timeout An optional timeout in seconds. 
+          # @param [optional Numeric] timeout An optional timeout in seconds.
           # @return [Integer] SUCCESS if no error occurred, FAILURE if a
           #   non-specific failure occurred, TIMEOUT if a timeout occurred.
           def force_flush(timeout: nil)
@@ -77,7 +77,7 @@ module OpenTelemetry
 
           # Called when {TracerProvider#shutdown} is called.
           #
-          # @param [optional Numeric] timeout An optional timeout in seconds. 
+          # @param [optional Numeric] timeout An optional timeout in seconds.
           # @return [Integer] SUCCESS if no error occurred, FAILURE if a
           #   non-specific failure occurred, TIMEOUT if a timeout occurred.
           def shutdown(timeout: nil)

--- a/sdk/lib/opentelemetry/sdk/trace/export/simple_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/simple_span_processor.rb
@@ -68,18 +68,20 @@ module OpenTelemetry
           # the process after an invocation, but before the `Processor` exports
           # the completed spans.
           #
+          # @param [optional Numeric] timeout An optional timeout in seconds. 
           # @return [Integer] SUCCESS if no error occurred, FAILURE if a
           #   non-specific failure occurred, TIMEOUT if a timeout occurred.
-          def force_flush
+          def force_flush(timeout: nil)
             SUCCESS
           end
 
           # Called when {TracerProvider#shutdown} is called.
           #
+          # @param [optional Numeric] timeout An optional timeout in seconds. 
           # @return [Integer] SUCCESS if no error occurred, FAILURE if a
           #   non-specific failure occurred, TIMEOUT if a timeout occurred.
-          def shutdown
-            @span_exporter&.shutdown || SUCCESS
+          def shutdown(timeout: nil)
+            @span_exporter&.shutdown(timeout: timeout) || SUCCESS
           end
         end
       end

--- a/sdk/lib/opentelemetry/sdk/trace/multi_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/multi_span_processor.rb
@@ -63,7 +63,7 @@ module OpenTelemetry
               remaining_timeout = timeout - (Time.now - start_time)
               return Export::TIMEOUT unless remaining_timeout.positive?
 
-              processor.force_flush(timeout: timeout)
+              processor.force_flush(timeout: Internal.maybe_timeout(timeout, start_time))
             end.uniq.max
           end
         end
@@ -82,7 +82,7 @@ module OpenTelemetry
               remaining_timeout = timeout - (Time.now - start_time)
               return Export::TIMEOUT unless remaining_timeout.positive?
 
-              processor.shutdown(timeout: timeout)
+              processor.shutdown(timeout: Internal.maybe_timeout(timeout, start_time))
             end.uniq.max
           end
         end

--- a/sdk/lib/opentelemetry/sdk/trace/multi_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/multi_span_processor.rb
@@ -62,6 +62,7 @@ module OpenTelemetry
             @span_processors.map do |processor|
               remaining_timeout = timeout - (Time.now - start_time)
               return Export::TIMEOUT unless remaining_timeout.positive?
+
               processor.force_flush(timeout: timeout)
             end.uniq.max
           end
@@ -80,6 +81,7 @@ module OpenTelemetry
             @span_processors.map do |processor|
               remaining_timeout = timeout - (Time.now - start_time)
               return Export::TIMEOUT unless remaining_timeout.positive?
+
               processor.shutdown(timeout: timeout)
             end.uniq.max
           end

--- a/sdk/lib/opentelemetry/sdk/trace/multi_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/multi_span_processor.rb
@@ -57,7 +57,7 @@ module OpenTelemetry
         def force_flush(timeout: nil)
           start_time = Time.now
           results = @span_processors.map do |processor|
-            remaining_timeout = Internal.maybe_timeout(timeout, start_time)
+            remaining_timeout = OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time)
             return Export::TIMEOUT if remaining_timeout&.zero?
 
             processor.force_flush(timeout: remaining_timeout)
@@ -73,7 +73,7 @@ module OpenTelemetry
         def shutdown(timeout: nil)
           start_time = Time.now
           results = @span_processors.map do |processor|
-            remaining_timeout = Internal.maybe_timeout(timeout, start_time)
+            remaining_timeout = OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time)
             return Export::TIMEOUT if remaining_timeout&.zero?
 
             processor.shutdown(timeout: remaining_timeout)

--- a/sdk/lib/opentelemetry/sdk/trace/noop_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/noop_span_processor.rb
@@ -52,7 +52,7 @@ module OpenTelemetry
 
         # Called when {TracerProvider#shutdown} is called.
         #
-        # @param [optional Numeric] timeout An optional timeout in seconds. 
+        # @param [optional Numeric] timeout An optional timeout in seconds.
         # @return [Integer] Export::SUCCESS if no error occurred, Export::FAILURE if
         #   a non-specific failure occurred, Export::TIMEOUT if a timeout occurred.
         def shutdown(timeout: nil)

--- a/sdk/lib/opentelemetry/sdk/trace/noop_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/noop_span_processor.rb
@@ -43,17 +43,19 @@ module OpenTelemetry
         # the process after an invocation, but before the `Processor` exports
         # the completed spans.
         #
+        # @param [optional Numeric] timeout An optional timeout in seconds.
         # @return [Integer] Export::SUCCESS if no error occurred, Export::FAILURE if
         #   a non-specific failure occurred, Export::TIMEOUT if a timeout occurred.
-        def force_flush
+        def force_flush(timeout: nil)
           Export::SUCCESS
         end
 
         # Called when {TracerProvider#shutdown} is called.
         #
+        # @param [optional Numeric] timeout An optional timeout in seconds. 
         # @return [Integer] Export::SUCCESS if no error occurred, Export::FAILURE if
         #   a non-specific failure occurred, Export::TIMEOUT if a timeout occurred.
-        def shutdown
+        def shutdown(timeout: nil)
           Export::SUCCESS
         end
       end

--- a/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
@@ -49,13 +49,15 @@ module OpenTelemetry
         # processed and exported.
         #
         # After this is called all the newly created {Span}s will be no-op.
-        def shutdown
+        #
+        # @param [optional Numeric] timeout An optional timeout in seconds. 
+        def shutdown(timeout: nil)
           @mutex.synchronize do
             if @stopped
               OpenTelemetry.logger.warn('calling Tracer#shutdown multiple times.')
               return
             end
-            @active_span_processor.shutdown
+            @active_span_processor.shutdown(timeout: timeout)
             @stopped = true
           end
         end

--- a/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
@@ -50,7 +50,7 @@ module OpenTelemetry
         #
         # After this is called all the newly created {Span}s will be no-op.
         #
-        # @param [optional Numeric] timeout An optional timeout in seconds. 
+        # @param [optional Numeric] timeout An optional timeout in seconds.
         def shutdown(timeout: nil)
           @mutex.synchronize do
             if @stopped

--- a/sdk/opentelemetry-sdk.gemspec
+++ b/sdk/opentelemetry-sdk.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 0.8.0'
+  spec.add_dependency 'opentelemetry-common', '~> 0.8.0'
 
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'faraday', '~> 0.13'

--- a/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
@@ -33,7 +33,7 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
       end
     end
 
-    def shutdown; end
+    def shutdown(timeout: nil); end
   end
 
   class TestTimeoutExporter < TestExporter

--- a/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
@@ -21,7 +21,7 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
     attr_reader :batches
     attr_reader :failed_batches
 
-    def export(batch)
+    def export(batch, timeout: nil)
       # If status codes is empty, its a success for less verbose testing
       s = @status_codes.shift
       if s.nil? || s == SUCCESS
@@ -44,7 +44,7 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
       super(**args)
     end
 
-    def export(batch)
+    def export(batch, timeout: nil)
       @state = :called
       # long enough to cause a timeout:
       sleep @sleep_for_seconds
@@ -301,6 +301,7 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
       let(:exporter_sleeps_for_millis) { exporter_timeout_millis + 700 }
 
       it 'is interrupted by a timeout' do
+        skip # TODO: fix the timeout testing
         _(exporter.state).must_equal(:called)
       end
     end

--- a/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
@@ -10,6 +10,7 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
   BatchSpanProcessor = OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor
   SUCCESS = OpenTelemetry::SDK::Trace::Export::SUCCESS
   FAILURE = OpenTelemetry::SDK::Trace::Export::FAILURE
+  TIMEOUT = OpenTelemetry::SDK::Trace::Export::TIMEOUT
 
   class TestExporter
     def initialize(status_codes: nil)
@@ -170,6 +171,36 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
                                  start_thread_on_boot: false)
         end
       end
+    end
+  end
+
+  describe '#force_flush' do
+    it 'reenqueues excess spans on timeout' do
+      test_exporter = TestExporter.new
+      bsp = BatchSpanProcessor.new(exporter: test_exporter)
+      bsp.on_finish(TestSpan.new)
+      result = bsp.force_flush(timeout: 0)
+
+      _(result).must_equal(TIMEOUT)
+
+      _(test_exporter.failed_batches.size).must_equal(0)
+      _(test_exporter.batches.size).must_equal(0)
+
+      _(bsp.instance_variable_get(:@spans).size).must_equal(1)
+    end
+  end
+
+  describe '#shutdown' do
+    it 'respects the timeout' do
+      test_exporter = TestExporter.new
+      bsp = BatchSpanProcessor.new(exporter: test_exporter)
+      bsp.on_finish(TestSpan.new)
+      bsp.shutdown(timeout: 0)
+
+      _(test_exporter.failed_batches.size).must_equal(0)
+      _(test_exporter.batches.size).must_equal(0)
+
+      _(bsp.instance_variable_get(:@spans).size).must_equal(1)
     end
   end
 

--- a/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
@@ -37,23 +37,6 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
     def shutdown(timeout: nil); end
   end
 
-  class TestTimeoutExporter < TestExporter
-    attr_reader :state
-
-    def initialize(sleep_for_millis: 0, **args)
-      @sleep_for_seconds = sleep_for_millis / 1000.0
-      super(**args)
-    end
-
-    def export(batch, timeout: nil)
-      @state = :called
-      # long enough to cause a timeout:
-      sleep @sleep_for_seconds
-      @state = :not_interrupted
-      super
-    end
-  end
-
   class TestSpan
     def initialize(id = nil, recording = true)
       trace_flags = recording ? OpenTelemetry::Trace::TraceFlags::SAMPLED : OpenTelemetry::Trace::TraceFlags::DEFAULT
@@ -295,46 +278,6 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
       expected = 100.times.map { |i| i }
 
       _(out).must_equal(expected)
-    end
-  end
-
-  describe 'export timeout' do
-    let(:exporter) do
-      TestTimeoutExporter.new(status_codes: [SUCCESS],
-                              sleep_for_millis: exporter_sleeps_for_millis)
-    end
-    let(:processor) do
-      BatchSpanProcessor.new(exporter: exporter,
-                             exporter_timeout_millis: exporter_timeout_millis,
-                             schedule_delay_millis: schedule_delay_millis)
-    end
-    let(:schedule_delay_millis) { 50 }
-    let(:exporter_timeout_millis) { 100 }
-    let(:spans) { [TestSpan.new, TestSpan.new] }
-
-    before do
-      spans.each { |ts| processor.on_finish(ts) }
-
-      # Ensure that work thread loops (longer than 'schedule_delay_millis'):
-      sleep((schedule_delay_millis + 100) / 1000.0)
-      processor.shutdown
-    end
-
-    describe 'normally' do
-      let(:exporter_sleeps_for_millis) { exporter_timeout_millis - 1 }
-
-      it 'exporter is not interrupted' do
-        _(exporter.state).must_equal(:not_interrupted)
-      end
-    end
-
-    describe 'when exporter runs too long' do
-      let(:exporter_sleeps_for_millis) { exporter_timeout_millis + 700 }
-
-      it 'is interrupted by a timeout' do
-        skip # TODO: fix the timeout testing
-        _(exporter.state).must_equal(:called)
-      end
     end
   end
 

--- a/sdk/test/opentelemetry/sdk/trace/export/multi_span_exporter_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/export/multi_span_exporter_test.rb
@@ -55,8 +55,8 @@ describe OpenTelemetry::SDK::Trace::Export::MultiSpanExporter do
   end
 
   it 'returns an error from #export if one exporter fails' do
-    mock_span_exporter.expect :export, export::SUCCESS, [Object]
-    mock_span_exporter2.expect :export, export::FAILURE, [Object]
+    mock_span_exporter.expect(:export, export::SUCCESS) { |a| a.to_a == spans }
+    mock_span_exporter2.expect(:export, export::FAILURE) { |a| a.to_a == spans }
 
     _(exporter_multi.export(spans)).must_equal export::FAILURE
     mock_span_exporter.verify
@@ -64,7 +64,7 @@ describe OpenTelemetry::SDK::Trace::Export::MultiSpanExporter do
   end
 
   it 'synthesizes an error if an exporter raises an exception' do
-    def mock_span_exporter.export(_)
+    def mock_span_exporter.export(_, timeout: nil)
       raise ArgumentError
     end
 

--- a/sdk/test/opentelemetry/sdk/trace/export/multi_span_exporter_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/export/multi_span_exporter_test.rb
@@ -78,8 +78,8 @@ describe OpenTelemetry::SDK::Trace::Export::MultiSpanExporter do
   end
 
   it 'forwards a #shutdown call to all exporters' do
-    mock_span_exporter.expect :shutdown, nil
-    mock_span_exporter2.expect :shutdown, nil
+    mock_span_exporter.expect :shutdown, nil, [{ timeout: nil }]
+    mock_span_exporter2.expect :shutdown, nil, [{ timeout: nil }]
 
     exporter_multi.shutdown
     mock_span_exporter.verify

--- a/sdk/test/opentelemetry/sdk/trace/export/simple_span_processor_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/export/simple_span_processor_test.rb
@@ -96,7 +96,7 @@ describe OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor do
   end
 
   it 'forwards calls to #shutdown to the exporter' do
-    mock_span_exporter.expect :shutdown, nil
+    mock_span_exporter.expect :shutdown, nil, [{timeout: nil}]
 
     processor.shutdown
     mock_span_exporter.verify

--- a/sdk/test/opentelemetry/sdk/trace/export/simple_span_processor_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/export/simple_span_processor_test.rb
@@ -96,7 +96,7 @@ describe OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor do
   end
 
   it 'forwards calls to #shutdown to the exporter' do
-    mock_span_exporter.expect :shutdown, nil, [{timeout: nil}]
+    mock_span_exporter.expect :shutdown, nil, [{ timeout: nil }]
 
     processor.shutdown
     mock_span_exporter.verify

--- a/sdk/test/opentelemetry/sdk/trace/multi_span_processor_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/multi_span_processor_test.rb
@@ -39,8 +39,8 @@ describe OpenTelemetry::SDK::Trace::MultiSpanProcessor do
   end
 
   it 'implements #force_flush' do
-    mock_processor1.expect :force_flush, nil
-    mock_processor2.expect :force_flush, nil
+    mock_processor1.expect :force_flush, nil, [{ timeout: nil }]
+    mock_processor2.expect :force_flush, nil, [{ timeout: nil }]
 
     processor.force_flush
 
@@ -49,8 +49,8 @@ describe OpenTelemetry::SDK::Trace::MultiSpanProcessor do
   end
 
   it 'implements #shutdown' do
-    mock_processor1.expect :shutdown, nil
-    mock_processor2.expect :shutdown, nil
+    mock_processor1.expect :shutdown, nil, [{ timeout: nil }]
+    mock_processor2.expect :shutdown, nil, [{ timeout: nil }]
 
     processor.shutdown
 

--- a/sdk/test/opentelemetry/sdk/trace/tracer_provider_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/tracer_provider_test.rb
@@ -21,7 +21,7 @@ describe OpenTelemetry::SDK::Trace::TracerProvider do
     let(:mock_span_processor) { Minitest::Mock.new }
 
     it 'notifies the span processor' do
-      mock_span_processor.expect(:shutdown, nil)
+      mock_span_processor.expect(:shutdown, nil, [{ timeout: nil }])
       tracer_provider.add_span_processor(mock_span_processor)
       tracer_provider.shutdown
       mock_span_processor.verify
@@ -38,7 +38,7 @@ describe OpenTelemetry::SDK::Trace::TracerProvider do
     end
 
     it 'only notifies the span processor once' do
-      mock_span_processor.expect(:shutdown, nil)
+      mock_span_processor.expect(:shutdown, nil, [{ timeout: nil }])
       tracer_provider.add_span_processor(mock_span_processor)
       tracer_provider.shutdown
       tracer_provider.shutdown


### PR DESCRIPTION
[The spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#span-processor) allows language implementers to support an optional timeout parameter for `ForceFlush` and `Shutdown`, for Span Exporters and Span Processors. E.g.

> Language library authors can decide if they want to make the flush timeout configurable.

We've implicitly expected users to leverage `Timeout.timeout` for this purpose, however @robertlaurin and I were implementing this in Shopify's OTLP exporter, and it requires dealing with a ton of corner cases (since the `Timeout::Error` can be raised anywhere). If we instead add the optional `timeout` parameter and pass it down the chain (updating appropriately to account for passing time), we have much more control over where exactly we handle timeouts.

In many respects, this is more important for `force_flush`, where we want to ensure that internal state remains consistent if a timeout occurs, but it will probably not be uncommon for exporters to call `force_flush` as part of `shutdown`.

This PR adds an optional `timeout:` parameter to both methods and propagates that through various call chains.

## TODO:
- [x] Add tests for timeouts