### PR TITLE
chore!: remove duplicate hostname resource attribute

### DIFF
--- a/resource_detectors/test/opentelemetry/detectors/google_cloud_platform_test.rb
+++ b/resource_detectors/test/opentelemetry/detectors/google_cloud_platform_test.rb
@@ -51,7 +51,6 @@ describe OpenTelemetry::Resource::Detectors::GoogleCloudPlatform do
           'cloud.account.id' => 'opentelemetry',
           'cloud.region' => 'us-central1',
           'cloud.zone' => 'us-central1-a',
-          'host.hostname' => 'opentelemetry-test',
           'host.id' => 'opentelemetry-test',
           'host.name' => 'opentelemetry-test',
           'k8s.cluster.name' => 'opentelemetry-cluster',

--- a/sdk/lib/opentelemetry/sdk/resources/constants.rb
+++ b/sdk/lib/opentelemetry/sdk/resources/constants.rb
@@ -79,10 +79,6 @@ module OpenTelemetry
 
         # Attributes defining a computing instance (e.g. host).
         HOST_RESOURCE = {
-          # Hostname of the host. It contains what the hostname command returns on the
-          # host machine.
-          hostname: 'host.hostname',
-
           # Unique host id. For Cloud this must be the instance_id assigned by the
           # cloud provider
           id: 'host.id',


### PR DESCRIPTION
I noticed this in JS, so I thought I'd fix it here also. There were two host name attributes: `host.name` and `host.hostname`. This PR removes the latter as per: https://github.com/open-telemetry/opentelemetry-specification/pull/838. The spec is pretty loose about the precedence to use when determining the `host.name` value. I chose the sequence: environment variable, gcp metadata hostname, Socket.gethostname. We can change that if there's a better ordering.