### PR TITLE
feat: add common helpers

### DIFF
--- a/.toys/.data/releases.yml
+++ b/.toys/.data/releases.yml
@@ -40,6 +40,11 @@ gems:
     directory: sdk
     version_constant: [OpenTelemetry, SDK, VERSION]
 
+  - name: opentelemetry-common
+    directory: common
+    version_rb_path: lib/opentelemetry/common/version.rb
+    version_constant: [OpenTelemetry, Common, VERSION]
+
   - name: opentelemetry-exporter-jaeger
     directory: exporter/jaeger
     version_constant: [OpenTelemetry, Exporter, Jaeger, VERSION]

--- a/common/.rubocop.yml
+++ b/common/.rubocop.yml
@@ -1,0 +1,29 @@
+AllCops:
+  TargetRubyVersion: '2.5.0'
+
+Bundler/OrderedGems:
+  Exclude:
+    - gemfiles/**/*
+Lint/UnusedMethodArgument:
+  Enabled: false
+Metrics/AbcSize:
+  Max: 18
+Metrics/LineLength:
+  Enabled: false
+Metrics/MethodLength:
+  Max: 20
+Metrics/ParameterLists:
+  Enabled: false
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - gemfiles/**/*
+Style/ModuleFunction:
+  Enabled: false
+Style/StringLiterals:
+  Exclude:
+    - gemfiles/**/*
+Metrics/BlockLength:
+  Enabled: false
+Naming/FileName:
+  Exclude:
+    - "lib/opentelemetry-common.rb"

--- a/common/.yardopts
+++ b/common/.yardopts
@@ -1,0 +1,9 @@
+--no-private
+--title=OpenTelemetry Common
+--markup=markdown
+--main=README.md
+./lib/opentelemetry/common/**/*.rb
+./lib/opentelemetry/common.rb
+-
+README.md
+CHANGELOG.md

--- a/common/Gemfile
+++ b/common/Gemfile
@@ -8,9 +8,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'opentelemetry-api', path: '../../api'
-gem 'opentelemetry-common', path: '../../common'
-
-group :test do
-  gem 'opentelemetry-sdk', path: '../../sdk'
+group :development, :test do
+  gem 'byebug'
+  gem 'pry'
 end

--- a/common/Gemfile
+++ b/common/Gemfile
@@ -9,6 +9,5 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
-  gem 'byebug'
   gem 'pry'
 end

--- a/common/LICENSE
+++ b/common/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2020 OpenTelemetry Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/common/README.md
+++ b/common/README.md
@@ -27,9 +27,9 @@ require 'opentelemetry/common'
 
 # TODO: example of semantic convention helpers
 
-# Context propagation in Koala instrumentation
-OpenTelemetry::Common::HTTP::ClientContext.with_attributes('peer.service' => 'facebook') do
-  ...
+# Context propagation in Net::HTTP client
+OpenTelemetry::Common::HTTP::ClientContext.with_attributes('peer.service' => 'example') do
+  Net::HTTP.get('example.com', '/index.html')
 end
 
 # Context propagation in Net::HTTP instrumentation

--- a/common/README.md
+++ b/common/README.md
@@ -1,0 +1,60 @@
+# Opentelemetry::Common
+
+The `opentelemetry-common` gem provides common helpers for OpenTelemetry.
+
+## What is OpenTelemetry?
+
+OpenTelemetry is an open source observability framework, providing a general-purpose API, SDK, and related tools required for the instrumentation of cloud-native software, frameworks, and libraries.
+
+OpenTelemetry provides a single set of APIs, libraries, agents, and collector services to capture distributed traces and metrics from your application. You can analyze them using Prometheus, Jaeger, and other observability tools.
+
+## How does this gem fit in?
+
+The `opentelemetry-common` gem provides common helpers for semantic conventions, context propagation patterns, etc. It depends only on the OpenTelemetry Ruby API, not the SDK.
+
+## How do I get started?
+
+Install the gem using:
+
+```
+gem install opentelemetry-common
+```
+
+Or, if you use Bundler, include `opentelemetry-common` in your `Gemfile`.
+
+```rb
+require 'opentelemetry/common'
+
+# TODO: example of semantic convention helpers
+
+# Context propagation in Koala instrumentation
+OpenTelemetry::Common::HTTP::ClientContext.with_attributes('peer.service' => 'facebook') do
+  ...
+end
+
+# Context propagation in Net::HTTP instrumentation
+attributes = OpenTelemetry::Common::HTTP::ClientContext.attributes
+tracer.in_span(
+  HTTP_METHODS_TO_SPAN_NAMES[req.method],
+  attributes: attributes.merge(
+    'http.method' => req.method,
+    'http.scheme' => USE_SSL_TO_SCHEME[use_ssl?],
+    'http.target' => req.path,
+    'peer.hostname' => @address,
+    'peer.port' => @port
+  ),
+  kind: :client
+) do |span|
+  ...
+end
+```
+
+## How can I get involved?
+
+The `opentelemetry-common` gem source is on github, along with related gems.
+
+The OpenTelemetry Ruby gems are maintained by the OpenTelemetry-Ruby special interest group (SIG). You can get involved by joining us on our gitter channel or attending our weekly meeting. See the meeting calendar for dates and times. For more information on this and other language SIGs, see the OpenTelemetry community page.
+
+## License
+
+The `opentelemetry-common` gem is distributed under the Apache 2.0 license. See LICENSE for more information.

--- a/common/Rakefile
+++ b/common/Rakefile
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+require 'yard'
+require 'rubocop/rake_task'
+
+RuboCop::RakeTask.new
+
+Rake::TestTask.new :test do |t|
+  # t.libs << '../sdk/lib'
+  t.libs << '../api/lib'
+  t.libs << 'test'
+  t.libs << 'lib'
+  t.test_files = FileList['test/**/*_test.rb']
+end
+
+YARD::Rake::YardocTask.new do |t|
+  t.stats_options = ['--list-undoc']
+end
+
+if RUBY_ENGINE == 'truffleruby'
+  task default: %i[test]
+else
+  task default: %i[test rubocop yard]
+end

--- a/common/lib/opentelemetry-common.rb
+++ b/common/lib/opentelemetry-common.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require_relative './opentelemetry/common'

--- a/common/lib/opentelemetry/common.rb
+++ b/common/lib/opentelemetry/common.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry'
+require 'opentelemetry/common/http'
+require 'opentelemetry/common/version'
+
+# OpenTelemetry is an open source observability framework, providing a
+# general-purpose API, SDK, and related tools required for the instrumentation
+# of cloud-native software, frameworks, and libraries.
+#
+# The OpenTelemetry module provides global accessors for telemetry objects.
+# See the documentation for the `opentelemetry-api` gem for details.
+module OpenTelemetry
+  # Common contains common helpers for semantic conventions, context propagation, etc.
+  module Common
+  end
+end

--- a/common/lib/opentelemetry/common/http.rb
+++ b/common/lib/opentelemetry/common/http.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Common
+    # HTTP contains common helpers for context propagation and semantic conventions.
+    module HTTP
+    end
+  end
+end
+
+require_relative './http/client_context'

--- a/common/lib/opentelemetry/common/http/client_context.rb
+++ b/common/lib/opentelemetry/common/http/client_context.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Common
+    module HTTP
+      # ClientContext contains common helpers for context propagation
+      module ClientContext
+        extend self
+
+        CURRENT_ATTRIBUTES_HASH = Context.create_key('current-attributes-hash')
+
+        private_constant :CURRENT_ATTRIBUTES_HASH
+
+        # Returns the attributes hash representing the HTTP client context found
+        # in the optional context or the current context if none is provided.
+        #
+        # @param [optional Context] context The context to lookup the current
+        #   attributes hash. Defaults to Context.current
+        def attributes(context = nil)
+          context ||= Context.current
+          context.value(CURRENT_ATTRIBUTES_HASH) || {}
+        end
+
+        # Returns a context containing the merged attributes hash, derived from the
+        # optional parent context, or the current context if one was not provided.
+        #
+        # @param [optional Context] context The context to use as the parent for
+        #   the returned context
+        def context_with_attributes(attributes_hash, parent_context: Context.current)
+          attributes_hash = attributes(parent_context).merge(attributes_hash)
+          parent_context.set_value(CURRENT_ATTRIBUTES_HASH, attributes_hash)
+        end
+
+        # Activates/deactivates the merged attributes hash within the current Context,
+        # which makes the "current attributes hash" available implicitly.
+        #
+        # On exit, the attributes hash that was active before calling this method
+        # will be reactivated.
+        #
+        # @param [Span] span the span to activate
+        # @yield [Hash, Context] yields attributes hash and a context containing the
+        #   attributes hash to the block.
+        def with_attributes(attributes_hash)
+          attributes_hash = attributes.merge(attributes_hash)
+          Context.with_value(CURRENT_ATTRIBUTES_HASH, attributes_hash) { |c, h| yield h, c }
+        end
+      end
+    end
+  end
+end

--- a/common/lib/opentelemetry/common/version.rb
+++ b/common/lib/opentelemetry/common/version.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Common
+    VERSION = '0.8.0'
+  end
+end

--- a/common/opentelemetry-common.gemspec
+++ b/common/opentelemetry-common.gemspec
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'opentelemetry/common/version'
+
+Gem::Specification.new do |spec|
+  spec.name        = 'opentelemetry-common'
+  spec.version     = OpenTelemetry::Common::VERSION
+  spec.authors     = ['OpenTelemetry Authors']
+  spec.email       = ['cncf-opentelemetry-contributors@lists.cncf.io']
+
+  spec.summary     = 'Common helpers for OpenTelemetry'
+  spec.description = 'Common helpers for OpenTelemetry'
+  spec.homepage    = 'https://github.com/open-telemetry/opentelemetry-ruby'
+  spec.license     = 'Apache-2.0'
+
+  spec.files = ::Dir.glob('lib/**/*.rb') +
+               ::Dir.glob('*.md') +
+               ['LICENSE', '.yardopts']
+  spec.require_paths = ['lib']
+  spec.required_ruby_version = '>= 2.5.0'
+
+  spec.add_development_dependency 'bundler', '>= 1.17'
+  spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'rake', '~> 12.0'
+  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'simplecov', '~> 0.17'
+  spec.add_development_dependency 'yard', '~> 0.9'
+  spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-common/v#{OpenTelemetry::Common::VERSION}/file.CHANGELOG.html"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/master/common'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/issues'
+    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-common/v#{OpenTelemetry::Common::VERSION}"
+  end
+end

--- a/common/test/opentelemetry/common/http_client_context_test.rb
+++ b/common/test/opentelemetry/common/http_client_context_test.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+describe OpenTelemetry::Common::HTTP::ClientContext do
+  let(:client_context) { OpenTelemetry::Common::HTTP::ClientContext }
+
+  describe '#attributes' do
+    let(:attributes) { { 'foo' => 'bar' } }
+
+    it 'returns an empty hash by default' do
+      _(client_context.attributes).must_equal({})
+    end
+
+    it 'returns the current attributes hash' do
+      client_context.with_attributes(attributes) do
+        _(client_context.attributes).must_equal(attributes)
+      end
+    end
+
+    it 'returns the current attributes hash from the provided context' do
+      context = client_context.context_with_attributes(attributes, parent_context: OpenTelemetry::Context.empty)
+      _(client_context.attributes).wont_equal(attributes)
+      _(client_context.attributes(context)).must_equal(attributes)
+    end
+  end
+
+  describe '#with_attributes' do
+    it 'yields the passed in attributes' do
+      client_context.with_attributes('foo' => 'bar') do |attributes|
+        _(attributes).must_equal('foo' => 'bar')
+      end
+    end
+
+    it 'yields context containing attributes' do
+      client_context.with_attributes('foo' => 'bar') do |attributes, context|
+        _(context).must_equal(OpenTelemetry::Context.current)
+        _(client_context.attributes).must_equal(attributes)
+      end
+    end
+
+    it 'should reactivate the attributes after the block' do
+      client_context.with_attributes('foo' => 'bar') do
+        _(client_context.attributes).must_equal('foo' => 'bar')
+
+        client_context.with_attributes('foo' => 'baz') do
+          _(client_context.attributes).must_equal('foo' => 'baz')
+        end
+
+        _(client_context.attributes).must_equal('foo' => 'bar')
+      end
+    end
+
+    it 'should merge attributes' do
+      client_context.with_attributes(
+        'a' => '1',
+        'c' => '2'
+      ) do
+        _(client_context.attributes).must_equal(
+          'a' => '1',
+          'c' => '2'
+        )
+
+        client_context.with_attributes(
+          'a' => '0',
+          'b' => '1'
+        ) do
+          _(client_context.attributes).must_equal(
+            'a' => '0',
+            'b' => '1',
+            'c' => '2'
+          )
+        end
+
+        _(client_context.attributes).must_equal(
+          'a' => '1',
+          'c' => '2'
+        )
+      end
+    end
+  end
+
+  describe '#context_with_attributes' do
+    it 'returns a context containing attributes' do
+      ctx = client_context.context_with_attributes('foo' => 'bar')
+      _(client_context.attributes(ctx)).must_equal('foo' => 'bar')
+    end
+
+    it 'returns a context containing attributes' do
+      parent_ctx = OpenTelemetry::Context.empty.set_value('foo', 'bar')
+      ctx = client_context.context_with_attributes({ 'bar' => 'baz' }, parent_context: parent_ctx)
+      _(client_context.attributes(ctx)).must_equal('bar' => 'baz')
+      _(ctx.value('foo')).must_equal('bar')
+    end
+  end
+end

--- a/common/test/test_helper.rb
+++ b/common/test/test_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'simplecov'
+SimpleCov.start
+
+require 'opentelemetry/common'
+require 'minitest/autorun'
+require 'pry'

--- a/instrumentation/all/Gemfile
+++ b/instrumentation/all/Gemfile
@@ -9,6 +9,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'opentelemetry-api', path: '../../api'
+gem 'opentelemetry-common', path: '../../common'
 gem 'opentelemetry-instrumentation-concurrent_ruby', path: '../concurrent_ruby'
 gem 'opentelemetry-instrumentation-dalli', path: '../dalli'
 gem 'opentelemetry-instrumentation-ethon', path: '../ethon'

--- a/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http.rb
+++ b/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http.rb
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require 'opentelemetry'
+require 'opentelemetry/common'
 
 module OpenTelemetry
   module Instrumentation

--- a/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/patches/instrumentation.rb
+++ b/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/patches/instrumentation.rb
@@ -18,15 +18,16 @@ module OpenTelemetry
               # Do not trace recursive call for starting the connection
               return super(req, body, &block) unless started?
 
+              attributes = OpenTelemetry::Common::HTTP::ClientContext.attributes
               tracer.in_span(
                 HTTP_METHODS_TO_SPAN_NAMES[req.method],
-                attributes: {
+                attributes: attributes.merge(
                   'http.method' => req.method,
                   'http.scheme' => USE_SSL_TO_SCHEME[use_ssl?],
                   'http.target' => req.path,
                   'peer.hostname' => @address,
                   'peer.port' => @port
-                },
+                ),
                 kind: :client
               ) do |span|
                 OpenTelemetry.propagation.http.inject(req)

--- a/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
+++ b/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 0.8.0'
+  spec.add_dependency 'opentelemetry-common', '~> 0.8.0'
 
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'minitest', '~> 5.0'


### PR DESCRIPTION
Partly addresses #443 and #284.

This adds an `opentelemetry-common` gem intended as a collection of helpers for common context propagation scenarios and for semantic conventions. To start, it includes HTTP client context helpers modelled on the Trace context helpers. It also uses these helpers in the Net::HTTP instrumentation.

I have not yet used the helpers in the Ethon, Excon, Faraday or RestClient instrumentation. I lack context (ha ha) for those gems.