### PR TITLE
refactor: remove extracted span context special case

### DIFF
--- a/api/lib/opentelemetry/trace/propagation/trace_context/text_map_extractor.rb
+++ b/api/lib/opentelemetry/trace/propagation/trace_context/text_map_extractor.rb
@@ -47,7 +47,8 @@ module OpenTelemetry
                                                   trace_flags: tp.flags,
                                                   tracestate: tracestate,
                                                   remote: true)
-            context.set_value(ContextKeys.extracted_span_context_key, span_context)
+            span = Trace::Span.new(span_context: span_context)
+            context.set_value(ContextKeys.current_span_key, span)
           rescue OpenTelemetry::Error
             context
           end

--- a/api/lib/opentelemetry/trace/propagation/trace_context/text_map_injector.rb
+++ b/api/lib/opentelemetry/trace/propagation/trace_context/text_map_injector.rb
@@ -45,8 +45,7 @@ module OpenTelemetry
           private
 
           def span_context_from(context)
-            context[ContextKeys.current_span_key]&.context ||
-              context[ContextKeys.extracted_span_context_key]
+            context[ContextKeys.current_span_key]&.context
           end
         end
       end

--- a/api/lib/opentelemetry/trace/tracer.rb
+++ b/api/lib/opentelemetry/trace/tracer.rb
@@ -17,24 +17,9 @@ module OpenTelemetry
       #
       # @param [optional Context] context The context to lookup the current
       #   {Span} from. Defaults to Context.current
-      def current_span(context = Context.current)
-        context.value(CURRENT_SPAN_KEY) || Span::INVALID
-      end
-
-      # Returns the the active span context from the given {Context}, or current
-      # if one is not explicitly passed in. The active span context may refer to
-      # a {SpanContext} that has been extracted. If both a current {Span} and an
-      # extracted, {SpanContext} exist, the context of the current {Span} will be
-      # returned.
-      #
-      # @param [optional Context] context The context to lookup the active
-      #   {SpanContext} from.
-      #
-      def active_span_context(context = nil)
+      def current_span(context = nil)
         context ||= Context.current
-        context.value(CURRENT_SPAN_KEY)&.context ||
-          context.value(EXTRACTED_SPAN_CONTEXT_KEY) ||
-          SpanContext::INVALID
+        context.value(CURRENT_SPAN_KEY) || Span::INVALID
       end
 
       # This is a helper for the default use-case of extending the current trace with a span.
@@ -92,7 +77,7 @@ module OpenTelemetry
       #
       # @return [Span]
       def start_span(name, with_parent: nil, with_parent_context: nil, attributes: nil, links: nil, start_timestamp: nil, kind: nil)
-        span_context = with_parent&.context || active_span_context(with_parent_context)
+        span_context = with_parent&.context || current_span(with_parent_context).context
         if span_context.valid?
           Span.new(span_context: span_context)
         else

--- a/api/lib/opentelemetry/trace/tracer.rb
+++ b/api/lib/opentelemetry/trace/tracer.rb
@@ -8,10 +8,9 @@ module OpenTelemetry
   module Trace
     # No-op implementation of Tracer.
     class Tracer
-      EXTRACTED_SPAN_CONTEXT_KEY = Propagation::ContextKeys.extracted_span_context_key
       CURRENT_SPAN_KEY = Propagation::ContextKeys.current_span_key
 
-      private_constant :EXTRACTED_SPAN_CONTEXT_KEY, :CURRENT_SPAN_KEY
+      private_constant :CURRENT_SPAN_KEY
 
       # Returns the current span from the current or provided context
       #

--- a/api/test/opentelemetry/trace/propagation/trace_context/text_extractor_test.rb
+++ b/api/test/opentelemetry/trace/propagation/trace_context/text_extractor_test.rb
@@ -7,8 +7,8 @@
 require 'test_helper'
 
 describe OpenTelemetry::Trace::Propagation::TraceContext::TextMapExtractor do
-  let(:span_context_key) do
-    OpenTelemetry::Trace::Propagation::ContextKeys.extracted_span_context_key
+  let(:current_span_key) do
+    OpenTelemetry::Trace::Propagation::ContextKeys.current_span_key
   end
   let(:traceparent_key) { 'traceparent' }
   let(:tracestate_key) { 'tracestate' }
@@ -46,7 +46,7 @@ describe OpenTelemetry::Trace::Propagation::TraceContext::TextMapExtractor do
 
     it 'returns a remote SpanContext with fields from the traceparent and tracestate headers' do
       ctx = extractor.extract(carrier, context) { |c, k| c[k] }
-      span_context = ctx[span_context_key]
+      span_context = ctx[current_span_key].context
       _(span_context).must_be :remote?
       _(span_context.trace_id).must_equal(("\0" * 15 + "\xaa").b)
       _(span_context.span_id).must_equal(("\0" * 7 + "\xea").b)
@@ -56,7 +56,7 @@ describe OpenTelemetry::Trace::Propagation::TraceContext::TextMapExtractor do
 
     it 'uses a default getter if one is not provided' do
       ctx = extractor.extract(carrier, context)
-      span_context = ctx[span_context_key]
+      span_context = ctx[current_span_key].context
       _(span_context).must_be :remote?
       _(span_context.trace_id).must_equal(("\0" * 15 + "\xaa").b)
       _(span_context.span_id).must_equal(("\0" * 7 + "\xea").b)
@@ -67,8 +67,7 @@ describe OpenTelemetry::Trace::Propagation::TraceContext::TextMapExtractor do
     it 'returns original context on error' do
       ctx = extractor.extract({}, context) { invalid_traceparent_header }
       _(ctx).must_equal(context)
-      span_context = ctx[span_context_key]
-      _(span_context).must_be_nil
+      _(ctx[current_span_key]).must_be_nil
     end
   end
 end

--- a/api/test/opentelemetry/trace/tracer_test.rb
+++ b/api/test/opentelemetry/trace/tracer_test.rb
@@ -62,38 +62,6 @@ describe OpenTelemetry::Trace::Tracer do
     end
   end
 
-  describe '#active_span_context' do
-    let(:current_span) { tracer.start_span('current') }
-
-    it 'returns an invalid span context by default' do
-      _(tracer.active_span_context).must_equal(invalid_span_context)
-    end
-
-    it 'returns the span context from the current context by default' do
-      wrapper_span = tracer.start_span('wrapper')
-
-      tracer.with_span(wrapper_span) do
-        _(tracer.active_span_context).must_equal(wrapper_span.context)
-      end
-    end
-
-    it 'returns span context from implicit and explicit contexts' do
-      wrapper_span = tracer.start_span('wrapper')
-      wrapper_ctx = nil
-
-      tracer.with_span(wrapper_span) do
-        wrapper_ctx = Context.current
-      end
-
-      inner_span = tracer.start_span('inner')
-
-      tracer.with_span(inner_span) do
-        _(tracer.active_span_context).must_equal(inner_span.context)
-        _(tracer.active_span_context(wrapper_ctx)).must_equal(wrapper_span.context)
-      end
-    end
-  end
-
   describe '#in_span' do
     let(:parent) { tracer.start_span('parent') }
 
@@ -168,21 +136,6 @@ describe OpenTelemetry::Trace::Tracer do
         end
 
         _(tracer.current_span).must_equal(outer)
-      end
-    end
-
-    it 'should reactivate the span context after the block' do
-      outer = tracer.start_span('outer')
-      inner = tracer.start_span('inner')
-
-      tracer.with_span(outer) do
-        _(tracer.active_span_context).must_equal(outer.context)
-
-        tracer.with_span(inner) do
-          _(tracer.active_span_context).must_equal(inner.context)
-        end
-
-        _(tracer.active_span_context).must_equal(outer.context)
       end
     end
   end

--- a/api/test/opentelemetry/trace/tracer_test.rb
+++ b/api/test/opentelemetry/trace/tracer_test.rb
@@ -31,8 +31,8 @@ describe OpenTelemetry::Trace::Tracer do
   let(:parent_span_context) { OpenTelemetry::Trace::SpanContext.new }
   let(:parent_context) do
     OpenTelemetry::Context.empty.set_value(
-      OpenTelemetry::Trace::Propagation::ContextKeys.extracted_span_context_key,
-      parent_span_context
+      OpenTelemetry::Trace::Propagation::ContextKeys.current_span_key,
+      OpenTelemetry::Trace::Span.new(span_context: parent_span_context)
     )
   end
   let(:current_span_key) do

--- a/sdk/lib/opentelemetry/sdk/trace/tracer.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/tracer.rb
@@ -36,7 +36,7 @@ module OpenTelemetry
         def start_span(name, with_parent: nil, with_parent_context: nil, attributes: nil, links: nil, start_timestamp: nil, kind: nil)
           name ||= 'empty'
 
-          parent_span_context = with_parent&.context || active_span_context(with_parent_context)
+          parent_span_context = with_parent&.context || current_span(with_parent_context).context
           parent_span_context = nil unless parent_span_context.valid?
           parent_span_id = parent_span_context&.span_id
           tracestate = parent_span_context&.tracestate

--- a/sdk/test/integration/global_tracer_configurations_test.rb
+++ b/sdk/test/integration/global_tracer_configurations_test.rb
@@ -55,8 +55,8 @@ describe OpenTelemetry::SDK, 'global_tracer_configurations' do
     let(:parent_span_context) { OpenTelemetry::Trace::SpanContext.new(tracestate: mock_tracestate, trace_flags: OpenTelemetry::Trace::TraceFlags::SAMPLED) }
     let(:parent_context) do
       OpenTelemetry::Context.empty.set_value(
-        OpenTelemetry::Trace::Propagation::ContextKeys.extracted_span_context_key,
-        parent_span_context
+        OpenTelemetry::Trace::Propagation::ContextKeys.current_span_key,
+        OpenTelemetry::Trace::Span.new(span_context: parent_span_context)
       )
     end
 

--- a/sdk/test/opentelemetry/sdk/trace/tracer_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/tracer_test.rb
@@ -149,8 +149,8 @@ describe OpenTelemetry::SDK::Trace::Tracer do
     end
     let(:context) do
       OpenTelemetry::Context.empty.set_value(
-        OpenTelemetry::Trace::Propagation::ContextKeys.extracted_span_context_key,
-        span_context
+        OpenTelemetry::Trace::Propagation::ContextKeys.current_span_key,
+        OpenTelemetry::Trace::Span.new(span_context: span_context)
       )
     end
 


### PR DESCRIPTION
Before this PR a context could contain an extracted span context, a current span, no span context, or both an extracted span context and a current span. This PR removes the special case handling needed for managing an extracted span context by wrapping it in a noop API span. With this simplification we only need to manage the current span.

Related to: https://github.com/open-telemetry/opentelemetry-specification/issues/949