### PR TITLE
feat: Add service_name setter to configurator

### DIFF
--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -44,6 +44,16 @@ module OpenTelemetry
         @resource = new_resource.merge(@resource)
       end
 
+      # Accepts a string that is merged in as the service.name resource attribute.
+      # The most recent assigned value will be used in the event of repeated
+      # calls to this setter.
+      # @param [String] service_name The value to be used as the service name
+      def service_name=(service_name)
+        @resource = OpenTelemetry::SDK::Resources::Resource.create(
+          OpenTelemetry::SDK::Resources::Constants::SERVICE_RESOURCE[:name] => service_name
+        ).merge(@resource)
+      end
+
       # Install an instrumentation with specificied optional +config+.
       # Use can be called multiple times to install multiple instrumentation.
       # Only +use+ or +use_all+, but not both when installing

--- a/sdk/test/opentelemetry/sdk/configurator_test.rb
+++ b/sdk/test/opentelemetry/sdk/configurator_test.rb
@@ -57,6 +57,24 @@ describe OpenTelemetry::SDK::Configurator do
     end
   end
 
+  describe '#service_name=' do
+    let(:configurator_resource) { configurator.instance_variable_get(:@resource) }
+    let(:configurator_resource_attributes) { configurator_resource.attribute_enumerator.to_h }
+    let(:expected_resource_attributes) do
+      {
+        'service.name' => 'Otel Demo App',
+        'telemetry.sdk.name' => 'opentelemetry',
+        'telemetry.sdk.language' => 'ruby',
+        'telemetry.sdk.version' => OpenTelemetry::SDK::VERSION
+      }
+    end
+
+    it 'assigns the service_name resource' do
+      configurator.service_name = 'Otel Demo App'
+      _(configurator_resource_attributes).must_equal(expected_resource_attributes)
+    end
+  end
+
   describe '#use' do
     it 'can be called multiple times' do
       configurator.use('TestInstrumentation', enabled: true)


### PR DESCRIPTION
Adds a convenience method so setter the service.name resource attribute.
Closes #379