### PR TITLE
feat: Add service_version setter to configurator

### DIFF
--- a/exporter/jaeger/README.md
+++ b/exporter/jaeger/README.md
@@ -40,9 +40,8 @@ OpenTelemetry::SDK.configure do |c|
       # OpenTelemetry::Exporter::Jaeger::CollectorExporter.new(endpoint: 'http://192.168.0.1:14268')
     )
   )
-  c.resource = OpenTelemetry::SDK::Resources::Resource.create(
-    OpenTelemetry::SDK::Resources::Constants::SERVICE_RESOURCE[:name] => 'jaeger-example'
-  )
+  c.service_name = 'jaeger-example'
+  c.service_version = '0.6.0'
 end
 
 # To start a trace you need to get a Tracer from the TracerProvider

--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -54,6 +54,16 @@ module OpenTelemetry
         ).merge(@resource)
       end
 
+      # Accepts a string that is merged in as the service.version resource attribute.
+      # The most recent assigned value will be used in the event of repeated
+      # calls to this setter.
+      # @param [String] service_version The value to be used as the service version
+      def service_version=(service_version)
+        @resource = OpenTelemetry::SDK::Resources::Resource.create(
+          OpenTelemetry::SDK::Resources::Constants::SERVICE_RESOURCE[:version] => service_version
+        ).merge(@resource)
+      end
+
       # Install an instrumentation with specificied optional +config+.
       # Use can be called multiple times to install multiple instrumentation.
       # Only +use+ or +use_all+, but not both when installing

--- a/sdk/test/opentelemetry/sdk/configurator_test.rb
+++ b/sdk/test/opentelemetry/sdk/configurator_test.rb
@@ -75,6 +75,24 @@ describe OpenTelemetry::SDK::Configurator do
     end
   end
 
+  describe '#service_version=' do
+    let(:configurator_resource) { configurator.instance_variable_get(:@resource) }
+    let(:configurator_resource_attributes) { configurator_resource.attribute_enumerator.to_h }
+    let(:expected_resource_attributes) do
+      {
+        'service.version' => '0.6.0',
+        'telemetry.sdk.name' => 'opentelemetry',
+        'telemetry.sdk.language' => 'ruby',
+        'telemetry.sdk.version' => OpenTelemetry::SDK::VERSION
+      }
+    end
+
+    it 'assigns the service_version resource' do
+      configurator.service_version = '0.6.0'
+      _(configurator_resource_attributes).must_equal(expected_resource_attributes)
+    end
+  end
+
   describe '#use' do
     it 'can be called multiple times' do
       configurator.use('TestInstrumentation', enabled: true)


### PR DESCRIPTION
PR #417 added a setter to the configurator for service.name - this follows suite by adding the same for service.version to simplify the setting of the other attribute requested by many tracing backends.

Prior to this change, setting the pair of these would have looked like this:

```ruby
c.service_name = 'Otel Demo App'
c.resource = OpenTelemetry::SDK::Resources::Resource.create(
  OpenTelemetry::SDK::Resources::Constants::SERVICE_RESOURCE[:version] => '0.6.0'
)
```

After this change, the same is accomplished with this:

```ruby
c.service_name = 'Otel Demo App'
c.service_version = '0.6.0'
```