### PR TITLE
fix!: pass full Context to samplers

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/samplers.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/samplers.rb
@@ -25,9 +25,10 @@ module OpenTelemetry
       # Where:
       #
       # @param [String] trace_id The trace_id of the {Span} to be created.
-      # @param [OpenTelemetry::Trace::SpanContext] parent_context The
-      #   {OpenTelemetry::Trace::SpanContext} of a parent span, typically
-      #   extracted from the wire. Can be nil for a root span.
+      # @param [OpenTelemetry::Context] parent_context The
+      #   {OpenTelemetry::Context} with a parent {Span}. The {Span}'s
+      #   {OpenTelemetry::Trace::SpanContext} may be invalid to indicate a
+      #   root span.
       # @param [Enumerable<Link>] links A collection of links to be associated
       #   with the {Span} to be created. Can be nil.
       # @param [String] name Name of the {Span} to be created.

--- a/sdk/lib/opentelemetry/sdk/trace/samplers/parent_based.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/samplers/parent_based.rb
@@ -37,12 +37,13 @@ module OpenTelemetry
           #
           # See {Samplers}.
           def should_sample?(trace_id:, parent_context:, links:, name:, kind:, attributes:)
-            delegate = if parent_context.nil?
+            parent_span_context = OpenTelemetry::Trace.current_span(parent_context).context
+            delegate = if !parent_span_context.valid?
                          @root
-                       elsif parent_context.remote?
-                         parent_context.trace_flags.sampled? ? @remote_parent_sampled : @remote_parent_not_sampled
+                       elsif parent_span_context.remote?
+                         parent_span_context.trace_flags.sampled? ? @remote_parent_sampled : @remote_parent_not_sampled
                        else
-                         parent_context.trace_flags.sampled? ? @local_parent_sampled : @local_parent_not_sampled
+                         parent_span_context.trace_flags.sampled? ? @local_parent_sampled : @local_parent_not_sampled
                        end
             delegate.should_sample?(trace_id: trace_id, parent_context: parent_context, links: links, name: name, kind: kind, attributes: attributes)
           end

--- a/sdk/lib/opentelemetry/sdk/trace/tracer.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/tracer.rb
@@ -33,7 +33,7 @@ module OpenTelemetry
           start_span(name, with_parent: Context.empty, attributes: attributes, links: links, start_timestamp: start_timestamp, kind: kind)
         end
 
-        def start_span(name, with_parent: nil, attributes: nil, links: nil, start_timestamp: nil, kind: nil) # rubocop:disable Metrics/AbcSize
+        def start_span(name, with_parent: nil, attributes: nil, links: nil, start_timestamp: nil, kind: nil)
           name ||= 'empty'
 
           with_parent ||= Context.current
@@ -42,12 +42,10 @@ module OpenTelemetry
             parent_span_id = parent_span_context.span_id
             tracestate = parent_span_context.tracestate
             trace_id = parent_span_context.trace_id
-          else
-            parent_span_context = nil
           end
           trace_id ||= OpenTelemetry::Trace.generate_trace_id
           sampler = tracer_provider.active_trace_config.sampler
-          result = sampler.should_sample?(trace_id: trace_id, parent_context: parent_span_context, links: links, name: name, kind: kind, attributes: attributes)
+          result = sampler.should_sample?(trace_id: trace_id, parent_context: with_parent, links: links, name: name, kind: kind, attributes: attributes)
           internal_create_span(result, name, kind, trace_id, parent_span_id, attributes, links, start_timestamp, tracestate, with_parent)
         end
 

--- a/sdk/test/opentelemetry/sdk/trace/samplers_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/samplers_test.rb
@@ -27,10 +27,14 @@ describe OpenTelemetry::SDK::Trace::Samplers do
     let(:result) { Result.new(decision: Decision::RECORD_AND_SAMPLE) }
     let(:sampled) { OpenTelemetry::Trace::TraceFlags.from_byte(1) }
     let(:not_sampled) { OpenTelemetry::Trace::TraceFlags.from_byte(0) }
-    let(:remote_sampled_parent_context) { OpenTelemetry::Trace::SpanContext.new(trace_id: trace_id, remote: true, trace_flags: sampled) }
-    let(:remote_not_sampled_parent_context) { OpenTelemetry::Trace::SpanContext.new(trace_id: trace_id, remote: true, trace_flags: not_sampled) }
-    let(:local_sampled_parent_context) { OpenTelemetry::Trace::SpanContext.new(trace_id: trace_id, remote: false, trace_flags: sampled) }
-    let(:local_not_sampled_parent_context) { OpenTelemetry::Trace::SpanContext.new(trace_id: trace_id, remote: false, trace_flags: not_sampled) }
+    let(:remote_sampled_parent_span_context) { OpenTelemetry::Trace::SpanContext.new(trace_id: trace_id, remote: true, trace_flags: sampled) }
+    let(:remote_not_sampled_parent_span_context) { OpenTelemetry::Trace::SpanContext.new(trace_id: trace_id, remote: true, trace_flags: not_sampled) }
+    let(:local_sampled_parent_span_context) { OpenTelemetry::Trace::SpanContext.new(trace_id: trace_id, remote: false, trace_flags: sampled) }
+    let(:local_not_sampled_parent_span_context) { OpenTelemetry::Trace::SpanContext.new(trace_id: trace_id, remote: false, trace_flags: not_sampled) }
+    let(:remote_sampled_parent_context) { OpenTelemetry::Trace.context_with_span(OpenTelemetry::Trace::Span.new(span_context: remote_sampled_parent_span_context)) }
+    let(:remote_not_sampled_parent_context) { OpenTelemetry::Trace.context_with_span(OpenTelemetry::Trace::Span.new(span_context: remote_not_sampled_parent_span_context)) }
+    let(:local_sampled_parent_context) { OpenTelemetry::Trace.context_with_span(OpenTelemetry::Trace::Span.new(span_context: local_sampled_parent_span_context)) }
+    let(:local_not_sampled_parent_context) { OpenTelemetry::Trace.context_with_span(OpenTelemetry::Trace::Span.new(span_context: local_not_sampled_parent_span_context)) }
 
     it 'provides defaults for parent samplers' do
       sampler = Samplers.parent_based(root: not_a_sampler)
@@ -187,7 +191,7 @@ describe OpenTelemetry::SDK::Trace::Samplers do
     [first, second].pack('Q>Q>')
   end
 
-  def call_sampler(sampler, trace_id: nil, parent_context: nil, links: nil, name: nil, kind: nil, attributes: nil)
+  def call_sampler(sampler, trace_id: nil, parent_context: OpenTelemetry::Context.current, links: nil, name: nil, kind: nil, attributes: nil)
     sampler.should_sample?(
       trace_id: trace_id || OpenTelemetry::Trace.generate_trace_id,
       parent_context: parent_context,


### PR DESCRIPTION
Fixes #468 

I marked this as a breaking change for the SDK because we're changing the type expected by the samplers.