### PR TITLE
chore: Fix reporting of conventional commit lint issues

### DIFF
--- a/.github/workflows/release-hook-on-open.yml
+++ b/.github/workflows/release-hook-on-open.yml
@@ -1,7 +1,7 @@
 name: "[release hook] Check commit messages"
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
 jobs:
@@ -17,6 +17,8 @@ jobs:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo
         uses: actions/checkout@v2
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
       - name: Install Toys
         run: "gem install --no-document toys"
       - name: Check commit messages

--- a/.toys/release/.data/templates/release-hook-on-open.yml.erb
+++ b/.toys/release/.data/templates/release-hook-on-open.yml.erb
@@ -1,7 +1,7 @@
 name: "[release hook] Check commit messages"
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
 jobs:
@@ -17,6 +17,8 @@ jobs:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo
         uses: actions/checkout@v2
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
       - name: Install Toys
         run: "gem install --no-document toys"
       - name: Check commit messages


### PR DESCRIPTION
Sync with upstream release script fixes.

This patch fixes the conventional commit linter. Previously, when a PR was opened from a fork and the commit message failed linting, the checker could not post details of the problem in a PR comment as intended, because the action's token didn't have sufficient permissions. Now we use a different trigger that runs in the base repo's context, thus giving the token enough permissions to write to the PR.