### PR TITLE
fix! implement new Span.Status spec

### DIFF
--- a/api/lib/opentelemetry/trace/status.rb
+++ b/api/lib/opentelemetry/trace/status.rb
@@ -26,7 +26,7 @@ module OpenTelemetry
 
       # Initialize a Status.
       #
-      # @param [Integer] canonical_code One of the standard gRPC codes: https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
+      # @param [Integer] canonical_code One of the canonical status codes below
       # @param [String] description
       def initialize(canonical_code, description: '')
         @canonical_code = canonical_code
@@ -37,78 +37,20 @@ module OpenTelemetry
       #
       # @return [Boolean]
       def ok?
-        @canonical_code == OK
+        @canonical_code != ERROR
       end
 
       # The following represents the canonical set of status codes of a
-      # finished {Span}, following the standard gRPC codes:
-      # https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
+      # finished {Span}
 
       # The operation completed successfully.
       OK = 0
 
-      # The operation was cancelled (typically by the caller).
-      CANCELLED = 1
+      # The default status.
+      UNSET = 1
 
-      # An unknown error.
-      UNKNOWN_ERROR = 2
-
-      # Client specified an invalid argument. Note that this differs from
-      # {FAILED_PRECONDITION}. {INVALID_ARGUMENT} indicates arguments that are
-      # problematic regardless of the state of the system.
-      INVALID_ARGUMENT = 3
-
-      # Deadline expired before operation could complete. For operations that
-      # change the state of the system, this error may be returned even if the
-      # operation has completed successfully.
-      DEADLINE_EXCEEDED = 4
-
-      # Some requested entity (e.g., file or directory) was not found.
-      NOT_FOUND = 5
-
-      # Some entity that we attempted to create (e.g., file or directory)
-      # already exists.
-      ALREADY_EXISTS = 6
-
-      # The caller does not have permission to execute the specified operation.
-      # {PERMISSION_DENIED} must not be used if the caller cannot be identified
-      # (use {UNAUTHENTICATED} instead for those errors).
-      PERMISSION_DENIED = 7
-
-      # Some resource has been exhausted, perhaps a per-user quota, or perhaps
-      # the entire file system is out of space.
-      RESOURCE_EXHAUSTED = 8
-
-      # Operation was rejected because the system is not in a state required
-      # for the operation's execution.
-      FAILED_PRECONDITION = 9
-
-      # The operation was aborted, typically due to a concurrency issue like
-      # sequencer check failures, transaction aborts, etc.
-      ABORTED = 10
-
-      # Operation was attempted past the valid range. E.g., seeking or reading
-      # past end of file. Unlike {INVALID_ARGUMENT}, this error indicates a
-      # problem that may be fixed if the system state changes.
-      OUT_OF_RANGE = 11
-
-      # Operation is not implemented or not supported/enabled in this service.
-      UNIMPLEMENTED = 12
-
-      # Internal errors. Means some invariants expected by underlying system
-      # has been broken.
-      INTERNAL_ERROR = 13
-
-      # The service is currently unavailable. This is a most likely a transient
-      # condition and may be corrected by retrying with a backoff.
-      UNAVAILABLE = 14
-
-      # Unrecoverable data loss or corruption.
-      DATA_LOSS = 15
-
-      # The request does not have valid authentication credentials for the
-      # operation.
-      UNAUTHENTICATED = 16
+      # An error.
+      ERROR = 2
     end
   end
 end

--- a/api/lib/opentelemetry/trace/tracer.rb
+++ b/api/lib/opentelemetry/trace/tracer.rb
@@ -42,7 +42,7 @@ module OpenTelemetry
         with_span(span) { |s, c| yield s, c }
       rescue Exception => e # rubocop:disable Lint/RescueException
         span&.record_exception(e)
-        span&.status = Status.new(Status::UNKNOWN_ERROR,
+        span&.status = Status.new(Status::ERROR,
                                   description: "Unhandled exception of type: #{e.class}")
         raise e
       ensure

--- a/api/lib/opentelemetry/trace/util/http_to_status.rb
+++ b/api/lib/opentelemetry/trace/util/http_to_status.rb
@@ -9,36 +9,17 @@ module OpenTelemetry
     module Util
       # Convenience methods, not necessarily required by the API specification.
       module HttpToStatus
-        # Implemented according to
-        # https://github.com/open-telemetry/opentelemetry-specification/issues/306
-        # https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-http.md#status
+        # Maps numeric HTTP status codes to Trace::Status. This module is a mixin for Trace::Status
+        # and is not intended for standalone use.
         #
         # @param code Numeric HTTP status
         # @return Status
-        def http_to_status(code) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
+        def http_to_status(code)
           case code.to_i
           when 100..399
             new(const_get(:OK))
-          when 401
-            new(const_get(:UNAUTHENTICATED))
-          when 403
-            new(const_get(:PERMISSION_DENIED))
-          when 404
-            new(const_get(:NOT_FOUND))
-          when 429
-            new(const_get(:RESOURCE_EXHAUSTED))
-          when 400..499
-            new(const_get(:INVALID_ARGUMENT))
-          when 501
-            new(const_get(:UNIMPLEMENTED))
-          when 503
-            new(const_get(:UNAVAILABLE))
-          when 504
-            new(const_get(:DEADLINE_EXCEEDED))
-          when 500..599
-            new(const_get(:INTERNAL_ERROR))
           else
-            new(const_get(:UNKNOWN_ERROR))
+            new(const_get(:ERROR))
           end
         end
       end

--- a/api/test/opentelemetry/trace/status_test.rb
+++ b/api/test/opentelemetry/trace/status_test.rb
@@ -34,22 +34,13 @@ describe OpenTelemetry::Trace::Status do
     end
 
     it 'maps http 4xx codes' do
-      assert_http_to_status(400, trace_status::INVALID_ARGUMENT)
-      assert_http_to_status(401, trace_status::UNAUTHENTICATED)
-      assert_http_to_status(403, trace_status::PERMISSION_DENIED)
-      assert_http_to_status(404, trace_status::NOT_FOUND)
-      assert_http_to_status(409, trace_status::INVALID_ARGUMENT)
-      assert_http_to_status(429, trace_status::RESOURCE_EXHAUSTED)
-      assert_http_to_status(499, trace_status::INVALID_ARGUMENT)
+      assert_http_to_status(400, trace_status::ERROR)
+      assert_http_to_status(499, trace_status::ERROR)
     end
 
     it 'maps http 5xx codes' do
-      assert_http_to_status(500, trace_status::INTERNAL_ERROR)
-      assert_http_to_status(501, trace_status::UNIMPLEMENTED)
-      assert_http_to_status(502, trace_status::INTERNAL_ERROR)
-      assert_http_to_status(503, trace_status::UNAVAILABLE)
-      assert_http_to_status(504, trace_status::DEADLINE_EXCEEDED)
-      assert_http_to_status(599, trace_status::INTERNAL_ERROR)
+      assert_http_to_status(500, trace_status::ERROR)
+      assert_http_to_status(599, trace_status::ERROR)
     end
   end
 
@@ -88,7 +79,7 @@ describe OpenTelemetry::Trace::Status do
     end
 
     it 'reflects canonical_code when not OK' do
-      canonical_codes = OpenTelemetry::Trace::Status.constants - %i[OK]
+      canonical_codes = OpenTelemetry::Trace::Status.constants - %i[OK UNSET]
       canonical_codes.each do |canonical_code|
         code = OpenTelemetry::Trace::Status.const_get(canonical_code)
         status = OpenTelemetry::Trace::Status.new(code)

--- a/exporter/jaeger/lib/opentelemetry/exporter/jaeger/encoder.rb
+++ b/exporter/jaeger/lib/opentelemetry/exporter/jaeger/encoder.rb
@@ -119,8 +119,15 @@ module OpenTelemetry
         end
 
         def encoded_status(status)
-          # TODO: OpenTracing doesn't specify how to report non-HTTP (i.e. generic) status.
-          EMPTY_ARRAY
+          return EMPTY_ARRAY unless status&.canonical_code == OpenTelemetry::Trace::Status::ERROR
+
+          Array(
+            Thrift::Tag.new(
+              KEY => 'error',
+              TYPE => Thrift::TagType::BOOL,
+              BOOL => true
+            )
+          )
         end
 
         def encoded_instrumentation_library(instrumentation_library)

--- a/exporter/jaeger/test/opentelemetry/exporters/jaeger/encoder_test.rb
+++ b/exporter/jaeger/test/opentelemetry/exporters/jaeger/encoder_test.rb
@@ -26,6 +26,19 @@ describe OpenTelemetry::Exporter::Jaeger::Encoder do
     )
   end
 
+  it 'encodes span.status and span.kind' do
+    span_data = create_span_data(status: OpenTelemetry::Trace::Status.new(OpenTelemetry::Trace::Status::ERROR), kind: :server)
+    encoded_span = Encoder.encoded_span(span_data)
+
+    _(encoded_span.tags.size).must_equal(2)
+
+    kind_tag = encoded_span.tags.find { |tag| tag.key == 'span.kind' }
+    error_tag = encoded_span.tags.find { |tag| tag.key == 'error' }
+
+    _(kind_tag.vStr).must_equal('server')
+    _(error_tag.vBool).must_equal(true)
+  end
+
   it 'encodes attributes in events and the span' do
     attributes = { 'akey' => 'avalue' }
     events = [
@@ -103,11 +116,11 @@ describe OpenTelemetry::Exporter::Jaeger::Encoder do
     end
   end
 
-  def create_span_data(attributes: nil, events: nil, links: nil, instrumentation_library: nil, trace_id: OpenTelemetry::Trace.generate_trace_id, trace_flags: OpenTelemetry::Trace::TraceFlags::DEFAULT, tracestate: nil)
+  def create_span_data(status: nil, kind: nil, attributes: nil, events: nil, links: nil, instrumentation_library: nil, trace_id: OpenTelemetry::Trace.generate_trace_id, trace_flags: OpenTelemetry::Trace::TraceFlags::DEFAULT, tracestate: nil)
     OpenTelemetry::SDK::Trace::SpanData.new(
       '',
-      nil,
-      nil,
+      kind,
+      status,
       OpenTelemetry::Trace::INVALID_SPAN_ID,
       0,
       0,

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -242,8 +242,9 @@ module OpenTelemetry
             end,
             dropped_links_count: span_data.total_recorded_links - span_data.links&.size.to_i,
             status: span_data.status&.yield_self do |status|
+              # TODO: fix this based on spec update.
               Opentelemetry::Proto::Trace::V1::Status.new(
-                code: status.canonical_code,
+                code: status.canonical_code == OpenTelemetry::Trace::Status::ERROR ? Opentelemetry::Proto::Trace::V1::Status::StatusCode::UnknownError : Opentelemetry::Proto::Trace::V1::Status::StatusCode::Ok,
                 message: status.description
               )
             end

--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -193,7 +193,10 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
                       name: 'root',
                       kind: Opentelemetry::Proto::Trace::V1::Span::SpanKind::INTERNAL,
                       start_time_unix_nano: (start_timestamp.to_r * 1_000_000_000).to_i,
-                      end_time_unix_nano: (end_timestamp.to_r * 1_000_000_000).to_i
+                      end_time_unix_nano: (end_timestamp.to_r * 1_000_000_000).to_i,
+                      status: Opentelemetry::Proto::Trace::V1::Status.new(
+                        code: Opentelemetry::Proto::Trace::V1::Status::StatusCode::Ok
+                      )
                     ),
                     Opentelemetry::Proto::Trace::V1::Span.new(
                       trace_id: trace_id,
@@ -202,7 +205,10 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
                       name: 'client',
                       kind: Opentelemetry::Proto::Trace::V1::Span::SpanKind::CLIENT,
                       start_time_unix_nano: ((start_timestamp + 2).to_r * 1_000_000_000).to_i,
-                      end_time_unix_nano: (end_timestamp.to_r * 1_000_000_000).to_i
+                      end_time_unix_nano: (end_timestamp.to_r * 1_000_000_000).to_i,
+                      status: Opentelemetry::Proto::Trace::V1::Status.new(
+                        code: Opentelemetry::Proto::Trace::V1::Status::StatusCode::Ok
+                      )
                     ),
                     Opentelemetry::Proto::Trace::V1::Span.new(
                       trace_id: trace_id,
@@ -211,7 +217,10 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
                       name: 'consumer',
                       kind: Opentelemetry::Proto::Trace::V1::Span::SpanKind::CONSUMER,
                       start_time_unix_nano: ((start_timestamp + 5).to_r * 1_000_000_000).to_i,
-                      end_time_unix_nano: (end_timestamp.to_r * 1_000_000_000).to_i
+                      end_time_unix_nano: (end_timestamp.to_r * 1_000_000_000).to_i,
+                      status: Opentelemetry::Proto::Trace::V1::Status.new(
+                        code: Opentelemetry::Proto::Trace::V1::Status::StatusCode::Ok
+                      )
                     ),
                     Opentelemetry::Proto::Trace::V1::Span.new(
                       trace_id: trace_id,
@@ -274,7 +283,10 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
                       name: 'server',
                       kind: Opentelemetry::Proto::Trace::V1::Span::SpanKind::SERVER,
                       start_time_unix_nano: ((start_timestamp + 3).to_r * 1_000_000_000).to_i,
-                      end_time_unix_nano: (end_timestamp.to_r * 1_000_000_000).to_i
+                      end_time_unix_nano: (end_timestamp.to_r * 1_000_000_000).to_i,
+                      status: Opentelemetry::Proto::Trace::V1::Status.new(
+                        code: Opentelemetry::Proto::Trace::V1::Status::StatusCode::Ok
+                      )
                     )
                   ]
                 )

--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -160,7 +160,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       span['i'] = 2
       span['s'] = 'val'
       span['a'] = [3, 4]
-      span.status = OpenTelemetry::Trace::Status.new(OpenTelemetry::Trace::Status::UNKNOWN_ERROR)
+      span.status = OpenTelemetry::Trace::Status.new(OpenTelemetry::Trace::Status::ERROR)
       client = with_ids(trace_id, client_span_id) { tracer.start_span('client', with_parent: span, kind: :client, start_timestamp: start_timestamp + 2).finish(end_timestamp: end_timestamp) }
       with_ids(trace_id, server_span_id) { other_tracer.start_span('server', with_parent: client, kind: :server, start_timestamp: start_timestamp + 3).finish(end_timestamp: end_timestamp) }
       span.add_event('event', attributes: { 'attr' => 42 }, timestamp: start_timestamp + 4)

--- a/instrumentation/ethon/lib/opentelemetry/instrumentation/ethon/patches/easy.rb
+++ b/instrumentation/ethon/lib/opentelemetry/instrumentation/ethon/patches/easy.rb
@@ -40,7 +40,7 @@ module OpenTelemetry
                 return_code = response_options[:return_code]
                 message = return_code ? ::Ethon::Curl.easy_strerror(return_code) : 'unknown reason'
                 @otel_span.status = OpenTelemetry::Trace::Status.new(
-                  OpenTelemetry::Trace::Status::UNKNOWN_ERROR,
+                  OpenTelemetry::Trace::Status::ERROR,
                   description: "Request has failed: #{message}"
                 )
               else

--- a/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/instrumentation_test.rb
+++ b/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/instrumentation_test.rb
@@ -123,7 +123,7 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
             _(span.attributes['http.status_code']).must_be_nil
             _(span.attributes['http.url']).must_equal 'http://example.com/test'
             _(span.status.canonical_code).must_equal(
-              OpenTelemetry::Trace::Status::UNKNOWN_ERROR
+              OpenTelemetry::Trace::Status::ERROR
             )
             _(span.status.description).must_equal(
               'Request has failed: Timeout was reached'

--- a/instrumentation/excon/lib/opentelemetry/instrumentation/excon/middlewares/tracer_middleware.rb
+++ b/instrumentation/excon/lib/opentelemetry/instrumentation/excon/middlewares/tracer_middleware.rb
@@ -92,7 +92,7 @@ module OpenTelemetry
 
                 if datum.key?(:error)
                   span.status = OpenTelemetry::Trace::Status.new(
-                    OpenTelemetry::Trace::Status::UNKNOWN_ERROR,
+                    OpenTelemetry::Trace::Status::ERROR,
                     description: "Request has failed: #{datum[:error]}"
                   )
                 end

--- a/instrumentation/excon/test/opentelemetry/instrumentation/excon/instrumentation_test.rb
+++ b/instrumentation/excon/test/opentelemetry/instrumentation/excon/instrumentation_test.rb
@@ -91,7 +91,7 @@ describe OpenTelemetry::Instrumentation::Excon::Instrumentation do
       _(span.attributes['http.host']).must_equal 'example.com'
       _(span.attributes['http.target']).must_equal '/timeout'
       _(span.status.canonical_code).must_equal(
-        OpenTelemetry::Trace::Status::UNKNOWN_ERROR
+        OpenTelemetry::Trace::Status::ERROR
       )
       _(span.status.description).must_equal(
         'Request has failed: Excon::Error::Timeout'

--- a/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
+++ b/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
@@ -83,7 +83,7 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
       _(span.attributes['net.peer.port']).must_equal port.to_s
 
       _(span.status.canonical_code).must_equal(
-        OpenTelemetry::Trace::Status::UNKNOWN_ERROR
+        OpenTelemetry::Trace::Status::ERROR
       )
       _(span.events.first.name).must_equal 'exception'
       _(span.events.first.attributes['exception.type']).must_equal 'Mysql2::Error'
@@ -120,7 +120,7 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
       _(span.attributes['net.peer.port']).must_equal port.to_s
 
       _(span.status.canonical_code).must_equal(
-        OpenTelemetry::Trace::Status::UNKNOWN_ERROR
+        OpenTelemetry::Trace::Status::ERROR
       )
       _(span.events.first.name).must_equal 'exception'
       _(span.events.first.attributes['exception.type']).must_equal 'Mysql2::Error'

--- a/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/instrumentation_test.rb
+++ b/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/instrumentation_test.rb
@@ -95,7 +95,7 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
       _(span.attributes['peer.hostname']).must_equal 'example.com'
       _(span.attributes['peer.port']).must_equal 443
       _(span.status.canonical_code).must_equal(
-        OpenTelemetry::Trace::Status::UNKNOWN_ERROR
+        OpenTelemetry::Trace::Status::ERROR
       )
       _(span.status.description).must_equal(
         'Unhandled exception of type: Net::OpenTimeout'

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/tracer_middleware_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/tracer_middleware_test.rb
@@ -184,7 +184,7 @@ describe OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware do
       assert_raises SimulatedError do
         Rack::MockRequest.new(rack_builder).get('/', env)
       end
-      _(first_span.status.canonical_code).must_equal OpenTelemetry::Trace::Status::UNKNOWN_ERROR
+      _(first_span.status.canonical_code).must_equal OpenTelemetry::Trace::Status::ERROR
     end
   end
 end

--- a/instrumentation/redis/test/opentelemetry/instrumentation/redis/instrumentation_test.rb
+++ b/instrumentation/redis/test/opentelemetry/instrumentation/redis/instrumentation_test.rb
@@ -88,7 +88,7 @@ describe OpenTelemetry::Instrumentation::Redis::Instrumentation do
       _(span.attributes['net.peer.name']).must_equal '127.0.0.1'
       _(span.attributes['net.peer.port']).must_equal 6379
       _(span.status.canonical_code).must_equal(
-        OpenTelemetry::Trace::Status::UNKNOWN_ERROR
+        OpenTelemetry::Trace::Status::ERROR
       )
       _(span.status.description).must_equal(
         'Unhandled exception of type: Redis::CommandError'

--- a/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_test.rb
+++ b/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_test.rb
@@ -107,7 +107,7 @@ describe OpenTelemetry::Instrumentation::Sinatra do
     it 'does not create unhandled exceptions for missing routes' do
       get '/one/missing_example/not_present'
 
-      _(exporter.finished_spans.first.status.canonical_code).must_equal 5
+      _(exporter.finished_spans.first.status.canonical_code).must_equal OpenTelemetry::Trace::Status::ERROR
       _(exporter.finished_spans.first.attributes).must_equal(
         'http.method' => 'GET',
         'http.url' => '/missing_example/not_present',

--- a/sdk/lib/opentelemetry/sdk/trace/span.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span.rb
@@ -16,6 +16,10 @@ module OpenTelemetry
       #
       # rubocop:disable Metrics/ClassLength
       class Span < OpenTelemetry::Trace::Span
+        DEFAULT_STATUS = OpenTelemetry::Trace::Status.new(OpenTelemetry::Trace::Status::UNSET)
+
+        private_constant(:DEFAULT_STATUS)
+
         # The following readers are intended for the use of SpanProcessors and
         # should not be considered part of the public interface for instrumentation.
         attr_reader :name, :status, :kind, :parent_span_id, :start_timestamp, :end_timestamp, :links, :resource, :instrumentation_library
@@ -248,7 +252,7 @@ module OpenTelemetry
           @resource = resource
           @instrumentation_library = instrumentation_library
           @ended = false
-          @status = nil
+          @status = DEFAULT_STATUS
           @total_recorded_events = 0
           @total_recorded_links = links&.size || 0
           @total_recorded_attributes = attributes&.size || 0

--- a/sdk/test/opentelemetry/sdk/trace/span_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/span_test.rb
@@ -223,8 +223,8 @@ describe OpenTelemetry::SDK::Trace::Span do
 
     it 'does not set the status if span is ended' do
       span.finish
-      span.status = Status.new(1, description: 'cancelled')
-      _(span.status).must_be_nil
+      span.status = Status.new(Status::ERROR, description: 'cancelled')
+      _(span.status.canonical_code).must_equal(Status::UNSET)
     end
   end
 

--- a/sdk/test/opentelemetry/sdk/trace/tracer_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/tracer_test.rb
@@ -301,7 +301,7 @@ describe OpenTelemetry::SDK::Trace::Tracer do
 
       _(span.events[0].name).must_equal('exception')
       _(span.events[0].attributes['exception.message']).must_equal('this is fine')
-      _(span.status.canonical_code).must_equal(OpenTelemetry::Trace::Status::UNKNOWN_ERROR)
+      _(span.status.canonical_code).must_equal(OpenTelemetry::Trace::Status::ERROR)
       _(span.status.description).must_equal('Unhandled exception of type: RuntimeError')
     end
   end


### PR DESCRIPTION
This implements the new Span.Status spec: https://github.com/open-telemetry/opentelemetry-specification/pull/966

We need the mapping to OTLP to be specified in order to complete this, however that is strictly additive and this implements the proposal for OK & Unset -> OK and Error -> UnknownError.