### PR TITLE
fix: OTLP parent_span_id should be nil for root

### DIFF
--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -215,7 +215,7 @@ module OpenTelemetry
             trace_id: span_data.trace_id,
             span_id: span_data.span_id,
             trace_state: span_data.tracestate,
-            parent_span_id: span_data.parent_span_id,
+            parent_span_id: span_data.parent_span_id == OpenTelemetry::Trace::INVALID_SPAN_ID ? nil : span_data.parent_span_id,
             name: span_data.name,
             kind: as_otlp_span_kind(span_data.kind),
             start_time_unix_nano: as_otlp_timestamp(span_data.start_timestamp),

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/version.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/version.rb
@@ -8,7 +8,7 @@ module OpenTelemetry
   module Exporter
     module OTLP
       ## Current OpenTelemetry OTLP exporter version
-      VERSION = '0.6.0'
+      VERSION = '0.6.1'
     end
   end
 end

--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -192,7 +192,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
                     Opentelemetry::Proto::Trace::V1::Span.new(
                       trace_id: trace_id,
                       span_id: root_span_id,
-                      parent_span_id: OpenTelemetry::Trace::INVALID_SPAN_ID,
+                      parent_span_id: nil,
                       name: 'root',
                       kind: Opentelemetry::Proto::Trace::V1::Span::SpanKind::INTERNAL,
                       start_time_unix_nano: (start_timestamp.to_r * 1_000_000_000).to_i,


### PR DESCRIPTION
The OTLP proto spec requires root spans to have an empty `parent_span_id` rather than an invalid span ID (all zero): https://github.com/open-telemetry/opentelemetry-proto/blob/30d237e1ff3ab7aa50e0922b5bebdd93505090af/opentelemetry/proto/trace/v1/trace.proto#L82-L84
