### PR TITLE
feat: default tracer prototype

### DIFF
--- a/api/lib/opentelemetry.rb
+++ b/api/lib/opentelemetry.rb
@@ -37,8 +37,8 @@ module OpenTelemetry
 
   # @return [Trace::Tracer] delegates to the registered tracer provider and
   #  returns a tracer with the given name and version. If called without without
-  #  arguments, it returns a tracer named 'default'.
-  def tracer(name = 'default', version = nil)
+  #  arguments, it returns an unnamed default tracer.
+  def tracer(name = nil, version = nil)
     tracer_provider.tracer(name, version)
   end
 

--- a/api/lib/opentelemetry.rb
+++ b/api/lib/opentelemetry.rb
@@ -35,6 +35,13 @@ module OpenTelemetry
     @tracer_provider ||= Trace::TracerProvider.new
   end
 
+  # @return [Trace::Tracer] returns a default tracer instance from the
+  #   registered tracer provider. If the tracer provider is operational, this
+  #   will be a named tracer with the name 'default'.
+  def default_tracer
+    tracer_provider.tracer('default')
+  end
+
   # @return [Object, Metrics::MeterProvider] registered meter provider or a
   #   default no-op implementation of the meter provider.
   def meter_provider

--- a/api/lib/opentelemetry.rb
+++ b/api/lib/opentelemetry.rb
@@ -35,11 +35,11 @@ module OpenTelemetry
     @tracer_provider ||= Trace::TracerProvider.new
   end
 
-  # @return [Trace::Tracer] returns a default tracer instance from the
-  #   registered tracer provider. If the tracer provider is operational, this
-  #   will be a named tracer with the name 'default'.
-  def default_tracer
-    tracer_provider.tracer('default')
+  # @return [Trace::Tracer] delegates to the registered tracer provider and
+  #  returns a tracer with the given name and version. If called without without
+  #  arguments, it returns a tracer named 'default'.
+  def tracer(name = 'default', version = nil)
+    tracer_provider.tracer(name, version)
   end
 
   # @return [Object, Metrics::MeterProvider] registered meter provider or a

--- a/api/test/opentelemetry_test.rb
+++ b/api/test/opentelemetry_test.rb
@@ -30,19 +30,34 @@ describe OpenTelemetry do
     end
   end
 
-  describe '.default_tracer' do
+  describe '.tracer' do
+    let(:mock_provider) { MiniTest::Mock.new }
+
+    before do
+      OpenTelemetry.tracer_provider = mock_provider
+    end
+
     after do
       # Ensure we don't leak custom tracer factories and tracers to other tests
       OpenTelemetry.tracer_provider = nil
     end
 
-    it 'returns instance of Trace::Tracer' do
-      default_tracer = OpenTelemetry.default_tracer
-      _(default_tracer).must_be_instance_of(OpenTelemetry::Trace::Tracer)
+    it 'delegates to tracer provider with default name' do
+      mock_provider.expect(:tracer, Object.new, ['default', nil])
+      _ = OpenTelemetry.tracer
+      mock_provider.verify
     end
 
-    it 'returns the same instance when accessed multiple times' do
-      _(OpenTelemetry.default_tracer).must_equal(OpenTelemetry.default_tracer)
+    it 'delegates to tracer provider with provided name' do
+      mock_provider.expect(:tracer, Object.new, ['foo', nil])
+      _ = OpenTelemetry.tracer('foo')
+      mock_provider.verify
+    end
+
+    it 'delegates to tracer provider with provided name and version' do
+      mock_provider.expect(:tracer, Object.new, ['foo', '0.4.0'])
+      _ = OpenTelemetry.tracer('foo', '0.4.0')
+      mock_provider.verify
     end
   end
 

--- a/api/test/opentelemetry_test.rb
+++ b/api/test/opentelemetry_test.rb
@@ -33,31 +33,39 @@ describe OpenTelemetry do
   describe '.tracer' do
     let(:mock_provider) { MiniTest::Mock.new }
 
-    before do
-      OpenTelemetry.tracer_provider = mock_provider
-    end
-
     after do
       # Ensure we don't leak custom tracer factories and tracers to other tests
       OpenTelemetry.tracer_provider = nil
     end
 
-    it 'delegates to tracer provider with default name' do
-      mock_provider.expect(:tracer, Object.new, ['default', nil])
-      _ = OpenTelemetry.tracer
-      mock_provider.verify
+    describe 'default tracer' do
+      it 'returns the same instance when accessed multiple times' do
+        _(OpenTelemetry.tracer).must_equal(OpenTelemetry.tracer)
+      end
     end
 
-    it 'delegates to tracer provider with provided name' do
-      mock_provider.expect(:tracer, Object.new, ['foo', nil])
-      _ = OpenTelemetry.tracer('foo')
-      mock_provider.verify
-    end
+    describe 'delegation' do
+      before do
+        OpenTelemetry.tracer_provider = mock_provider
+      end
 
-    it 'delegates to tracer provider with provided name and version' do
-      mock_provider.expect(:tracer, Object.new, ['foo', '0.4.0'])
-      _ = OpenTelemetry.tracer('foo', '0.4.0')
-      mock_provider.verify
+      it 'delegates to tracer provider' do
+        mock_provider.expect(:tracer, Object.new, [nil, nil])
+        _ = OpenTelemetry.tracer
+        mock_provider.verify
+      end
+
+      it 'delegates to tracer provider with provided name' do
+        mock_provider.expect(:tracer, Object.new, ['foo', nil])
+        _ = OpenTelemetry.tracer('foo')
+        mock_provider.verify
+      end
+
+      it 'delegates to tracer provider with provided name and version' do
+        mock_provider.expect(:tracer, Object.new, ['foo', '0.4.0'])
+        _ = OpenTelemetry.tracer('foo', '0.4.0')
+        mock_provider.verify
+      end
     end
   end
 

--- a/api/test/opentelemetry_test.rb
+++ b/api/test/opentelemetry_test.rb
@@ -30,6 +30,22 @@ describe OpenTelemetry do
     end
   end
 
+  describe '.default_tracer' do
+    after do
+      # Ensure we don't leak custom tracer factories and tracers to other tests
+      OpenTelemetry.tracer_provider = nil
+    end
+
+    it 'returns instance of Trace::Tracer' do
+      default_tracer = OpenTelemetry.default_tracer
+      _(default_tracer).must_be_instance_of(OpenTelemetry::Trace::Tracer)
+    end
+
+    it 'returns the same instance when accessed multiple times' do
+      _(OpenTelemetry.default_tracer).must_equal(OpenTelemetry.default_tracer)
+    end
+  end
+
   describe '.logger' do
     it 'should log things' do
       t = Tempfile.new('logger')

--- a/sdk/test/integration/api_trace_test.rb
+++ b/sdk/test/integration/api_trace_test.rb
@@ -106,4 +106,10 @@ describe OpenTelemetry::SDK, 'API_trace' do
       _(@child_span_with_links.to_span_data.links.size).must_equal number_of_links
     end
   end
+
+  describe 'default tracer' do
+    it 'returns tracer named default' do
+      _(OpenTelemetry.default_tracer.name).must_equal('default')
+    end
+  end
 end

--- a/sdk/test/integration/api_trace_test.rb
+++ b/sdk/test/integration/api_trace_test.rb
@@ -106,10 +106,4 @@ describe OpenTelemetry::SDK, 'API_trace' do
       _(@child_span_with_links.to_span_data.links.size).must_equal number_of_links
     end
   end
-
-  describe 'default tracer' do
-    it 'returns tracer named default' do
-      _(OpenTelemetry.default_tracer.name).must_equal('default')
-    end
-  end
 end


### PR DESCRIPTION
# Description
With the OTel Ruby API as it currently stands `Tracer` is the one stop shop for everything that a user needs / wants to do with a span. This design is intentional and was chosen for it's simplicity. There are currently questions around how interactions with context and the current span should be handled: see https://github.com/open-telemetry/opentelemetry-specification/issues/1019.

This description is ridiculously long as it assumes little to no familiarity with the Ruby API. If you are familiar with the project, skip the **Changes in this PR**  section towards the bottom.

For folks less familiar with the project, I'll show how the API currently works for a handful scenarios, and then go on to explain the changes added in this PR and what improvements they bring.

## Tracer operations

First, get a handle on a tracer

```ruby
# obtain a named tracer
tracer = OpenTelemetry.tracer_provider.tracer('my-app', '0.0.1')
```

The rest of the examples use this tracer

### Span creation

#### Start span
```ruby
# create and return a span / does not modify context
span = tracer.start_span('a-span')
```

#### Start span in current context
```ruby
# create a new span, set it in the active context
tracer.in_span('a-span') do |span|
  # execute this block of code in the active context
end
```

### Span and context managment

#### Read the current span

##### From the current (implicit) context

```ruby
span = tracer.current_span
```

##### From an explicit context

```ruby
span = tracer.current_span(some_context)
```

#### Set span in a context

##### Implicit context

```ruby
new_context = tracer.context_with_span(span)

```

##### Explicit context

```ruby
new_context = tracer.context_with_span(span, parent_context: some_context)
```

##### Execute block with span in a context

```ruby
tracer.with_span(some_span) do |span, context|
  #run this block with span set in the active context
end
```

## Changes in this PR

The `Tracer#current_context` and `Tracer#span_with_context` methods do not explicitly depend on state from a tracer instance, so they could be class (static) methods on a tracer. However, this introduces some unneccessary complications to the API. 

As an alternative solution, this PR introduces an easy to access default tracer on the top-level OpenTelemetry module. It's available as `OpenTelemetry.tracer` and can be used whenever a user needs to access tracer methods, but does not have an explicit handle on one.

For example, users might want to grab the `current_span` out of the ether to add  an attribute, or event.

```ruby
OpenTelemetry.tracer.
             current_span&.
             add_event('an-event', attributes: {'k1': 'v1', 'k2': 'v2'})
```

The `OpenTelemetry.tracer` method is just a delegate to the global tracer provider. When called without parameters, it returns a tracer named "default". It can also take arguments for name and version which becomes a shortcut for `OpenTelemetry.tracer_provider('tracer-name', 'tracer-version')`.             

### Alternatives

[Originally](https://github.com/open-telemetry/opentelemetry-ruby/commit/1f789dad7a5c7989a8e24c97012587e640bf2296) I added a `default_tracer` method that delegates to the global tracer provider, obtains a tracer named 'default', and memoizes and returns the result. It has the benefit of not having to lookup the tracer each time it's invoked. I switched to the `tracer` delegate method as it solves the same use case, is less verbose, and is usable in other scenarios. I think it's worth the tradeoff, but  could be convinced otherwise.