### PR TITLE
fix: set span name to sinatra.route

### DIFF
--- a/instrumentation/sinatra/lib/opentelemetry/instrumentation/sinatra/middlewares/tracer_middleware.rb
+++ b/instrumentation/sinatra/lib/opentelemetry/instrumentation/sinatra/middlewares/tracer_middleware.rb
@@ -15,10 +15,8 @@ module OpenTelemetry
           end
 
           def call(env)
-            span_name = env['sinatra.route'] || env['PATH_INFO']
-
             tracer.in_span(
-              span_name,
+              env['PATH_INFO'],
               attributes: { 'http.method' => env['REQUEST_METHOD'],
                             'http.url' => env['PATH_INFO'] },
               kind: :server,
@@ -46,6 +44,7 @@ module OpenTelemetry
             span.set_attribute('http.status_code', status)
             span.set_attribute('http.status_text', ::Rack::Utils::HTTP_STATUS_CODES[status])
             span.set_attribute('http.route', env['sinatra.route'].split.last) if env['sinatra.route']
+            span.name = env['sinatra.route'] if env['sinatra.route']
             span.status = OpenTelemetry::Trace::Status.http_to_status(status)
           end
         end


### PR DESCRIPTION
The previous attempt at this failed due to sinatra.route not having been set yet. This moves the logic for using sinatra.route to later in the process and only updates the span name if sinatra.route exists.