### PR TITLE
Add documentation on usage scenarios for span processors

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -13,6 +13,9 @@ module OpenTelemetry
         # Implementation of the duck type SpanProcessor that batches spans
         # exported by the SDK then pushes them to the exporter pipeline.
         #
+        # Typically, the BatchSpanProcessor will be more suitable for
+        # production environments than the SimpleSpanProcessor.
+        #
         # All spans reported by the SDK implementation are first added to a
         # synchronized queue (with a {max_queue_size} maximum size, after the
         # size is reached spans are dropped) and exported every

--- a/sdk/lib/opentelemetry/sdk/trace/export/simple_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/simple_span_processor.rb
@@ -12,6 +12,12 @@ module OpenTelemetry
         # {Span} to {io.opentelemetry.proto.trace.v1.Span} and passes it to the
         # configured exporter.
         #
+        # Typically, the SimpleSpanProcessor will be most suitable for use in testing;
+        # it should be used with caution in production. It may be appropriate for
+        # production use in scenarios where creating multiple threads is not desirable
+        # as well as scenarios where different custom attributes should be added to
+        # individual spans based on code scopes.
+        #
         # Only spans that are recorded are converted, {OpenTelemetry::Trace::Span#is_recording?} must
         # return true.
         class SimpleSpanProcessor


### PR DESCRIPTION
Addresses #397. As noted in that issue, there wasn't anything in the spec about the different scenarios in which to use simple vs. batch span processors, so I ended up making a spec PR for this as well: https://github.com/open-telemetry/opentelemetry-specification/pull/1135.

As of this writing, my spec PR has received one approval and there are no open questions or requested changes related to the differences between the two types of span processors. The documentation I'm submitting here is extracted from that PR.