### PR TITLE
Added README for concurrent ruby 

### DIFF
--- a/instrumentation/concurrent_ruby/README.md
+++ b/instrumentation/concurrent_ruby/README.md
@@ -40,7 +40,7 @@ The OpenTelemetry Ruby gems are maintained by the OpenTelemetry-Ruby special int
 
 Apache 2.0 license. See [LICENSE][license-github] for more information.
 
-[concurentruby-home]: https://github.com/ruby-concurrency/concurrent-ruby
+[concurrent-ruby-home]: https://github.com/ruby-concurrency/concurrent-ruby
 [bundler-home]: https://bundler.io
 [repo-github]: https://github.com/open-telemetry/opentelemetry-ruby
 [license-github]: https://github.com/open-telemetry/opentelemetry-ruby/blob/master/LICENSE

--- a/instrumentation/concurrent_ruby/README.md
+++ b/instrumentation/concurrent_ruby/README.md
@@ -1,0 +1,49 @@
+# OpenTelemetry Concurrent Ruby Instrumentation
+
+The OpenTelemetry Concurrent Ruby gem is a community maintained instrumentation for the [Concurrent Ruby][concurentruby-home]. This is a concurrency toolkit inspired from various languages and classic concurrency patterns. 
+
+## How do I get started?
+
+Install the gem using:
+
+```
+gem install opentelemetry-instrumentation-concurrent_ruby
+```
+
+Or, if you use [bundler][bundler-home], include `opentelemetry-instrumentation-concurrent_ruby` in your `Gemfile`.
+
+## Usage
+
+To install the instrumentation, call `use` with the name of the instrumentation.
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::ConcurrentRuby'
+end
+```
+
+Alternatively, you can also call `use_all` to install all the available instrumentation.
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use_all
+end
+```
+
+## How can I get involved?
+
+The `opentelemetry-instrumentation-concurrent_ruby` gem source is [on github][repo-github], along with related gems including `opentelemetry-api` and `opentelemetry-sdk`.
+
+The OpenTelemetry Ruby gems are maintained by the OpenTelemetry-Ruby special interest group (SIG). You can get involved by joining us on our [gitter channel][ruby-gitter] or attending our weekly meeting. See the [meeting calendar][community-meetings] for dates and times. For more information on this and other language SIGs, see the OpenTelemetry [community page][ruby-sig].
+
+## License
+
+Apache 2.0 license. See [LICENSE][license-github] for more information.
+
+[concurentruby-home]: https://github.com/ruby-concurrency/concurrent-ruby
+[bundler-home]: https://bundler.io
+[repo-github]: https://github.com/open-telemetry/opentelemetry-ruby
+[license-github]: https://github.com/open-telemetry/opentelemetry-ruby/blob/master/LICENSE
+[ruby-sig]: https://github.com/open-telemetry/community#ruby-sig
+[community-meetings]: https://github.com/open-telemetry/community#community-meetings
+[ruby-gitter]: https://gitter.im/open-telemetry/opentelemetry-ruby

--- a/instrumentation/concurrent_ruby/README.md
+++ b/instrumentation/concurrent_ruby/README.md
@@ -1,6 +1,6 @@
 # OpenTelemetry Concurrent Ruby Instrumentation
 
-The OpenTelemetry Concurrent Ruby gem is a community maintained instrumentation for the [Concurrent Ruby][concurentruby-home]. This is a concurrency toolkit inspired from various languages and classic concurrency patterns. 
+The OpenTelemetry Concurrent Ruby gem is a community maintained instrumentation for the [Concurrent Ruby][concurrent-ruby-home]. This is a concurrency toolkit inspired from various languages and classic concurrency patterns. 
 
 ## How do I get started?
 


### PR DESCRIPTION
This PR adds documentation for Concurrent Ruby, closing [#234.](https://github.com/open-telemetry/opentelemetry-ruby/issues/234)

I have added a README document describing the Concurrent ruby gem, installation methods and its license. 