### PR TITLE
Export resources from Jaeger

### DIFF
--- a/exporters/jaeger/lib/opentelemetry/exporters/jaeger/exporter.rb
+++ b/exporters/jaeger/lib/opentelemetry/exporters/jaeger/exporter.rb
@@ -83,8 +83,9 @@ module OpenTelemetry
             end
 
           grouped_encoded_spans.each_pair do |resource, encoded_spans|
+            process = encoded_process(resource)
             encoded_spans.chunk(&batcher).each do |batch_and_spans_with_size|
-              yield Thrift::Batch.new('process' => encoded_process(resource), 'spans' => batch_and_spans_with_size.last.map(&:first))
+              yield Thrift::Batch.new('process' => process, 'spans' => batch_and_spans_with_size.last.map(&:first))
             end
           end
           SUCCESS

--- a/exporters/jaeger/lib/opentelemetry/exporters/jaeger/exporter.rb
+++ b/exporters/jaeger/lib/opentelemetry/exporters/jaeger/exporter.rb
@@ -70,12 +70,19 @@ module OpenTelemetry
         # and the remaining batches will be discarded. Returns SUCCESS after all batches
         # have been successfully yielded.
         def encoded_batches(span_data)
-          encoded_spans = span_data.map(&method(:encoded_span))
-          encoded_span_sizes = encoded_spans.map(&method(:encoded_span_size))
-          return FAILURE if encoded_span_sizes.any? { |size| size > @max_packet_size }
+          grouped_encoded_spans = \
+            span_data.each_with_object(Hash.new { |h, k| h[k] = []}) do |span, memo|
+              encoded_data = encoded_span(span)
+              encoded_size = encoded_span_size(encoded_data)
+              return FAILURE if encoded_size > @max_packet_size
 
-          encoded_spans.zip(encoded_span_sizes).chunk(&batcher).each do |batch_and_spans_with_size|
-            yield Thrift::Batch.new('process' => encoded_process, 'spans' => batch_and_spans_with_size.last.map(&:first))
+              memo[span.library_resource] << [encoded_data, encoded_size]
+            end
+
+          grouped_encoded_spans.each_pair do |resource, encoded_spans|
+            encoded_spans.chunk(&batcher).each do |batch_and_spans_with_size|
+              yield Thrift::Batch.new('process' => encoded_process(resource), 'spans' => batch_and_spans_with_size.last.map(&:first))
+            end
           end
           SUCCESS
         end
@@ -122,12 +129,12 @@ module OpenTelemetry
           @transport.size
         end
 
-        def encoded_process
+        def encoded_process(resource)
           @encoded_process ||= begin
-            tags = [] # TODO: figure this out.
-            # tags = OpenTelemetry.tracer.resource.label_enumerator.map do |key, value|
-            #   Thrift::Tag.new('key' => key, 'vType' => Thrift::TagType::STRING, 'vStr' => value)
-            # end
+            tags = resource&.label_enumerator&.map do |key, value|
+              Thrift::Tag.new('key' => key, 'vType' => Thrift::TagType::STRING, 'vStr' => value)
+            end || EMPTY_ARRAY
+
             Thrift::Process.new('serviceName' => @service_name, 'tags' => tags)
           end
         end

--- a/exporters/jaeger/lib/opentelemetry/exporters/jaeger/exporter.rb
+++ b/exporters/jaeger/lib/opentelemetry/exporters/jaeger/exporter.rb
@@ -74,7 +74,7 @@ module OpenTelemetry
         # have been successfully yielded.
         def encoded_batches(span_data)
           grouped_encoded_spans = \
-            span_data.each_with_object(Hash.new { |h, k| h[k] = []}) do |span, memo|
+            span_data.each_with_object(Hash.new { |h, k| h[k] = [] }) do |span, memo|
               encoded_data = encoded_span(span)
               encoded_size = encoded_span_size(encoded_data)
               return FAILURE if encoded_size > @max_packet_size

--- a/exporters/jaeger/lib/opentelemetry/exporters/jaeger/exporter.rb
+++ b/exporters/jaeger/lib/opentelemetry/exporters/jaeger/exporter.rb
@@ -133,11 +133,8 @@ module OpenTelemetry
         end
 
         def encoded_process(resource)
-          @encoded_process ||= begin
-            tags = resource ? encoded_tags(resource.label_enumerator) : EMPTY_ARRAY
-
-            Thrift::Process.new('serviceName' => @service_name, 'tags' => tags)
-          end
+          tags = resource ? encoded_tags(resource.label_enumerator) : EMPTY_ARRAY
+          Thrift::Process.new('serviceName' => @service_name, 'tags' => tags)
         end
       end
     end

--- a/exporters/jaeger/lib/opentelemetry/exporters/jaeger/exporter.rb
+++ b/exporters/jaeger/lib/opentelemetry/exporters/jaeger/exporter.rb
@@ -79,7 +79,7 @@ module OpenTelemetry
               encoded_size = encoded_span_size(encoded_data)
               return FAILURE if encoded_size > @max_packet_size
 
-              memo[span.library_resource] << [encoded_data, encoded_size]
+              memo[span.resource] << [encoded_data, encoded_size]
             end
 
           grouped_encoded_spans.each_pair do |resource, encoded_spans|

--- a/exporters/jaeger/lib/opentelemetry/exporters/jaeger/exporter/encoding_utils.rb
+++ b/exporters/jaeger/lib/opentelemetry/exporters/jaeger/exporter/encoding_utils.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Exporters
+    module Jaeger
+      class Exporter
+        # @api private
+        module EncodingUtils
+          def encoded_tags(attributes)
+            attributes&.map do |key, value|
+              encoded_tag(key, value)
+            end || EMPTY_ARRAY
+          end
+
+          def encoded_tag(key, value)
+            @type_map ||= {
+              LONG => Thrift::TagType::LONG,
+              DOUBLE => Thrift::TagType::DOUBLE,
+              STRING => Thrift::TagType::STRING,
+              BOOL => Thrift::TagType::BOOL
+            }.freeze
+
+            value_key = case value
+                        when Integer then LONG
+                        when Float then DOUBLE
+                        when String, Array then STRING
+                        when false, true then BOOL
+                        end
+            value = value.to_json if value.is_a?(Array)
+            Thrift::Tag.new(
+              KEY => key,
+              TYPE => @type_map[value_key],
+              value_key => value
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/exporters/jaeger/test/opentelemetry/exporters/jaeger/exporter_test.rb
+++ b/exporters/jaeger/test/opentelemetry/exporters/jaeger/exporter_test.rb
@@ -81,8 +81,8 @@ describe OpenTelemetry::Exporters::Jaeger::Exporter do
       socket.bind('127.0.0.1', 0)
       exporter = OpenTelemetry::Exporters::Jaeger::Exporter.new(service_name: 'test', host: '127.0.0.1', port: socket.addr[1], max_packet_size: 128)
 
-      span_data1 = create_span_data(library_resource: OpenTelemetry::SDK::Resources::Resource.create('k1' => 'v1'))
-      span_data2 = create_span_data(library_resource: OpenTelemetry::SDK::Resources::Resource.create('k2' => 'v2'))
+      span_data1 = create_span_data(resource: OpenTelemetry::SDK::Resources::Resource.create('k1' => 'v1'))
+      span_data2 = create_span_data(resource: OpenTelemetry::SDK::Resources::Resource.create('k2' => 'v2'))
 
       result = exporter.export([span_data1, span_data2])
       packet1 = socket.recvfrom(65_000)
@@ -97,11 +97,11 @@ describe OpenTelemetry::Exporters::Jaeger::Exporter do
 
   def create_span_data(name: '', kind: nil, status: nil, parent_span_id: OpenTelemetry::Trace::INVALID_SPAN_ID, child_count: 0,
                        total_recorded_attributes: 0, total_recorded_events: 0, total_recorded_links: 0, start_timestamp: Time.now,
-                       end_timestamp: Time.now, attributes: nil, links: nil, events: nil, library_resource: nil, instrumentation_library: nil,
+                       end_timestamp: Time.now, attributes: nil, links: nil, events: nil, resource: nil, instrumentation_library: nil,
                        span_id: OpenTelemetry::Trace.generate_span_id, trace_id: OpenTelemetry::Trace.generate_trace_id,
                        trace_flags: OpenTelemetry::Trace::TraceFlags::DEFAULT, tracestate: nil)
     OpenTelemetry::SDK::Trace::SpanData.new(name, kind, status, parent_span_id, child_count, total_recorded_attributes,
                                             total_recorded_events, total_recorded_links, start_timestamp, end_timestamp,
-                                            attributes, links, events, library_resource, instrumentation_library, span_id, trace_id, trace_flags, tracestate)
+                                            attributes, links, events, resource, instrumentation_library, span_id, trace_id, trace_flags, tracestate)
   end
 end

--- a/sdk/lib/opentelemetry/sdk/trace/span.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span.rb
@@ -18,7 +18,7 @@ module OpenTelemetry
       class Span < OpenTelemetry::Trace::Span
         # The following readers are intended for the use of SpanProcessors and
         # should not be considered part of the public interface for instrumentation.
-        attr_reader :name, :status, :kind, :parent_span_id, :start_timestamp, :end_timestamp, :links, :library_resource, :instrumentation_library
+        attr_reader :name, :status, :kind, :parent_span_id, :start_timestamp, :end_timestamp, :links, :resource, :instrumentation_library
 
         # Return a frozen copy of the current attributes. This is intended for
         # use of SpanProcesses and should not be considered part of the public
@@ -227,7 +227,7 @@ module OpenTelemetry
             @attributes,
             @links,
             @events,
-            @library_resource,
+            @resource,
             @instrumentation_library,
             context.span_id,
             context.trace_id,
@@ -237,7 +237,7 @@ module OpenTelemetry
         end
 
         # @api private
-        def initialize(context, name, kind, parent_span_id, trace_config, span_processor, attributes, links, start_timestamp, library_resource, instrumentation_library) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+        def initialize(context, name, kind, parent_span_id, trace_config, span_processor, attributes, links, start_timestamp, resource, instrumentation_library) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
           super(span_context: context)
           @mutex = Mutex.new
           @name = name
@@ -245,7 +245,7 @@ module OpenTelemetry
           @parent_span_id = parent_span_id.freeze || OpenTelemetry::Trace::INVALID_SPAN_ID
           @trace_config = trace_config
           @span_processor = span_processor
-          @library_resource = library_resource
+          @resource = resource
           @instrumentation_library = instrumentation_library
           @ended = false
           @status = nil

--- a/sdk/lib/opentelemetry/sdk/trace/span_data.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span_data.rb
@@ -23,7 +23,7 @@ module OpenTelemetry
                             :attributes,
                             :links,
                             :events,
-                            :library_resource,
+                            :resource,
                             :instrumentation_library,
                             :span_id,
                             :trace_id,


### PR DESCRIPTION
Fixes #312 and #314.

This PR updates the Jaeger exporter to export resources as process tags. It properly accounts for multiple resources in the same process, by grouping by resource and sending associated spans in batches.

cc: @genebean