### PR TITLE
fix! remove child_count

### DIFF
--- a/exporter/jaeger/test/opentelemetry/exporters/jaeger/encoder_test.rb
+++ b/exporter/jaeger/test/opentelemetry/exporters/jaeger/encoder_test.rb
@@ -112,7 +112,6 @@ describe OpenTelemetry::Exporter::Jaeger::Encoder do
       0,
       0,
       0,
-      0,
       Time.now,
       Time.now,
       attributes,

--- a/exporter/jaeger/test/test_helper.rb
+++ b/exporter/jaeger/test/test_helper.rb
@@ -11,12 +11,12 @@ require 'opentelemetry/exporter/jaeger'
 require 'minitest/autorun'
 require 'webmock/minitest'
 
-def create_span_data(name: '', kind: nil, status: nil, parent_span_id: OpenTelemetry::Trace::INVALID_SPAN_ID, child_count: 0,
+def create_span_data(name: '', kind: nil, status: nil, parent_span_id: OpenTelemetry::Trace::INVALID_SPAN_ID,
                      total_recorded_attributes: 0, total_recorded_events: 0, total_recorded_links: 0, start_timestamp: Time.now,
                      end_timestamp: Time.now, attributes: nil, links: nil, events: nil, resource: nil, instrumentation_library: nil,
                      span_id: OpenTelemetry::Trace.generate_span_id, trace_id: OpenTelemetry::Trace.generate_trace_id,
                      trace_flags: OpenTelemetry::Trace::TraceFlags::DEFAULT, tracestate: nil)
-  OpenTelemetry::SDK::Trace::SpanData.new(name, kind, status, parent_span_id, child_count, total_recorded_attributes,
+  OpenTelemetry::SDK::Trace::SpanData.new(name, kind, status, parent_span_id, total_recorded_attributes,
                                           total_recorded_events, total_recorded_links, start_timestamp, end_timestamp,
                                           attributes, links, events, resource, instrumentation_library, span_id, trace_id, trace_flags, tracestate)
 end

--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -298,14 +298,14 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
     end
   end
 
-  def create_span_data(name: '', kind: nil, status: nil, parent_span_id: OpenTelemetry::Trace::INVALID_SPAN_ID, child_count: 0,
+  def create_span_data(name: '', kind: nil, status: nil, parent_span_id: OpenTelemetry::Trace::INVALID_SPAN_ID,
                        total_recorded_attributes: 0, total_recorded_events: 0, total_recorded_links: 0, start_timestamp: Time.now,
                        end_timestamp: Time.now, attributes: nil, links: nil, events: nil, resource: nil,
                        instrumentation_library: OpenTelemetry::SDK::InstrumentationLibrary.new('', 'v0.0.1'),
                        span_id: OpenTelemetry::Trace.generate_span_id, trace_id: OpenTelemetry::Trace.generate_trace_id,
                        trace_flags: OpenTelemetry::Trace::TraceFlags::DEFAULT, tracestate: nil)
     resource ||= OpenTelemetry::SDK::Resources::Resource.telemetry_sdk
-    OpenTelemetry::SDK::Trace::SpanData.new(name, kind, status, parent_span_id, child_count, total_recorded_attributes,
+    OpenTelemetry::SDK::Trace::SpanData.new(name, kind, status, parent_span_id, total_recorded_attributes,
                                             total_recorded_events, total_recorded_links, start_timestamp, end_timestamp,
                                             attributes, links, events, resource, instrumentation_library, span_id, trace_id, trace_flags, tracestate)
   end

--- a/sdk/lib/opentelemetry/sdk/trace/span.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span.rb
@@ -219,7 +219,6 @@ module OpenTelemetry
             @kind,
             @status,
             @parent_span_id,
-            @child_count,
             @total_recorded_attributes,
             @total_recorded_events,
             @total_recorded_links,
@@ -250,7 +249,6 @@ module OpenTelemetry
           @instrumentation_library = instrumentation_library
           @ended = false
           @status = nil
-          @child_count = 0
           @total_recorded_events = 0
           @total_recorded_links = links&.size || 0
           @total_recorded_attributes = attributes&.size || 0

--- a/sdk/lib/opentelemetry/sdk/trace/span.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span.rb
@@ -237,7 +237,7 @@ module OpenTelemetry
         end
 
         # @api private
-        def initialize(context, name, kind, parent_span_id, trace_config, span_processor, attributes, links, start_timestamp, resource, instrumentation_library) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+        def initialize(context, name, kind, parent_span_id, trace_config, span_processor, attributes, links, start_timestamp, resource, instrumentation_library) # rubocop:disable Metrics/AbcSize
           super(span_context: context)
           @mutex = Mutex.new
           @name = name

--- a/sdk/lib/opentelemetry/sdk/trace/span_data.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span_data.rb
@@ -14,7 +14,6 @@ module OpenTelemetry
                             :kind,
                             :status,
                             :parent_span_id,
-                            :child_count,
                             :total_recorded_attributes,
                             :total_recorded_events,
                             :total_recorded_links,


### PR DESCRIPTION
`child_count` is not required or supported by OTLP, so we don't need to
record it anymore in `SpanData` or track it in `Span` (we weren't, but we
had an unnecessary instance variable).

This is a breaking change for `SpanExporter`s that may have used
`SpanData`'s child_count. None of the exporters in this repo used it,
and I doubt anyone else did either.