### PR TITLE
fix!: assorted SpanContext fixes

### DIFF
--- a/api/lib/opentelemetry/trace/link.rb
+++ b/api/lib/opentelemetry/trace/link.rb
@@ -18,7 +18,7 @@ module OpenTelemetry
       # Returns the {SpanContext} for this link
       #
       # @return [SpanContext]
-      attr_reader :context
+      attr_reader :span_context
 
       # Returns the frozen attributes for this link.
       #
@@ -33,13 +33,13 @@ module OpenTelemetry
       #   frozen during Link initialization.
       # @return [Link]
       def initialize(span_context, attributes = nil)
-        @context = span_context
+        @span_context = span_context
         @attributes = attributes.freeze || EMPTY_ATTRIBUTES
       end
 
       # Returns true if two {Link}s are equal.
       def ==(other)
-        other.context == @context && other.attributes == @attributes
+        other.span_context == @span_context && other.attributes == @attributes
       end
     end
   end

--- a/api/lib/opentelemetry/trace/propagation/trace_context/text_map_injector.rb
+++ b/api/lib/opentelemetry/trace/propagation/trace_context/text_map_injector.rb
@@ -36,7 +36,7 @@ module OpenTelemetry
             return carrier unless (span_context = span_context_from(context))
 
             setter ||= DEFAULT_SETTER
-            setter.call(carrier, @traceparent_key, TraceParent.from_context(span_context).to_s)
+            setter.call(carrier, @traceparent_key, TraceParent.from_span_context(span_context).to_s)
             setter.call(carrier, @tracestate_key, span_context.tracestate) unless span_context.tracestate.nil?
 
             carrier
@@ -45,7 +45,7 @@ module OpenTelemetry
           private
 
           def span_context_from(context)
-            OpenTelemetry::Trace.current_span(context)&.context
+            OpenTelemetry::Trace.current_span(context).context
           end
         end
       end

--- a/api/lib/opentelemetry/trace/propagation/trace_context/trace_parent.rb
+++ b/api/lib/opentelemetry/trace/propagation/trace_context/trace_parent.rb
@@ -31,9 +31,9 @@ module OpenTelemetry
 
           class << self
             # Creates a new {TraceParent} from a supplied {Trace::SpanContext}
-            # @param [SpanContext] ctx The context
+            # @param [SpanContext] ctx The span context
             # @return [TraceParent] a trace parent
-            def from_context(ctx)
+            def from_span_context(ctx)
               new(trace_id: ctx.trace_id, span_id: ctx.span_id, flags: ctx.trace_flags)
             end
 

--- a/api/test/opentelemetry/trace/link_test.rb
+++ b/api/test/opentelemetry/trace/link_test.rb
@@ -12,13 +12,13 @@ describe OpenTelemetry::Trace::Link do
   describe '.new' do
     it 'accepts a span_context' do
       link = Link.new(span_context)
-      _(link.context).must_equal(span_context)
+      _(link.span_context).must_equal(span_context)
     end
 
     it 'returns a link with the given span context and attributes' do
       link = Link.new(span_context, '1' => 1)
       _(link.attributes).must_equal('1' => 1)
-      _(link.context).must_equal(span_context)
+      _(link.span_context).must_equal(span_context)
     end
 
     it 'returns a link with no attributes by default' do

--- a/api/test/opentelemetry/trace/propagation/trace_context/trace_parent_test.rb
+++ b/api/test/opentelemetry/trace/propagation/trace_context/trace_parent_test.rb
@@ -10,7 +10,7 @@ describe OpenTelemetry::Trace::Propagation::TraceContext::TraceParent do
   Trace = OpenTelemetry::Trace
   let(:good) do
     flags = Trace::TraceFlags.from_byte(1)
-    TraceParent.from_context(Trace::SpanContext.new(trace_flags: flags))
+    TraceParent.from_span_context(Trace::SpanContext.new(trace_flags: flags))
   end
 
   describe '.to_s' do
@@ -26,7 +26,7 @@ describe OpenTelemetry::Trace::Propagation::TraceContext::TraceParent do
 
   it 'should make a traceparent from a span context' do
     sp = OpenTelemetry::Trace::SpanContext.new
-    tp = TraceParent.from_context(sp)
+    tp = TraceParent.from_span_context(sp)
 
     _(sp.trace_id).must_equal tp.trace_id
     _(sp.span_id).must_equal  tp.span_id

--- a/exporter/jaeger/lib/opentelemetry/exporter/jaeger/encoder.rb
+++ b/exporter/jaeger/lib/opentelemetry/exporter/jaeger/encoder.rb
@@ -111,9 +111,9 @@ module OpenTelemetry
           links&.map do |link|
             Thrift::SpanRef.new(
               'refType' => Thrift::SpanRefType::CHILD_OF,
-              'traceIdLow' => int64(link.context.trace_id[16, 16]),
-              'traceIdHigh' => int64(link.context.trace_id[0, 16]),
-              'spanId' => int64(link.context.span_id)
+              'traceIdLow' => int64(link.span_context.trace_id[16, 16]),
+              'traceIdHigh' => int64(link.span_context.trace_id[0, 16]),
+              'spanId' => int64(link.span_context.span_id)
             )
           end
         end

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -232,9 +232,9 @@ module OpenTelemetry
             dropped_events_count: span_data.total_recorded_events - span_data.events&.size.to_i,
             links: span_data.links&.map do |link|
               Opentelemetry::Proto::Trace::V1::Span::Link.new(
-                trace_id: link.context.trace_id,
-                span_id: link.context.span_id,
-                trace_state: link.context.tracestate,
+                trace_id: link.span_context.trace_id,
+                span_id: link.span_context.span_id,
+                trace_state: link.span_context.tracestate,
                 attributes: link.attributes&.map { |k, v| as_otlp_key_value(k, v) }
                 # TODO: track dropped_attributes_count in Span#trim_links
               )

--- a/sdk/lib/opentelemetry/sdk/trace/span.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span.rb
@@ -294,7 +294,7 @@ module OpenTelemetry
             attrs.keep_if { |key, value| Internal.valid_key?(key) && Internal.valid_value?(value) }
             excess = attrs.size - max_attributes_per_link
             excess.times { attrs.shift } if excess.positive?
-            OpenTelemetry::Trace::Link.new(link.context, attrs)
+            OpenTelemetry::Trace::Link.new(link.span_context, attrs)
           end.freeze
         end
 

--- a/sdk/lib/opentelemetry/sdk/trace/tracer.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/tracer.rb
@@ -38,10 +38,13 @@ module OpenTelemetry
 
           with_parent ||= Context.current
           parent_span_context = OpenTelemetry::Trace.current_span(with_parent).context
-          parent_span_context = nil unless parent_span_context.valid?
-          parent_span_id = parent_span_context&.span_id
-          tracestate = parent_span_context&.tracestate
-          trace_id = parent_span_context&.trace_id
+          if parent_span_context.valid?
+            parent_span_id = parent_span_context.span_id
+            tracestate = parent_span_context.tracestate
+            trace_id = parent_span_context.trace_id
+          else
+            parent_span_context = nil
+          end
           trace_id ||= OpenTelemetry::Trace.generate_trace_id
           sampler = tracer_provider.active_trace_config.sampler
           result = sampler.should_sample?(trace_id: trace_id, parent_context: parent_span_context, links: links, name: name, kind: kind, attributes: attributes)

--- a/sdk/test/opentelemetry/sdk/trace/tracer_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/tracer_test.rb
@@ -227,7 +227,7 @@ describe OpenTelemetry::SDK::Trace::Tracer do
     end
 
     it 'creates a span with all supplied parameters' do
-      links = [OpenTelemetry::Trace::Link.new(context)]
+      links = [OpenTelemetry::Trace::Link.new(span_context)]
       name = 'span'
       kind = OpenTelemetry::Trace::SpanKind::INTERNAL
       attributes = { '1' => 1 }
@@ -254,7 +254,7 @@ describe OpenTelemetry::SDK::Trace::Tracer do
 
     it 'uses the context from parent if supplied' do
       parent = tracer.start_root_span('root')
-      parent_ctx = OpenTelemetry::Trace.with_span(parent) { |_, ctx| ctx }
+      parent_ctx = OpenTelemetry::Trace.context_with_span(parent)
       span = tracer.start_span('child', with_parent: parent_ctx)
       _(span.parent_span_id).must_equal(parent.context.span_id)
       _(span.context.trace_id).must_equal(parent.context.trace_id)


### PR DESCRIPTION
Assorted small changes from #440.

There is a single breaking change: `Link#context` -> `Link#span_context`.