### PR TITLE
updates rack's bundler dependency to match the rest of instrumentations

### DIFF
--- a/instrumentation/rack/opentelemetry-instrumentation-rack.gemspec
+++ b/instrumentation/rack/opentelemetry-instrumentation-rack.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-api', '~> 0.5.0'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
-  spec.add_development_dependency 'bundler', '~> 2.0.2'
+  spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 0.0'
   spec.add_development_dependency 'rack', '~> 2.0.8'


### PR DESCRIPTION
The rack instrumentation references `bundler ~> 2.0.2` which is atypical and leads to the following error:

```
**** Entering instrumentation/rack
bundle install
Fetching gem metadata from https://rubygems.org/.........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler (~> 2.0.2)

  Current Bundler version:
    bundler (2.1.4)
This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?

Could not find gem 'bundler (~> 2.0.2)' in any of the relevant sources:
  the local ruby installation
rake aborted!
Command failed with status (6): [bundle install...]
/Users/mlang/projects/otel/mwlang/opentelemetry-ruby/Rakefile:147:in `block (3 levels) in foreach_gem'
/Users/mlang/.rvm/gems/ruby-2.6.5/gems/bundler-2.1.4/lib/bundler.rb:376:in `block in with_clean_env'
/Users/mlang/.rvm/gems/ruby-2.6.5/gems/bundler-2.1.4/lib/bundler.rb:677:in `with_env'
/Users/mlang/.rvm/gems/ruby-2.6.5/gems/bundler-2.1.4/lib/bundler.rb:376:in `with_clean_env'
/Users/mlang/projects/otel/mwlang/opentelemetry-ruby/Rakefile:146:in `block (2 levels) in foreach_gem'
/Users/mlang/projects/otel/mwlang/opentelemetry-ruby/Rakefile:144:in `chdir'
/Users/mlang/projects/otel/mwlang/opentelemetry-ruby/Rakefile:144:in `block in foreach_gem'
/Users/mlang/projects/otel/mwlang/opentelemetry-ruby/Rakefile:141:in `each'
/Users/mlang/projects/otel/mwlang/opentelemetry-ruby/Rakefile:141:in `foreach_gem'
/Users/mlang/projects/otel/mwlang/opentelemetry-ruby/Rakefile:9:in `block (2 levels) in <top (required)>'
/Users/mlang/.rvm/gems/ruby-2.6.5/gems/rake-12.3.3/exe/rake:27:in `<top (required)>'
/Users/mlang/.rvm/gems/ruby-2.6.5/bin/ruby_executable_hooks:24:in `eval'
/Users/mlang/.rvm/gems/ruby-2.6.5/bin/ruby_executable_hooks:24:in `<main>'
Tasks: TOP => each:bundle_install
(See full trace by running task with --trace)
```

Grepping all the other instrumentation gemspecs: 
```
instrumentation >> grep bundler **/*.gemspec
all/opentelemetry-instrumentation-all.gemspec:  spec.add_development_dependency 'bundler', '>= 1.17'
concurrent_ruby/opentelemetry-instrumentation-concurrent_ruby.gemspec:  spec.add_development_dependency 'bundler', '>= 1.17'
ethon/opentelemetry-instrumentation-ethon.gemspec:  spec.add_development_dependency 'bundler', '>= 1.17'
excon/opentelemetry-instrumentation-excon.gemspec:  spec.add_development_dependency 'bundler', '>= 1.17'
faraday/opentelemetry-instrumentation-faraday.gemspec:  spec.add_development_dependency 'bundler', '>= 1.17'
mysql2/opentelemetry-instrumentation-mysql2.gemspec:  spec.add_development_dependency 'bundler', '>= 1.17'
net_http/opentelemetry-instrumentation-net_http.gemspec:  spec.add_development_dependency 'bundler', '>= 1.17'
rack/opentelemetry-instrumentation-rack.gemspec:  spec.add_development_dependency 'bundler', '~> 2.0.2'
redis/opentelemetry-instrumentation-redis.gemspec:  spec.add_development_dependency 'bundler', '>= 1.17'
restclient/opentelemetry-instrumentation-restclient.gemspec:  spec.add_development_dependency 'bundler', '>= 1.17'
sidekiq/opentelemetry-instrumentation-sidekiq.gemspec:  spec.add_development_dependency 'bundler', '>= 1.17'
sinatra/opentelemetry-instrumentation-sinatra.gemspec:  spec.add_development_dependency 'bundler', '>= 1.17'
```

Changing the dependency from `~> 2.0.2` to `>= 1.17` resolves:

```
rack >> bundle install
Fetching gem metadata from https://rubygems.org/.........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Using rake 12.3.3
Using public_suffix 4.0.5
Using addressable 2.7.0
Using bundler 2.1.4
Using thor 1.0.1
Using appraisal 2.2.0
Using ast 2.4.1
Using safe_yaml 1.0.5
Using crack 0.4.3
Using docile 1.3.2
Using hashdiff 1.0.1
Using jaro_winkler 1.5.4
Using json 2.3.1
Using minitest 5.14.2
Using opentelemetry-api 0.5.1 from source at `../../api`
Using opentelemetry-instrumentation-rack 0.5.0 from source at `.`
Using opentelemetry-sdk 0.5.1 from source at `../../sdk`
Using parallel 1.19.2
Using parser 2.7.1.4
Using rack 2.0.9
Using rack-test 1.1.0
Using rainbow 3.0.0
Using ruby-progressbar 1.10.1
Using unicode-display_width 1.6.1
Using rubocop 0.73.0
Using simplecov-html 0.10.2
Using simplecov 0.17.1
Using webmock 3.7.6
Using yard 0.9.25
Using yard-doctest 0.1.17
Bundle complete! 14 Gemfile dependencies, 30 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.

>> rake test
Run options: --seed 33608

# Running:

.................................

Finished in 0.078571s, 420.0023 runs/s, 560.0031 assertions/s.

33 runs, 44 assertions, 0 failures, 0 errors, 0 skips
```