### PR TITLE
chore: Add documentation, changelog, source, and issue links to gemspec metadata

### DIFF
--- a/api/opentelemetry-api.gemspec
+++ b/api/opentelemetry-api.gemspec
@@ -34,4 +34,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.17'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-api/v#{OpenTelemetry::VERSION}/file.CHANGELOG.html"
+    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/api"
+    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
+    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-api/v#{OpenTelemetry::VERSION}"
+  end
 end

--- a/api/opentelemetry-api.gemspec
+++ b/api/opentelemetry-api.gemspec
@@ -36,9 +36,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 
   if spec.respond_to?(:metadata)
-    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-api/v#{OpenTelemetry::VERSION}/file.CHANGELOG.html"
-    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/api"
-    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
-    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-api/v#{OpenTelemetry::VERSION}"
+    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-api/v#{OpenTelemetry::VERSION}/file.CHANGELOG.html"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/master/api'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/issues'
+    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-api/v#{OpenTelemetry::VERSION}"
   end
 end

--- a/exporter/jaeger/opentelemetry-exporter-jaeger.gemspec
+++ b/exporter/jaeger/opentelemetry-exporter-jaeger.gemspec
@@ -38,4 +38,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-exporter-jaeger/v#{OpenTelemetry::Exporter::Jaeger::VERSION}/file.CHANGELOG.html"
+    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/exporter/jaeger"
+    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
+    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-exporter-jaeger/v#{OpenTelemetry::Exporter::Jaeger::VERSION}"
+  end
 end

--- a/exporter/jaeger/opentelemetry-exporter-jaeger.gemspec
+++ b/exporter/jaeger/opentelemetry-exporter-jaeger.gemspec
@@ -40,9 +40,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 
   if spec.respond_to?(:metadata)
-    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-exporter-jaeger/v#{OpenTelemetry::Exporter::Jaeger::VERSION}/file.CHANGELOG.html"
-    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/exporter/jaeger"
-    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
-    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-exporter-jaeger/v#{OpenTelemetry::Exporter::Jaeger::VERSION}"
+    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-exporter-jaeger/v#{OpenTelemetry::Exporter::Jaeger::VERSION}/file.CHANGELOG.html"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/master/exporter/jaeger'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/issues'
+    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-exporter-jaeger/v#{OpenTelemetry::Exporter::Jaeger::VERSION}"
   end
 end

--- a/exporter/otlp/opentelemetry-exporter-otlp.gemspec
+++ b/exporter/otlp/opentelemetry-exporter-otlp.gemspec
@@ -39,9 +39,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 
   if spec.respond_to?(:metadata)
-    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-exporter-otlp/v#{OpenTelemetry::Exporter::OTLP::VERSION}/file.CHANGELOG.html"
-    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/exporter/otlp"
-    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
-    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-exporter-otlp/v#{OpenTelemetry::Exporter::OTLP::VERSION}"
+    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-exporter-otlp/v#{OpenTelemetry::Exporter::OTLP::VERSION}/file.CHANGELOG.html"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/master/exporter/otlp'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/issues'
+    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-exporter-otlp/v#{OpenTelemetry::Exporter::OTLP::VERSION}"
   end
 end

--- a/exporter/otlp/opentelemetry-exporter-otlp.gemspec
+++ b/exporter/otlp/opentelemetry-exporter-otlp.gemspec
@@ -37,4 +37,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-exporter-otlp/v#{OpenTelemetry::Exporter::OTLP::VERSION}/file.CHANGELOG.html"
+    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/exporter/otlp"
+    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
+    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-exporter-otlp/v#{OpenTelemetry::Exporter::OTLP::VERSION}"
+  end
 end

--- a/instrumentation/all/opentelemetry-instrumentation-all.gemspec
+++ b/instrumentation/all/opentelemetry-instrumentation-all.gemspec
@@ -48,9 +48,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 
   if spec.respond_to?(:metadata)
-    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-all/v#{OpenTelemetry::Instrumentation::All::VERSION}/file.CHANGELOG.html"
-    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/all"
-    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
-    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-all/v#{OpenTelemetry::Instrumentation::All::VERSION}"
+    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-all/v#{OpenTelemetry::Instrumentation::All::VERSION}/file.CHANGELOG.html"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/all'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/issues'
+    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-all/v#{OpenTelemetry::Instrumentation::All::VERSION}"
   end
 end

--- a/instrumentation/all/opentelemetry-instrumentation-all.gemspec
+++ b/instrumentation/all/opentelemetry-instrumentation-all.gemspec
@@ -46,4 +46,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-all/v#{OpenTelemetry::Instrumentation::All::VERSION}/file.CHANGELOG.html"
+    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/all"
+    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
+    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-all/v#{OpenTelemetry::Instrumentation::All::VERSION}"
+  end
 end

--- a/instrumentation/concurrent_ruby/opentelemetry-instrumentation-concurrent_ruby.gemspec
+++ b/instrumentation/concurrent_ruby/opentelemetry-instrumentation-concurrent_ruby.gemspec
@@ -36,4 +36,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-concurrent_ruby/v#{OpenTelemetry::Instrumentation::ConcurrentRuby::VERSION}/file.CHANGELOG.html"
+    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/concurrent_ruby"
+    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
+    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-concurrent_ruby/v#{OpenTelemetry::Instrumentation::ConcurrentRuby::VERSION}"
+  end
 end

--- a/instrumentation/concurrent_ruby/opentelemetry-instrumentation-concurrent_ruby.gemspec
+++ b/instrumentation/concurrent_ruby/opentelemetry-instrumentation-concurrent_ruby.gemspec
@@ -38,9 +38,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 
   if spec.respond_to?(:metadata)
-    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-concurrent_ruby/v#{OpenTelemetry::Instrumentation::ConcurrentRuby::VERSION}/file.CHANGELOG.html"
-    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/concurrent_ruby"
-    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
-    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-concurrent_ruby/v#{OpenTelemetry::Instrumentation::ConcurrentRuby::VERSION}"
+    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-concurrent_ruby/v#{OpenTelemetry::Instrumentation::ConcurrentRuby::VERSION}/file.CHANGELOG.html"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/concurrent_ruby'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/issues'
+    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-concurrent_ruby/v#{OpenTelemetry::Instrumentation::ConcurrentRuby::VERSION}"
   end
 end

--- a/instrumentation/dalli/opentelemetry-instrumentation-dalli.gemspec
+++ b/instrumentation/dalli/opentelemetry-instrumentation-dalli.gemspec
@@ -36,4 +36,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-dalli/v#{OpenTelemetry::Instrumentation::Dalli::VERSION}/file.CHANGELOG.html"
+    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/dalli"
+    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
+    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-dalli/v#{OpenTelemetry::Instrumentation::Dalli::VERSION}"
+  end
 end

--- a/instrumentation/dalli/opentelemetry-instrumentation-dalli.gemspec
+++ b/instrumentation/dalli/opentelemetry-instrumentation-dalli.gemspec
@@ -38,9 +38,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 
   if spec.respond_to?(:metadata)
-    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-dalli/v#{OpenTelemetry::Instrumentation::Dalli::VERSION}/file.CHANGELOG.html"
-    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/dalli"
-    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
-    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-dalli/v#{OpenTelemetry::Instrumentation::Dalli::VERSION}"
+    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-dalli/v#{OpenTelemetry::Instrumentation::Dalli::VERSION}/file.CHANGELOG.html"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/dalli'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/issues'
+    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-dalli/v#{OpenTelemetry::Instrumentation::Dalli::VERSION}"
   end
 end

--- a/instrumentation/ethon/opentelemetry-instrumentation-ethon.gemspec
+++ b/instrumentation/ethon/opentelemetry-instrumentation-ethon.gemspec
@@ -38,9 +38,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 
   if spec.respond_to?(:metadata)
-    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-ethon/v#{OpenTelemetry::Instrumentation::Ethon::VERSION}/file.CHANGELOG.html"
-    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/ethon"
-    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
-    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-ethon/v#{OpenTelemetry::Instrumentation::Ethon::VERSION}"
+    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-ethon/v#{OpenTelemetry::Instrumentation::Ethon::VERSION}/file.CHANGELOG.html"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/ethon'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/issues'
+    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-ethon/v#{OpenTelemetry::Instrumentation::Ethon::VERSION}"
   end
 end

--- a/instrumentation/ethon/opentelemetry-instrumentation-ethon.gemspec
+++ b/instrumentation/ethon/opentelemetry-instrumentation-ethon.gemspec
@@ -36,4 +36,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-ethon/v#{OpenTelemetry::Instrumentation::Ethon::VERSION}/file.CHANGELOG.html"
+    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/ethon"
+    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
+    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-ethon/v#{OpenTelemetry::Instrumentation::Ethon::VERSION}"
+  end
 end

--- a/instrumentation/excon/opentelemetry-instrumentation-excon.gemspec
+++ b/instrumentation/excon/opentelemetry-instrumentation-excon.gemspec
@@ -37,4 +37,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-excon/v#{OpenTelemetry::Instrumentation::Excon::VERSION}/file.CHANGELOG.html"
+    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/excon"
+    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
+    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-excon/v#{OpenTelemetry::Instrumentation::Excon::VERSION}"
+  end
 end

--- a/instrumentation/excon/opentelemetry-instrumentation-excon.gemspec
+++ b/instrumentation/excon/opentelemetry-instrumentation-excon.gemspec
@@ -39,9 +39,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 
   if spec.respond_to?(:metadata)
-    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-excon/v#{OpenTelemetry::Instrumentation::Excon::VERSION}/file.CHANGELOG.html"
-    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/excon"
-    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
-    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-excon/v#{OpenTelemetry::Instrumentation::Excon::VERSION}"
+    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-excon/v#{OpenTelemetry::Instrumentation::Excon::VERSION}/file.CHANGELOG.html"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/excon'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/issues'
+    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-excon/v#{OpenTelemetry::Instrumentation::Excon::VERSION}"
   end
 end

--- a/instrumentation/faraday/opentelemetry-instrumentation-faraday.gemspec
+++ b/instrumentation/faraday/opentelemetry-instrumentation-faraday.gemspec
@@ -39,9 +39,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 
   if spec.respond_to?(:metadata)
-    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-faraday/v#{OpenTelemetry::Instrumentation::Faraday::VERSION}/file.CHANGELOG.html"
-    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/faraday"
-    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
-    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-faraday/v#{OpenTelemetry::Instrumentation::Faraday::VERSION}"
+    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-faraday/v#{OpenTelemetry::Instrumentation::Faraday::VERSION}/file.CHANGELOG.html"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/faraday'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/issues'
+    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-faraday/v#{OpenTelemetry::Instrumentation::Faraday::VERSION}"
   end
 end

--- a/instrumentation/faraday/opentelemetry-instrumentation-faraday.gemspec
+++ b/instrumentation/faraday/opentelemetry-instrumentation-faraday.gemspec
@@ -37,4 +37,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-faraday/v#{OpenTelemetry::Instrumentation::Faraday::VERSION}/file.CHANGELOG.html"
+    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/faraday"
+    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
+    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-faraday/v#{OpenTelemetry::Instrumentation::Faraday::VERSION}"
+  end
 end

--- a/instrumentation/mysql2/opentelemetry-instrumentation-mysql2.gemspec
+++ b/instrumentation/mysql2/opentelemetry-instrumentation-mysql2.gemspec
@@ -36,4 +36,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-mysql2/v#{OpenTelemetry::Instrumentation::Mysql2::VERSION}/file.CHANGELOG.html"
+    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/mysql2"
+    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
+    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-mysql2/v#{OpenTelemetry::Instrumentation::Mysql2::VERSION}"
+  end
 end

--- a/instrumentation/mysql2/opentelemetry-instrumentation-mysql2.gemspec
+++ b/instrumentation/mysql2/opentelemetry-instrumentation-mysql2.gemspec
@@ -38,9 +38,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 
   if spec.respond_to?(:metadata)
-    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-mysql2/v#{OpenTelemetry::Instrumentation::Mysql2::VERSION}/file.CHANGELOG.html"
-    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/mysql2"
-    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
-    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-mysql2/v#{OpenTelemetry::Instrumentation::Mysql2::VERSION}"
+    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-mysql2/v#{OpenTelemetry::Instrumentation::Mysql2::VERSION}/file.CHANGELOG.html"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/mysql2'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/issues'
+    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-mysql2/v#{OpenTelemetry::Instrumentation::Mysql2::VERSION}"
   end
 end

--- a/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
+++ b/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
@@ -36,4 +36,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-net_http/v#{OpenTelemetry::Instrumentation::Net::HTTP::VERSION}/file.CHANGELOG.html"
+    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/net_http"
+    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
+    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-net_http/v#{OpenTelemetry::Instrumentation::Net::HTTP::VERSION}"
+  end
 end

--- a/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
+++ b/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
@@ -38,9 +38,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 
   if spec.respond_to?(:metadata)
-    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-net_http/v#{OpenTelemetry::Instrumentation::Net::HTTP::VERSION}/file.CHANGELOG.html"
-    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/net_http"
-    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
-    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-net_http/v#{OpenTelemetry::Instrumentation::Net::HTTP::VERSION}"
+    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-net_http/v#{OpenTelemetry::Instrumentation::Net::HTTP::VERSION}/file.CHANGELOG.html"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/net_http'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/issues'
+    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-net_http/v#{OpenTelemetry::Instrumentation::Net::HTTP::VERSION}"
   end
 end

--- a/instrumentation/rack/opentelemetry-instrumentation-rack.gemspec
+++ b/instrumentation/rack/opentelemetry-instrumentation-rack.gemspec
@@ -41,9 +41,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 
   if spec.respond_to?(:metadata)
-    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-rack/v#{OpenTelemetry::Instrumentation::Rack::VERSION}/file.CHANGELOG.html"
-    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/rack"
-    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
-    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-rack/v#{OpenTelemetry::Instrumentation::Rack::VERSION}"
+    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-rack/v#{OpenTelemetry::Instrumentation::Rack::VERSION}/file.CHANGELOG.html"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/rack'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/issues'
+    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-rack/v#{OpenTelemetry::Instrumentation::Rack::VERSION}"
   end
 end

--- a/instrumentation/rack/opentelemetry-instrumentation-rack.gemspec
+++ b/instrumentation/rack/opentelemetry-instrumentation-rack.gemspec
@@ -39,4 +39,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-rack/v#{OpenTelemetry::Instrumentation::Rack::VERSION}/file.CHANGELOG.html"
+    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/rack"
+    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
+    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-rack/v#{OpenTelemetry::Instrumentation::Rack::VERSION}"
+  end
 end

--- a/instrumentation/redis/opentelemetry-instrumentation-redis.gemspec
+++ b/instrumentation/redis/opentelemetry-instrumentation-redis.gemspec
@@ -37,4 +37,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-redis/v#{OpenTelemetry::Instrumentation::Redis::VERSION}/file.CHANGELOG.html"
+    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/redis"
+    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
+    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-redis/v#{OpenTelemetry::Instrumentation::Redis::VERSION}"
+  end
 end

--- a/instrumentation/redis/opentelemetry-instrumentation-redis.gemspec
+++ b/instrumentation/redis/opentelemetry-instrumentation-redis.gemspec
@@ -39,9 +39,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 
   if spec.respond_to?(:metadata)
-    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-redis/v#{OpenTelemetry::Instrumentation::Redis::VERSION}/file.CHANGELOG.html"
-    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/redis"
-    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
-    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-redis/v#{OpenTelemetry::Instrumentation::Redis::VERSION}"
+    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-redis/v#{OpenTelemetry::Instrumentation::Redis::VERSION}/file.CHANGELOG.html"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/redis'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/issues'
+    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-redis/v#{OpenTelemetry::Instrumentation::Redis::VERSION}"
   end
 end

--- a/instrumentation/restclient/opentelemetry-instrumentation-restclient.gemspec
+++ b/instrumentation/restclient/opentelemetry-instrumentation-restclient.gemspec
@@ -37,4 +37,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-restclient/v#{OpenTelemetry::Instrumentation::RestClient::VERSION}/file.CHANGELOG.html"
+    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/restclient"
+    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
+    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-restclient/v#{OpenTelemetry::Instrumentation::RestClient::VERSION}"
+  end
 end

--- a/instrumentation/restclient/opentelemetry-instrumentation-restclient.gemspec
+++ b/instrumentation/restclient/opentelemetry-instrumentation-restclient.gemspec
@@ -39,9 +39,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 
   if spec.respond_to?(:metadata)
-    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-restclient/v#{OpenTelemetry::Instrumentation::RestClient::VERSION}/file.CHANGELOG.html"
-    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/restclient"
-    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
-    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-restclient/v#{OpenTelemetry::Instrumentation::RestClient::VERSION}"
+    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-restclient/v#{OpenTelemetry::Instrumentation::RestClient::VERSION}/file.CHANGELOG.html"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/restclient'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/issues'
+    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-restclient/v#{OpenTelemetry::Instrumentation::RestClient::VERSION}"
   end
 end

--- a/instrumentation/sidekiq/opentelemetry-instrumentation-sidekiq.gemspec
+++ b/instrumentation/sidekiq/opentelemetry-instrumentation-sidekiq.gemspec
@@ -36,4 +36,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-sidekiq/v#{OpenTelemetry::Instrumentation::Sidekiq::VERSION}/file.CHANGELOG.html"
+    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/sidekiq"
+    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
+    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-sidekiq/v#{OpenTelemetry::Instrumentation::Sidekiq::VERSION}"
+  end
 end

--- a/instrumentation/sidekiq/opentelemetry-instrumentation-sidekiq.gemspec
+++ b/instrumentation/sidekiq/opentelemetry-instrumentation-sidekiq.gemspec
@@ -38,9 +38,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 
   if spec.respond_to?(:metadata)
-    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-sidekiq/v#{OpenTelemetry::Instrumentation::Sidekiq::VERSION}/file.CHANGELOG.html"
-    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/sidekiq"
-    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
-    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-sidekiq/v#{OpenTelemetry::Instrumentation::Sidekiq::VERSION}"
+    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-sidekiq/v#{OpenTelemetry::Instrumentation::Sidekiq::VERSION}/file.CHANGELOG.html"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/sidekiq'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/issues'
+    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-sidekiq/v#{OpenTelemetry::Instrumentation::Sidekiq::VERSION}"
   end
 end

--- a/instrumentation/sinatra/opentelemetry-instrumentation-sinatra.gemspec
+++ b/instrumentation/sinatra/opentelemetry-instrumentation-sinatra.gemspec
@@ -40,9 +40,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 
   if spec.respond_to?(:metadata)
-    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-sinatra/v#{OpenTelemetry::Instrumentation::Sinatra::VERSION}/file.CHANGELOG.html"
-    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/sinatra"
-    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
-    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-sinatra/v#{OpenTelemetry::Instrumentation::Sinatra::VERSION}"
+    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-sinatra/v#{OpenTelemetry::Instrumentation::Sinatra::VERSION}/file.CHANGELOG.html"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/sinatra'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/issues'
+    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-sinatra/v#{OpenTelemetry::Instrumentation::Sinatra::VERSION}"
   end
 end

--- a/instrumentation/sinatra/opentelemetry-instrumentation-sinatra.gemspec
+++ b/instrumentation/sinatra/opentelemetry-instrumentation-sinatra.gemspec
@@ -38,4 +38,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-sinatra/v#{OpenTelemetry::Instrumentation::Sinatra::VERSION}/file.CHANGELOG.html"
+    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/sinatra"
+    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
+    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-sinatra/v#{OpenTelemetry::Instrumentation::Sinatra::VERSION}"
+  end
 end

--- a/resource_detectors/opentelemetry-resource_detectors.gemspec
+++ b/resource_detectors/opentelemetry-resource_detectors.gemspec
@@ -36,9 +36,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 
   if spec.respond_to?(:metadata)
-    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-resource_detectors/v#{OpenTelemetry::Resource::Detectors::VERSION}/file.CHANGELOG.html"
-    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/resource_detectors"
-    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
-    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-resource_detectors/v#{OpenTelemetry::Resource::Detectors::VERSION}"
+    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-resource_detectors/v#{OpenTelemetry::Resource::Detectors::VERSION}/file.CHANGELOG.html"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/master/resource_detectors'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/issues'
+    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-resource_detectors/v#{OpenTelemetry::Resource::Detectors::VERSION}"
   end
 end

--- a/resource_detectors/opentelemetry-resource_detectors.gemspec
+++ b/resource_detectors/opentelemetry-resource_detectors.gemspec
@@ -34,4 +34,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.17'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-resource_detectors/v#{OpenTelemetry::Resource::Detectors::VERSION}/file.CHANGELOG.html"
+    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/resource_detectors"
+    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
+    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-resource_detectors/v#{OpenTelemetry::Resource::Detectors::VERSION}"
+  end
 end

--- a/sdk/opentelemetry-sdk.gemspec
+++ b/sdk/opentelemetry-sdk.gemspec
@@ -35,4 +35,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.17'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-sdk/v#{OpenTelemetry::SDK::VERSION}/file.CHANGELOG.html"
+    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/sdk"
+    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
+    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-sdk/v#{OpenTelemetry::SDK::VERSION}"
+  end
 end

--- a/sdk/opentelemetry-sdk.gemspec
+++ b/sdk/opentelemetry-sdk.gemspec
@@ -37,9 +37,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 
   if spec.respond_to?(:metadata)
-    spec.metadata["changelog_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-sdk/v#{OpenTelemetry::SDK::VERSION}/file.CHANGELOG.html"
-    spec.metadata["source_code_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/tree/master/sdk"
-    spec.metadata["bug_tracker_uri"] = "https://github.com/open-telemetry/opentelemetry-ruby/issues"
-    spec.metadata["documentation_uri"] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-sdk/v#{OpenTelemetry::SDK::VERSION}"
+    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-sdk/v#{OpenTelemetry::SDK::VERSION}/file.CHANGELOG.html"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/master/sdk'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/issues'
+    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-sdk/v#{OpenTelemetry::SDK::VERSION}"
   end
 end


### PR DESCRIPTION
Adds several links to the gem pages on rubygems.org. Note: the documentation and changelog links point to the yardocs that are now being built to github pages.