### PR TITLE
docs: Use BatchSpanProcessor in examples

### DIFF
--- a/exporter/jaeger/README.md
+++ b/exporter/jaeger/README.md
@@ -34,10 +34,10 @@ require 'opentelemetry/exporter/jaeger'
 # Configure the sdk with custom export
 OpenTelemetry::SDK.configure do |c|
   c.add_span_processor(
-    OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(
-      OpenTelemetry::Exporter::Jaeger::AgentExporter.new(host: '127.0.0.1', port: 6831)
+    OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
+      exporter: OpenTelemetry::Exporter::Jaeger::AgentExporter.new(host: '127.0.0.1', port: 6831)
       # Alternatively, for the collector exporter:
-      # OpenTelemetry::Exporter::Jaeger::CollectorExporter.new(endpoint: 'http://192.168.0.1:14268')
+      # exporter: OpenTelemetry::Exporter::Jaeger::CollectorExporter.new(endpoint: 'http://192.168.0.1:14268/api/traces')
     )
   )
   c.resource = OpenTelemetry::SDK::Resources::Resource.create(

--- a/exporter/otlp/README.md
+++ b/exporter/otlp/README.md
@@ -38,8 +38,8 @@ require 'opentelemetry/exporter/otlp'
 # Configure the sdk with custom export
 OpenTelemetry::SDK.configure do |c|
   c.add_span_processor(
-    OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(
-      OpenTelemetry::Exporter::OTLP::Exporter.new(
+    OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
+      exporter: OpenTelemetry::Exporter::OTLP::Exporter.new(
         host: 'localhost', port: 55680
       )
     )


### PR DESCRIPTION
All real-world usage should avoid the `SimpleSpanProcessor` so it is not what we should be recommending by way of our example code. This updates the two places it was being recommended to instead use the `BatchSpanProcessor`. 

This relates to #397 but does not resolve it.

This update also includes correcting the Jaeger collector endpoint for #378
