### PR TITLE
Correct "peer" attributes according to semantic conventions

### DIFF
--- a/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/patches/server.rb
+++ b/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/patches/server.rb
@@ -15,8 +15,8 @@ module OpenTelemetry
             attributes = {
               'db.system' => 'memcached',
               'db.statement' => Utils.format_command(operation, args),
-              'net.peer.name' => hostname,
-              'net.peer.port' => port
+              'peer.hostname' => hostname,
+              'peer.port' => port
             }
 
             tracer.in_span(operation, attributes: attributes, kind: :client) do

--- a/instrumentation/dalli/test/opentelemetry/instrumentation/dalli/instrumentation_test.rb
+++ b/instrumentation/dalli/test/opentelemetry/instrumentation/dalli/instrumentation_test.rb
@@ -42,8 +42,8 @@ describe OpenTelemetry::Instrumentation::Dalli::Instrumentation do
       _(span.name).must_equal 'set'
       _(span.attributes['db.system']).must_equal 'memcached'
       _(span.attributes['db.statement']).must_equal 'set foo bar 0 0'
-      _(span.attributes['net.peer.name']).must_equal host
-      _(span.attributes['net.peer.port']).must_equal port
+      _(span.attributes['peer.hostname']).must_equal host
+      _(span.attributes['peer.port']).must_equal port
     end
 
     it 'after dalli#set' do
@@ -53,8 +53,8 @@ describe OpenTelemetry::Instrumentation::Dalli::Instrumentation do
       _(span.name).must_equal 'get'
       _(span.attributes['db.system']).must_equal 'memcached'
       _(span.attributes['db.statement']).must_equal 'get foo'
-      _(span.attributes['net.peer.name']).must_equal host
-      _(span.attributes['net.peer.port']).must_equal port
+      _(span.attributes['peer.hostname']).must_equal host
+      _(span.attributes['peer.port']).must_equal port
     end
 
     it 'after dalli#get_multi' do
@@ -64,8 +64,8 @@ describe OpenTelemetry::Instrumentation::Dalli::Instrumentation do
       _(span.name).must_equal 'getkq'
       _(span.attributes['db.system']).must_equal 'memcached'
       _(span.attributes['db.statement']).must_equal 'getkq foo bar'
-      _(span.attributes['net.peer.name']).must_equal host
-      _(span.attributes['net.peer.port']).must_equal port
+      _(span.attributes['peer.hostname']).must_equal host
+      _(span.attributes['peer.port']).must_equal port
     end
 
     it 'after error' do
@@ -80,8 +80,8 @@ describe OpenTelemetry::Instrumentation::Dalli::Instrumentation do
       _(span.name).must_equal 'getkq'
       _(span.attributes['db.system']).must_equal 'memcached'
       _(span.attributes['db.statement']).must_equal 'getkq foo bar'
-      _(span.attributes['net.peer.name']).must_equal host
-      _(span.attributes['net.peer.port']).must_equal port
+      _(span.attributes['peer.hostname']).must_equal host
+      _(span.attributes['peer.port']).must_equal port
 
       span_event = span.events.first
       _(span_event.name).must_equal 'exception'

--- a/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
+++ b/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
@@ -76,8 +76,8 @@ module OpenTelemetry
               'db.type' => 'mysql',
               'db.instance' => database_name,
               'db.url' => "mysql://#{host}:#{port}",
-              'net.peer.name' => host,
-              'net.peer.port' => port
+              'peer.hostname' => host,
+              'peer.port' => port
             }
           end
 

--- a/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
+++ b/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
@@ -65,8 +65,8 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
       _(span.attributes['db.instance']).must_equal 'mysql'
       _(span.attributes['db.statement']).must_equal 'SELECT 1'
       _(span.attributes['db.url']).must_equal "mysql://#{host}:#{port}"
-      _(span.attributes['net.peer.name']).must_equal host.to_s
-      _(span.attributes['net.peer.port']).must_equal port.to_s
+      _(span.attributes['peer.hostname']).must_equal host.to_s
+      _(span.attributes['peer.port']).must_equal port.to_s
     end
 
     it 'after error' do
@@ -79,8 +79,8 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
       _(span.attributes['db.instance']).must_equal 'mysql'
       _(span.attributes['db.statement']).must_equal 'SELECT INVALID'
       _(span.attributes['db.url']).must_equal "mysql://#{host}:#{port}"
-      _(span.attributes['net.peer.name']).must_equal host.to_s
-      _(span.attributes['net.peer.port']).must_equal port.to_s
+      _(span.attributes['peer.hostname']).must_equal host.to_s
+      _(span.attributes['peer.port']).must_equal port.to_s
 
       _(span.status.code).must_equal(
         OpenTelemetry::Trace::Status::ERROR
@@ -102,8 +102,8 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
       _(span.attributes['db.instance']).must_equal 'mysql'
       _(span.attributes['db.statement']).must_equal explain_sql
       _(span.attributes['db.url']).must_equal "mysql://#{host}:#{port}"
-      _(span.attributes['net.peer.name']).must_equal host.to_s
-      _(span.attributes['net.peer.port']).must_equal port.to_s
+      _(span.attributes['peer.hostname']).must_equal host.to_s
+      _(span.attributes['peer.port']).must_equal port.to_s
     end
 
     it 'uses component.name and instance.name as span.name fallbacks with invalid sql' do
@@ -116,8 +116,8 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
       _(span.attributes['db.instance']).must_equal 'mysql'
       _(span.attributes['db.statement']).must_equal 'DESELECT 1'
       _(span.attributes['db.url']).must_equal "mysql://#{host}:#{port}"
-      _(span.attributes['net.peer.name']).must_equal host.to_s
-      _(span.attributes['net.peer.port']).must_equal port.to_s
+      _(span.attributes['peer.hostname']).must_equal host.to_s
+      _(span.attributes['peer.port']).must_equal port.to_s
 
       _(span.status.code).must_equal(
         OpenTelemetry::Trace::Status::ERROR

--- a/instrumentation/redis/lib/opentelemetry/instrumentation/redis/patches/client.rb
+++ b/instrumentation/redis/lib/opentelemetry/instrumentation/redis/patches/client.rb
@@ -52,8 +52,8 @@ module OpenTelemetry
               'db.type' => 'redis',
               'db.instance' => options[:db].to_s,
               'db.url' => "redis://#{host}:#{port}",
-              'net.peer.name' => host,
-              'net.peer.port' => port
+              'peer.hostname' => host,
+              'peer.port' => port
             }
           end
 

--- a/instrumentation/redis/test/opentelemetry/instrumentation/redis/instrumentation_test.rb
+++ b/instrumentation/redis/test/opentelemetry/instrumentation/redis/instrumentation_test.rb
@@ -40,8 +40,8 @@ describe OpenTelemetry::Instrumentation::Redis::Instrumentation do
       _(span.attributes['db.instance']).must_equal '0'
       _(span.attributes['db.statement']).must_equal 'AUTH ?'
       _(span.attributes['db.url']).must_equal 'redis://127.0.0.1:6379'
-      _(span.attributes['net.peer.name']).must_equal '127.0.0.1'
-      _(span.attributes['net.peer.port']).must_equal 6379
+      _(span.attributes['peer.hostname']).must_equal '127.0.0.1'
+      _(span.attributes['peer.port']).must_equal 6379
     end
 
     it 'after requests' do
@@ -59,8 +59,8 @@ describe OpenTelemetry::Instrumentation::Redis::Instrumentation do
         'SET K ' + 'x' * 47 + '...'
       )
       _(set_span.attributes['db.url']).must_equal 'redis://127.0.0.1:6379'
-      _(set_span.attributes['net.peer.name']).must_equal '127.0.0.1'
-      _(set_span.attributes['net.peer.port']).must_equal 6379
+      _(set_span.attributes['peer.hostname']).must_equal '127.0.0.1'
+      _(set_span.attributes['peer.port']).must_equal 6379
 
       get_span = exporter.finished_spans.last
       _(get_span.name).must_equal 'GET'
@@ -68,8 +68,8 @@ describe OpenTelemetry::Instrumentation::Redis::Instrumentation do
       _(get_span.attributes['db.instance']).must_equal '0'
       _(get_span.attributes['db.statement']).must_equal 'GET K'
       _(get_span.attributes['db.url']).must_equal 'redis://127.0.0.1:6379'
-      _(get_span.attributes['net.peer.name']).must_equal '127.0.0.1'
-      _(get_span.attributes['net.peer.port']).must_equal 6379
+      _(get_span.attributes['peer.hostname']).must_equal '127.0.0.1'
+      _(get_span.attributes['peer.port']).must_equal 6379
     end
 
     it 'after error' do
@@ -85,8 +85,8 @@ describe OpenTelemetry::Instrumentation::Redis::Instrumentation do
         'THIS_IS_NOT_A_REDIS_FUNC THIS_IS_NOT_A_VALID_ARG'
       )
       _(span.attributes['db.url']).must_equal 'redis://127.0.0.1:6379'
-      _(span.attributes['net.peer.name']).must_equal '127.0.0.1'
-      _(span.attributes['net.peer.port']).must_equal 6379
+      _(span.attributes['peer.hostname']).must_equal '127.0.0.1'
+      _(span.attributes['peer.port']).must_equal 6379
       _(span.status.code).must_equal(
         OpenTelemetry::Trace::Status::ERROR
       )
@@ -108,8 +108,8 @@ describe OpenTelemetry::Instrumentation::Redis::Instrumentation do
       _(span.attributes['db.instance']).must_equal '0'
       _(span.attributes['db.statement']).must_equal "SET v1 0\nINCR v1\nGET v1"
       _(span.attributes['db.url']).must_equal 'redis://example.com:8321'
-      _(span.attributes['net.peer.name']).must_equal 'example.com'
-      _(span.attributes['net.peer.port']).must_equal 8321
+      _(span.attributes['peer.hostname']).must_equal 'example.com'
+      _(span.attributes['peer.port']).must_equal 8321
     end
   end
 end


### PR DESCRIPTION
Rename attributes according to https://opentracing.io/specification/conventions/

net.peer.name --> peer.hostname
net.peer.port --> peer.port