### PR TITLE
export instrumentation library for jaeger

### DIFF
--- a/exporters/jaeger/lib/opentelemetry/exporters/jaeger/exporter/span_encoder.rb
+++ b/exporters/jaeger/lib/opentelemetry/exporters/jaeger/exporter/span_encoder.rb
@@ -24,7 +24,10 @@ module OpenTelemetry
               'flags' => span_data.trace_flags.sampled? ? 1 : 0,
               'startTime' => start_time,
               'duration' => duration,
-              'tags' => encoded_tags(span_data.attributes) + encoded_status(span_data.status) + encoded_kind(span_data.kind),
+              'tags' => encoded_tags(span_data.attributes) +
+                 encoded_status(span_data.status) +
+                 encoded_kind(span_data.kind) +
+                 encoded_instrumentation_library(span_data.instrumentation_library),
               'logs' => encoded_logs(span_data.events)
             )
           end
@@ -76,6 +79,21 @@ module OpenTelemetry
           def encoded_status(status)
             # TODO: OpenTracing doesn't specify how to report non-HTTP (i.e. generic) status.
             EMPTY_ARRAY
+          end
+
+          def encoded_instrumentation_library(instrumentation_library)
+            return EMPTY_ARRAY unless instrumentation_library
+            tags = []
+
+            if instrumentation_library.name
+              tags << encoded_tag('otel.instrumentation_library.name', instrumentation_library.name)
+            end
+
+            if instrumentation_library.version
+              tags << encoded_tag('otel.instrumentation_library.version', instrumentation_library.version)
+            end
+
+            tags
           end
 
           def encoded_tags(attributes)

--- a/exporters/jaeger/lib/opentelemetry/exporters/jaeger/exporter/span_encoder.rb
+++ b/exporters/jaeger/lib/opentelemetry/exporters/jaeger/exporter/span_encoder.rb
@@ -83,16 +83,10 @@ module OpenTelemetry
 
           def encoded_instrumentation_library(instrumentation_library)
             return EMPTY_ARRAY unless instrumentation_library
+
             tags = []
-
-            if instrumentation_library.name
-              tags << encoded_tag('otel.instrumentation_library.name', instrumentation_library.name)
-            end
-
-            if instrumentation_library.version
-              tags << encoded_tag('otel.instrumentation_library.version', instrumentation_library.version)
-            end
-
+            tags << encoded_tag('otel.instrumentation_library.name', instrumentation_library.name) if instrumentation_library.name
+            tags << encoded_tag('otel.instrumentation_library.version', instrumentation_library.version) if instrumentation_library.version
             tags
           end
 

--- a/exporters/jaeger/test/opentelemetry/exporters/jaeger/exporter/span_encoder_test.rb
+++ b/exporters/jaeger/test/opentelemetry/exporters/jaeger/exporter/span_encoder_test.rb
@@ -73,11 +73,9 @@ describe OpenTelemetry::Exporters::Jaeger::Exporter::SpanEncoder do
       _(name_tag.key).must_equal('otel.instrumentation_library.name')
       _(name_tag.vStr).must_equal('mylib')
 
-
       _(version_tag.key).must_equal('otel.instrumentation_library.version')
       _(version_tag.vStr).must_equal('0.1.0')
     end
-
 
     it 'skips nil values' do
       lib = OpenTelemetry::SDK::InstrumentationLibrary.new('mylib')

--- a/exporters/jaeger/test/opentelemetry/exporters/jaeger/exporter/span_encoder_test.rb
+++ b/exporters/jaeger/test/opentelemetry/exporters/jaeger/exporter/span_encoder_test.rb
@@ -60,7 +60,40 @@ describe OpenTelemetry::Exporters::Jaeger::Exporter::SpanEncoder do
     )
   end
 
-  def create_span_data(attributes: nil, events: nil, links: nil, trace_id: OpenTelemetry::Trace.generate_trace_id, trace_flags: OpenTelemetry::Trace::TraceFlags::DEFAULT, tracestate: nil)
+  describe 'instrumentation library' do
+    it 'encodes library and version when set' do
+      lib = OpenTelemetry::SDK::InstrumentationLibrary.new('mylib', '0.1.0')
+      span_data = create_span_data(instrumentation_library: lib)
+      encoded_span = span_encoder.encoded_span(span_data)
+
+      _(encoded_span.tags.size).must_equal(2)
+
+      name_tag, version_tag = encoded_span.tags
+
+      _(name_tag.key).must_equal('otel.instrumentation_library.name')
+      _(name_tag.vStr).must_equal('mylib')
+
+
+      _(version_tag.key).must_equal('otel.instrumentation_library.version')
+      _(version_tag.vStr).must_equal('0.1.0')
+    end
+
+
+    it 'skips nil values' do
+      lib = OpenTelemetry::SDK::InstrumentationLibrary.new('mylib')
+      span_data = create_span_data(instrumentation_library: lib)
+      encoded_span = span_encoder.encoded_span(span_data)
+
+      _(encoded_span.tags.size).must_equal(1)
+
+      name_tag, = encoded_span.tags
+
+      _(name_tag.key).must_equal('otel.instrumentation_library.name')
+      _(name_tag.vStr).must_equal('mylib')
+    end
+  end
+
+  def create_span_data(attributes: nil, events: nil, links: nil, instrumentation_library: nil, trace_id: OpenTelemetry::Trace.generate_trace_id, trace_flags: OpenTelemetry::Trace::TraceFlags::DEFAULT, tracestate: nil)
     OpenTelemetry::SDK::Trace::SpanData.new(
       '',
       nil,
@@ -76,7 +109,7 @@ describe OpenTelemetry::Exporters::Jaeger::Exporter::SpanEncoder do
       links,
       events,
       nil,
-      nil,
+      instrumentation_library,
       OpenTelemetry::Trace.generate_span_id,
       trace_id,
       trace_flags,


### PR DESCRIPTION
Fixes #344. This PR properly exports the instrumentation library by merging the name and version into span tags. See: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk_exporters/jaeger.md#instrumentationlibrary