### PR TITLE
fix: signal at batch_size

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -75,7 +75,7 @@ module OpenTelemetry
               n = spans.size + 1 - max_queue_size
               spans.shift(n) if n.positive?
               spans << span
-              @condition.signal if spans.size > max_queue_size / 2
+              @condition.signal if spans.size > batch_size
             end
           end
 


### PR DESCRIPTION
... instead of half max queue size. This makes the trigger independent of the queue size. We're running with this in production and it has helped significantly reduce dropped spans.