### PR TITLE
fix! Return results from force_flush and shutdown

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/export.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export.rb
@@ -7,16 +7,21 @@
 module OpenTelemetry
   module SDK
     module Trace
-      # The Export module contains the built-in exporters for the OpenTelemetry
+      # The Export module contains the built-in exporters and span processors for the OpenTelemetry
       # reference implementation.
       module Export
-        # Result codes for the SpanExporter#export method.
+        # Result codes for the SpanExporter#export method and the SpanProcessor#force_flush and SpanProcessor#shutdown methods.
 
-        # The export operation finished successfully.
+        # The operation finished successfully.
         SUCCESS = 0
 
-        # The export operation finished with an error.
+        # The operation finished with an error.
         FAILURE = 1
+
+        # Additional result code for the SpanProcessor#force_flush and SpanProcessor#shutdown methods.
+
+        # The operation timed out.
+        TIMEOUT = 2
       end
     end
   end

--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -87,6 +87,9 @@ module OpenTelemetry
           # necessary, such as when using some FaaS providers that may suspend
           # the process after an invocation, but before the `Processor` exports
           # the completed spans.
+          #
+          # @return [Integer] SUCCESS if no error occurred, FAILURE if a
+          #   non-specific failure occurred, TIMEOUT if a timeout occurred.
           def force_flush
             snapshot = lock do
               reset_on_fork(restart_thread: false) if @keep_running
@@ -97,10 +100,14 @@ module OpenTelemetry
               result_code = @exporter.export(batch)
               report_result(result_code, batch)
             end
+            SUCCESS
           end
 
           # shuts the consumer thread down and flushes the current accumulated buffer
           # will block until the thread is finished
+          #
+          # @return [Integer] SUCCESS if no error occurred, FAILURE if a
+          #   non-specific failure occurred, TIMEOUT if a timeout occurred.
           def shutdown
             lock do
               @keep_running = false

--- a/sdk/lib/opentelemetry/sdk/trace/export/console_span_exporter.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/console_span_exporter.rb
@@ -14,24 +14,21 @@ module OpenTelemetry
         #
         # Potentially useful for exploratory purposes.
         class ConsoleSpanExporter
-          ResultCodes = OpenTelemetry::SDK::Trace::Export
-
-          private_constant(:ResultCodes)
-
           def initialize
             @stopped = false
           end
 
           def export(spans)
-            return ResultCodes::FAILURE if @stopped
+            return FAILURE if @stopped
 
             Array(spans).each { |s| pp s }
 
-            ResultCodes::SUCCESS
+            SUCCESS
           end
 
           def shutdown
             @stopped = true
+            SUCCESS
           end
         end
       end

--- a/sdk/lib/opentelemetry/sdk/trace/export/in_memory_span_exporter.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/in_memory_span_exporter.rb
@@ -73,11 +73,15 @@ module OpenTelemetry
 
           # Called when {TracerProvider#shutdown} is called, if this exporter is
           # registered to a {TracerProvider} object.
+          #
+          # @return [Integer] SUCCESS if no error occurred, FAILURE if a
+          #   non-specific failure occurred, TIMEOUT if a timeout occurred.
           def shutdown
             @mutex.synchronize do
               @finished_spans.clear
               @stopped = true
             end
+            SUCCESS
           end
         end
       end

--- a/sdk/lib/opentelemetry/sdk/trace/export/multi_span_exporter.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/multi_span_exporter.rb
@@ -35,8 +35,11 @@ module OpenTelemetry
 
           # Called when {TracerProvider#shutdown} is called, if this exporter is
           # registered to a {TracerProvider} object.
+          #
+          # @return [Integer] SUCCESS if no error occurred, FAILURE if a
+          #   non-specific failure occurred, TIMEOUT if a timeout occurred.
           def shutdown
-            @span_exporters.each(&:shutdown)
+            @span_exporters.map(&:shutdown).uniq.max
           end
 
           private

--- a/sdk/lib/opentelemetry/sdk/trace/export/noop_span_exporter.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/noop_span_exporter.rb
@@ -34,6 +34,7 @@ module OpenTelemetry
           # registered to a {TracerProvider} object.
           def shutdown
             @stopped = true
+            SUCCESS
           end
         end
       end

--- a/sdk/lib/opentelemetry/sdk/trace/export/simple_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/simple_span_processor.rb
@@ -59,11 +59,19 @@ module OpenTelemetry
           # necessary, such as when using some FaaS providers that may suspend
           # the process after an invocation, but before the `Processor` exports
           # the completed spans.
-          def force_flush; end
+          #
+          # @return [Integer] SUCCESS if no error occurred, FAILURE if a
+          #   non-specific failure occurred, TIMEOUT if a timeout occurred.
+          def force_flush
+            SUCCESS
+          end
 
           # Called when {TracerProvider#shutdown} is called.
+          #
+          # @return [Integer] SUCCESS if no error occurred, FAILURE if a
+          #   non-specific failure occurred, TIMEOUT if a timeout occurred.
           def shutdown
-            @span_exporter&.shutdown
+            @span_exporter&.shutdown || SUCCESS
           end
         end
       end

--- a/sdk/lib/opentelemetry/sdk/trace/multi_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/multi_span_processor.rb
@@ -48,13 +48,19 @@ module OpenTelemetry
         # necessary, such as when using some FaaS providers that may suspend
         # the process after an invocation, but before the `Processor` exports
         # the completed spans.
+        #
+        # @return [Integer] Export::SUCCESS if no error occurred, Export::FAILURE if
+        #   a non-specific failure occurred, Export::TIMEOUT if a timeout occurred.
         def force_flush
-          @span_processors.each(&:force_flush)
+          @span_processors.map(&:force_flush).uniq.max
         end
 
         # Called when {TracerProvider#shutdown} is called.
+        #
+        # @return [Integer] Export::SUCCESS if no error occurred, Export::FAILURE if
+        #   a non-specific failure occurred, Export::TIMEOUT if a timeout occurred.
         def shutdown
-          @span_processors.each(&:shutdown)
+          @span_processors.map(&:shutdown).uniq.max
         end
       end
     end

--- a/sdk/lib/opentelemetry/sdk/trace/noop_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/noop_span_processor.rb
@@ -40,10 +40,20 @@ module OpenTelemetry
         # necessary, such as when using some FaaS providers that may suspend
         # the process after an invocation, but before the `Processor` exports
         # the completed spans.
-        def force_flush; end
+        #
+        # @return [Integer] Export::SUCCESS if no error occurred, Export::FAILURE if
+        #   a non-specific failure occurred, Export::TIMEOUT if a timeout occurred.
+        def force_flush
+          Export::SUCCESS
+        end
 
         # Called when {TracerProvider#shutdown} is called.
-        def shutdown; end
+        #
+        # @return [Integer] Export::SUCCESS if no error occurred, Export::FAILURE if
+        #   a non-specific failure occurred, Export::TIMEOUT if a timeout occurred.
+        def shutdown
+          Export::SUCCESS
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #405 

This adds return codes for `SpanProcessor#force_flush` and `SpanProcessor#shutdown`. They don't necessarily make sense on their own at the moment, but once #341 lands, this will allow callers to check for success/failure/timeout.

Since most of the processors live in the `Export` module, I overloaded the result codes we've already defined there, and added `TIMEOUT`.