### PR TITLE
chore: Better error and edge case checking when modifying version and changelog

### DIFF
--- a/.toys/release/.lib/release_requester.rb
+++ b/.toys/release/.lib/release_requester.rb
@@ -225,8 +225,14 @@ class ReleaseRequester
       path = @utils.gem_version_rb_path(@gem_name, from: :context)
       @utils.log("Modifying version file #{path}")
       content = ::File.read(path)
-      content.sub!(/  VERSION = "\d+\.\d+\.\d+(?:\.\w+)*"/,
-                   "  VERSION = \"#{@new_version}\"")
+      original_content = content.dup
+      changed = content.sub!(/  VERSION\s*=\s*(["'])\d+\.\d+\.\d+(?:\.\w+)*["']/,
+                             "  VERSION = \\1#{@new_version}\\1")
+      @utils.error("Could not find VERSION constant for #{@gem_name} in #{path}") unless changed
+      if content == original_content
+        @utils.warning("Version constant for #{@gem_name} is already #{@new_version}.")
+        return
+      end
       ::File.open(path, "w") { |file| file.write(content) }
     end
 
@@ -234,8 +240,12 @@ class ReleaseRequester
       path = @utils.gem_changelog_path(@gem_name, from: :context)
       @utils.log("Modifying changelog file #{path}")
       content = ::File.read(path)
-      changed = content.sub!(%r{\n### (v\d+\.\d+\.\d+ / \d\d\d\d-\d\d-\d\d)},
-                             "\n#{@full_changelog}\n\n### \\1")
+      if content =~ %r{\n### v#{@new_version} / \d\d\d\d-\d\d-\d\d\n}
+        @utils.warning("Changelog entry for #{@gem_name} #{@new_version} already seems to exist.")
+        return
+      end
+      changed = content.sub!(%r{\n### (v\d+\.\d+\.\d+ / \d\d\d\d-\d\d-\d\d)\n},
+                             "\n#{@full_changelog}\n\n### \\1\n")
       unless changed
         content << "\n" until content.end_with?("\n\n")
         content << @full_changelog << "\n"
@@ -346,6 +356,9 @@ class ReleaseRequester
   end
 
   def create_release_commit
+    if @utils.capture(["git", "diff"]).strip.empty?
+      @utils.error("No changes to make. Are you sure the version to release is correct?")
+    end
     check_branch_cmd = ["git", "rev-parse", "--verify", "--quiet", @release_branch_name]
     if @utils.exec(check_branch_cmd, e: false).success?
       @utils.exec(["git", "branch", "-D", @release_branch_name])

--- a/.toys/release/.lib/release_requester.rb
+++ b/.toys/release/.lib/release_requester.rb
@@ -297,6 +297,9 @@ class ReleaseRequester
 
   def gem_info(gem_name, override_version: nil)
     raise "Gem list is already finished" if @gem_info_list.frozen?
+    if @gem_info_list.any? { |gem_info| gem_info.gem_name == gem_name }
+      @utils.error("Gem #{gem_name} listed multiple times in release request")
+    end
     initial_setup unless @performed_initial_setup
     info = GemInfo.new(@utils, gem_name, override_version, @release_ref)
     @gem_info_list << info

--- a/.toys/release/create-labels.rb
+++ b/.toys/release/create-labels.rb
@@ -93,7 +93,7 @@ def update_label(label)
   label_name = label["name"]
   return unless yes || confirm("Update fields of \"#{label_name}\"? ", default: true)
   body = ::JSON.dump(color: label["color"], description: label["description"])
-  exec(["gh", "api", "-XPATCH", ::CGI.escape("repos/#{@utils.repo_path}/labels/#{label_name}"),
+  exec(["gh", "api", "-XPATCH", "repos/#{@utils.repo_path}/labels/#{label_name}",
         "--input", "-", "-H", "Accept: application/vnd.github.v3+json"],
        in: [:string, body], out: :null)
 end
@@ -101,7 +101,7 @@ end
 def delete_label(label)
   label_name = label["name"]
   return unless yes || confirm("Label \"#{label_name}\" unrecognized. Delete? ", default: true)
-  exec(["gh", "api", "-XDELETE", ::CGI.escape("repos/#{@utils.repo_path}/labels/#{label_name}"),
+  exec(["gh", "api", "-XDELETE", "repos/#{@utils.repo_path}/labels/#{label_name}",
         "-H", "Accept: application/vnd.github.v3+json"],
        out: :null)
 end

--- a/.toys/release/request.rb
+++ b/.toys/release/request.rb
@@ -43,7 +43,12 @@ flag :gems, "--gems=VAL" do
     "If no version is specified for a gem, a version is inferred from the" \
       " conventional commit messages. If this flag is omitted or left blank," \
       " all gems in the repository that have at least one commit of type" \
-      " 'fix', 'feat', or 'docs', or a breaking change, will be released."
+      " 'fix', 'feat', or 'docs', or a breaking change, will be released.",
+    "",
+    "You can also use the special gem name 'all' which forces release of all" \
+      " gems in the repository regardless of whether they have significant" \
+      " changes. You can also supply a version with 'all' to release all gems" \
+      " with the same version."
 end
 flag :git_remote, "--git-remote=VAL" do
   default "origin"

--- a/.toys/release/request.rb
+++ b/.toys/release/request.rb
@@ -109,7 +109,13 @@ def populate_requester
   gem_list = gems.to_s.empty? ? @utils.all_gems : gems.split(/[\s,]+/)
   gem_list.each do |entry|
     gem_name, override_version = entry.split(":", 2)
-    requester.gem_info(gem_name, override_version: override_version)
+    if gem_name == "all"
+      @utils.all_gems.each do |name|
+        requester.gem_info(name, override_version: override_version)
+      end
+    else
+      requester.gem_info(gem_name, override_version: override_version)
+    end
   end
   requester
 end

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -229,7 +229,9 @@ Releases are normally performed using GitHub Actions.
         by including their names, space-delimited, in this this field. You can
         optionally append `:<version>` to any gem in the list to specify the
         version to release, or omit the version to let the script decide based
-        on conventional commits.
+        on conventional commits. You can also use the special name `all` to
+        force release of all gems (and even `all:<version>` to release all gems
+        with the same version.)
  3. The workflow will analyze the conventional commit messages for the gems to
     release, and will open a _release pull request_. This pull request will
     include the appropriate changes to each gem's version constants, and an


### PR DESCRIPTION
Changes to release scripts:

* Relax the version constant regex so it recognizes single quotes and different spacing
* Fail fast if the version constant cannot be found
* Issue a warning if the version constant was already set to the new version
* If a changelog entry for the new version already exists, issue a warning and do not add another
* Display a more helpful error if no changes were made and the PR would be empty
* Support for force-releasing all gems by using the gem name "all".
* Remove spurious escaping when updating labels