### PR TITLE
docs: fix use of add_event in OTLP doc

### DIFF
--- a/exporter/otlp/README.md
+++ b/exporter/otlp/README.md
@@ -54,7 +54,7 @@ tracer.in_span('foo') do |span|
   # set an attribute
   span.set_attribute('platform', 'osx')
   # add an event
-  span.add_event(name: 'event in bar')
+  span.add_event('event in bar')
   # create bar as child of foo
   tracer.in_span('bar') do |child_span|
     # inspect the span


### PR DESCRIPTION
The named parameter was replaced with a positional parameter.

Reported in #380 