### PR TITLE
fix: update IL attribute naming convention to match spec

### DIFF
--- a/exporter/jaeger/lib/opentelemetry/exporter/jaeger/encoder.rb
+++ b/exporter/jaeger/lib/opentelemetry/exporter/jaeger/encoder.rb
@@ -134,8 +134,8 @@ module OpenTelemetry
           return EMPTY_ARRAY unless instrumentation_library
 
           tags = []
-          tags << encoded_tag('otel.instrumentation_library.name', instrumentation_library.name) if instrumentation_library.name
-          tags << encoded_tag('otel.instrumentation_library.version', instrumentation_library.version) if instrumentation_library.version
+          tags << encoded_tag('otel.library.name', instrumentation_library.name) if instrumentation_library.name
+          tags << encoded_tag('otel.library.version', instrumentation_library.version) if instrumentation_library.version
           tags
         end
 

--- a/exporter/jaeger/test/opentelemetry/exporters/jaeger/encoder_test.rb
+++ b/exporter/jaeger/test/opentelemetry/exporters/jaeger/encoder_test.rb
@@ -95,10 +95,10 @@ describe OpenTelemetry::Exporter::Jaeger::Encoder do
 
       name_tag, version_tag = encoded_span.tags
 
-      _(name_tag.key).must_equal('otel.instrumentation_library.name')
+      _(name_tag.key).must_equal('otel.library.name')
       _(name_tag.vStr).must_equal('mylib')
 
-      _(version_tag.key).must_equal('otel.instrumentation_library.version')
+      _(version_tag.key).must_equal('otel.library.version')
       _(version_tag.vStr).must_equal('0.1.0')
     end
 
@@ -111,7 +111,7 @@ describe OpenTelemetry::Exporter::Jaeger::Encoder do
 
       name_tag, = encoded_span.tags
 
-      _(name_tag.key).must_equal('otel.instrumentation_library.name')
+      _(name_tag.key).must_equal('otel.library.name')
       _(name_tag.vStr).must_equal('mylib')
     end
   end


### PR DESCRIPTION
This PR addresses https://github.com/open-telemetry/opentelemetry-ruby/issues/423