### PR TITLE
fix: BatchSpanProcessor should not spawn a thread during app boot for forking webservers

### DIFF
--- a/sdk/lib/opentelemetry/sdk/internal.rb
+++ b/sdk/lib/opentelemetry/sdk/internal.rb
@@ -16,6 +16,16 @@ module OpenTelemetry
         value.is_a?(TrueClass) || value.is_a?(FalseClass)
       end
 
+      def to_boolean(value)
+        return nil if value.nil?
+        return value if boolean?(value)
+
+        case value.to_s
+        when /\A(true|t|yes|y|1)\z/i then true
+        when /\A(false|f|no|n|0)\z/i then false
+        end
+      end
+
       def valid_key?(key)
         key.instance_of?(String)
       end

--- a/sdk/lib/opentelemetry/sdk/trace/export.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export.rb
@@ -27,6 +27,7 @@ module OpenTelemetry
   end
 end
 
+require 'opentelemetry/sdk/trace/export/dispatcher_detector'
 require 'opentelemetry/sdk/trace/export/batch_span_processor'
 require 'opentelemetry/sdk/trace/export/console_span_exporter'
 require 'opentelemetry/sdk/trace/export/in_memory_span_exporter'

--- a/sdk/lib/opentelemetry/sdk/trace/export/dispatcher_detector.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/dispatcher_detector.rb
@@ -66,7 +66,7 @@ module OpenTelemetry
           end
 
           def detect_glassfish
-            defined?(::JRuby) && defined?(::JRuby::Rack::VERSION) && defined?(::GlassFish::Server)
+            defined?(::JRuby::Rack::VERSION) && defined?(::GlassFish::Server)
           end
 
           def detect_litespeed
@@ -74,7 +74,7 @@ module OpenTelemetry
           end
 
           def detect_mongrel
-            defined?(::Mongrel) && defined?(::Mongrel::HttpServer)
+            defined?(::Mongrel::HttpServer)
           end
 
           def detect_passenger
@@ -86,7 +86,7 @@ module OpenTelemetry
           end
 
           def detect_rainbows
-            defined?(::Rainbows) && defined?(::Rainbows::HttpServer) && object_loaded?(::Rainbows::HttpServer)
+            defined?(::Rainbows::HttpServer) && object_loaded?(::Rainbows::HttpServer)
           end
 
           def detect_resque
@@ -110,7 +110,7 @@ module OpenTelemetry
           end
 
           def detect_thin
-            defined?(::Thin) && defined?(::Thin::Server) && object_loaded?(::Thin::Server)
+            defined?(::Thin::Server) && object_loaded?(::Thin::Server)
           end
 
           def detect_torquebox
@@ -118,15 +118,15 @@ module OpenTelemetry
           end
 
           def detect_trinidad
-            defined?(::JRuby) && defined?(::JRuby::Rack::VERSION) && defined?(::Trinidad::Server)
+            defined?(::JRuby::Rack::VERSION) && defined?(::Trinidad::Server)
           end
 
           def detect_unicorn
-            defined?(::Unicorn) && defined?(::Unicorn::HttpServer) && object_loaded?(::Unicorn::HttpServer)
+            defined?(::Unicorn::HttpServer) && object_loaded?(::Unicorn::HttpServer)
           end
 
           def detect_webrick
-            defined?(::WEBrick) && defined?(::WEBrick::VERSION)
+            defined?(::WEBrick::VERSION)
           end
 
           def object_loaded?(klass)

--- a/sdk/lib/opentelemetry/sdk/trace/export/dispatcher_detector.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/dispatcher_detector.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Trace
+      module Export
+        # Singleton used to find the "dispatcher" of the current process,
+        # i.e. the web server (Puma, Unicorn) or job processor (Sidekiq, Resque)
+        # used to execute code. Detection is done on a best-effort basis.
+        # To avoid ambiguity, is recommended to explicitly set the
+        # OTEL_DISPATCHER environment variable.
+        module DispatcherDetector # rubocop:disable Metrics/ModuleLength
+          extend self
+
+          DISPATCHERS = %i[ delayed_job
+                            resque
+                            sidekiq
+                            puma
+                            passenger
+                            rainbows
+                            unicorn
+                            torquebox
+                            trinidad
+                            glassfish
+                            thin
+                            mongrel
+                            litespeed
+                            webrick
+                            fastcgi ].freeze
+
+          def dispatcher
+            @dispatcher ||= env_dispatcher || detect_dispatcher
+          end
+
+          private
+
+          def env_dispatcher
+            env = ENV['OTEL_DISPATCHER']&.strip&.to_sym
+            return unless env
+
+            dispatcher = DISPATCHERS.detect { |d| d == env }
+            if dispatcher
+              OpenTelemetry.logger.info("Dispatcher :#{dispatcher} set by OTEL_DISPATCHER environment variable")
+            else
+              OpenTelemetry.logger.warn("OTEL_DISPATCHER \"#{dispatcher}\" not valid")
+            end
+            dispatcher
+          end
+
+          def detect_dispatcher
+            dispatcher = DISPATCHERS.detect { |d| send :"detect_#{d}" }
+            OpenTelemetry.logger.info("Dispatcher :#{dispatcher} auto-detected") if dispatcher
+            dispatcher
+          end
+
+          def detect_delayed_job
+            executable =~ /delayed_job$/ || (executable == 'rake' && ARGV.include?('jobs:work'))
+          end
+
+          def detect_fastcgi
+            defined?(::FCGI)
+          end
+
+          def detect_glassfish
+            defined?(::JRuby) && defined?(::JRuby::Rack::VERSION) && defined?(::GlassFish::Server)
+          end
+
+          def detect_litespeed
+            caller.pop =~ %r{fcgi-bin/RailsRunner\.rb}
+          end
+
+          def detect_mongrel
+            defined?(::Mongrel) && defined?(::Mongrel::HttpServer)
+          end
+
+          def detect_passenger
+            defined?(::PhusionPassenger)
+          end
+
+          def detect_puma
+            defined?(::Puma) && executable == 'puma'
+          end
+
+          def detect_rainbows
+            defined?(::Rainbows) && defined?(::Rainbows::HttpServer) && object_loaded?(::Rainbows::HttpServer)
+          end
+
+          def detect_resque
+            defined?(::Resque) && (resque_rake? || resque_pool_rake? || resque_pool_exec?)
+          end
+
+          def resque_rake?
+            executable == 'rake' && ARGV.include?('resque:work') && (ENV['QUEUE'] || ENV['QUEUES'])
+          end
+
+          def resque_pool_rake?
+            executable == 'rake' && ARGV.include?('resque:pool')
+          end
+
+          def resque_pool_exec?
+            executable == 'resque-pool' && defined?(::Resque::Pool)
+          end
+
+          def detect_sidekiq
+            defined?(::Sidekiq) && executable == 'sidekiq'
+          end
+
+          def detect_thin
+            defined?(::Thin) && defined?(::Thin::Server) && object_loaded?(::Thin::Server)
+          end
+
+          def detect_torquebox
+            defined?(::JRuby) && defined?(::TorqueBox)
+          end
+
+          def detect_trinidad
+            defined?(::JRuby) && defined?(::JRuby::Rack::VERSION) && defined?(::Trinidad::Server)
+          end
+
+          def detect_unicorn
+            defined?(::Unicorn) && defined?(::Unicorn::HttpServer) && object_loaded?(::Unicorn::HttpServer)
+          end
+
+          def detect_webrick
+            defined?(::WEBrick) && defined?(::WEBrick::VERSION)
+          end
+
+          def object_loaded?(klass)
+            return true unless object_space_supported?
+
+            ObjectSpace.each_object(klass) { |_| return true }
+            false
+          end
+
+          def object_space_supported?
+            if defined?(::JRuby) && JRuby.respond_to?(:runtime)
+              JRuby.runtime.is_object_space_enabled
+            else
+              defined?(::ObjectSpace)
+            end
+          end
+
+          def executable
+            File.basename($PROGRAM_NAME)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
BatchSpanProcessor should not spawn a thread during app boot for forking webservers (passenger puma rainbows unicorn)

I have added code which detects the webserver. You can also set it explicity with OTEL_DISPATCHER env var.

Fixes #462

TODO:
* [ ] determine where to put DispatcherDetector (i.e. which namespace)
* [ ] add tests to DispatcherDetector after approach is confirmed by code reviewer