### PR TITLE
fix: add error_handler to configurator

### DIFF
--- a/sdk/lib/opentelemetry/sdk.rb
+++ b/sdk/lib/opentelemetry/sdk.rb
@@ -56,6 +56,13 @@ module OpenTelemetry
       configurator = Configurator.new
       yield configurator if block_given?
       configurator.configure
+    rescue StandardError => e
+      if configurator.error_handler
+        configurator.error_handler.call(e)
+      else
+        OpenTelemetry.logger.error("unexpected error in span.on_finish - #{e}")
+        raise
+      end
     end
   end
 end

--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -15,10 +15,18 @@ module OpenTelemetry
 
       private_constant :USE_MODE_UNSPECIFIED, :USE_MODE_ONE, :USE_MODE_ALL
 
+      # An optional handler for configuration errors. If no error_handler is
+      # configured, configuration errors will escape the OpenTelemetry.sdk.configure
+      # method.
+      #
+      # Error handlers are callable and accept a single (exception object) argument.
+      attr_accessor :error_handler
+
       attr_writer :logger, :http_extractors, :http_injectors, :text_map_extractors,
                   :text_map_injectors
 
       def initialize
+        @error_handler = nil
         @instrumentation_names = []
         @instrumentation_config_map = {}
         @http_extractors = nil

--- a/sdk/test/opentelemetry/sdk/configurator_test.rb
+++ b/sdk/test/opentelemetry/sdk/configurator_test.rb
@@ -23,7 +23,7 @@ describe OpenTelemetry::SDK::Configurator do
 
   describe '#error_handler' do
     it 'raises configuration errors by default' do
-      _ { OpenTelemetry::SDK.configure { |c| raise 'hell' } }.must_raise(StandardError)
+      _ { OpenTelemetry::SDK.configure { |_| raise 'hell' } }.must_raise(StandardError)
     end
 
     it 'receives configuration errors if overridden' do

--- a/sdk/test/opentelemetry/sdk/configurator_test.rb
+++ b/sdk/test/opentelemetry/sdk/configurator_test.rb
@@ -21,6 +21,22 @@ describe OpenTelemetry::SDK::Configurator do
     end
   end
 
+  describe '#error_handler' do
+    it 'raises configuration errors by default' do
+      _ { OpenTelemetry::SDK.configure { |c| raise 'hell' } }.must_raise(StandardError)
+    end
+
+    it 'receives configuration errors if overridden' do
+      raised_error = nil
+      custom_handler = ->(e) { raised_error = e }
+      OpenTelemetry::SDK.configure do |c|
+        c.error_handler = custom_handler
+        raise 'hell'
+      end
+      _(raised_error).must_be_kind_of(StandardError)
+    end
+  end
+
   describe '#resource=' do
     let(:configurator_resource) { configurator.instance_variable_get(:@resource) }
     let(:configurator_resource_attributes) { configurator_resource.attribute_enumerator.to_h }


### PR DESCRIPTION
fixes #464 

This is a localized fix. I'd like to discuss whether we should have an `error_handler` just for `OpenTelemetry::SDK.configure` or whether we should try to address the "strict mode" thing again.

The spec [states](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/error-handling.md#configuring-error-handlers):
> SDK implementations MUST allow end users to change the library's default error handling behavior for relevant errors. Application developers may want to run with strict error handling in a staging environment to catch invalid uses of the API, or malformed config. Note that configuring a custom error handler in this way is the only exception to the basic error handling principles outlined above. The mechanism by which end users set or register a custom error handler should follow language-specific conventions.

It provides examples for Go and for Java. Both are global error handlers rather than purely config-related. Java uses the logger mechanism. I do not know how to make that work in Ruby, or what an idiomatic approach to this in Ruby might look like.