### PR TITLE
chore: Tool for building yardoc during release

### DIFF
--- a/.toys/.data/releases.yml
+++ b/.toys/.data/releases.yml
@@ -9,6 +9,8 @@ required_checks_timeout: 1200
 # Git user attached to commits for release pull requests.
 git_user_name: Daniel Azuma
 git_user_email: dazuma@gmail.com
+# Toys tool that builds YARD reference docs
+docs_builder_tool: [yardoc]
 
 # Control the conventional commit linter.
 commit_lint:

--- a/.toys/yardoc.rb
+++ b/.toys/yardoc.rb
@@ -1,0 +1,15 @@
+desc "Build YARD documentation for the gem in the current directory"
+
+include :exec, e: true
+include :fileutils
+
+set_context_directory Dir.pwd
+
+def run
+  raise "No yardopts in the current directory" unless File.file?(".yardopts")
+  rm_rf(".yardoc")
+  rm_rf("doc")
+  exec_tool(["yardoc", "_build"])
+end
+
+expand :yardoc, name: "_build", bundler: true


### PR DESCRIPTION
This should enable building reference documentation during the release process and pushing it to https://open-telemetry.github.io/opentelemetry-ruby