### PR TITLE
fix: SDK Span.recording? after finish

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/span.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span.rb
@@ -52,7 +52,7 @@ module OpenTelemetry
         #   like events with the #add_event operation and attributes using
         #   #set_attribute.
         def recording?
-          true
+          !@ended
         end
 
         # Set attribute

--- a/sdk/test/opentelemetry/sdk/trace/span_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/span_test.rb
@@ -47,6 +47,11 @@ describe OpenTelemetry::SDK::Trace::Span do
     it 'returns true' do
       _(span).must_be :recording?
     end
+
+    it 'returns false when span is finished' do
+      span.finish
+      _(span).wont_be :recording?
+    end
   end
 
   describe '#set_attribute' do


### PR DESCRIPTION
[The spec states](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#isrecording)
> After a `Span` is ended, it usually becomes non-recording and thus `IsRecording` SHOULD consequently return false for ended Spans.
