### PR TITLE
feat: Redis attribute propagation

### DIFF
--- a/instrumentation/redis/README.md
+++ b/instrumentation/redis/README.md
@@ -30,6 +30,17 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
+The Redis instrumentation allows the user to supply additional attributes via context propagation. This may be used to propagate attributes from instrumentation for things like Resque and Sidekiq, for example, to attach to the Redis client spans.
+
+```ruby
+require 'opentelemetry/instrumentation/redis'
+
+redis = ::Redis.new
+OpenTelemetry::Instrumentation::Redis.with_attributes('peer.service' => 'cache') do
+  redis.set('K', 'x')
+end
+```
+
 ## Example
 
 An example of usage can be seen in [`example/redis.rb`](https://github.com/open-telemetry/opentelemetry-ruby/blob/master/instrumentation/redis/example/redis.rb).

--- a/instrumentation/redis/lib/opentelemetry/instrumentation/redis.rb
+++ b/instrumentation/redis/lib/opentelemetry/instrumentation/redis.rb
@@ -10,6 +10,45 @@ module OpenTelemetry
   module Instrumentation
     # Contains the OpenTelemetry instrumentation for the Redis gem
     module Redis
+      extend self
+
+      CURRENT_ATTRIBUTES_HASH = Context.create_key('current-attributes-hash')
+
+      private_constant :CURRENT_ATTRIBUTES_HASH
+
+      # Returns the attributes hash representing the Redis client context found
+      # in the optional context or the current context if none is provided.
+      #
+      # @param [optional Context] context The context to lookup the current
+      #   attributes hash. Defaults to Context.current
+      def attributes(context = nil)
+        context ||= Context.current
+        context.value(CURRENT_ATTRIBUTES_HASH) || {}
+      end
+
+      # Returns a context containing the merged attributes hash, derived from the
+      # optional parent context, or the current context if one was not provided.
+      #
+      # @param [optional Context] context The context to use as the parent for
+      #   the returned context
+      def context_with_attributes(attributes_hash, parent_context: Context.current)
+        attributes_hash = attributes(parent_context).merge(attributes_hash)
+        parent_context.set_value(CURRENT_ATTRIBUTES_HASH, attributes_hash)
+      end
+
+      # Activates/deactivates the merged attributes hash within the current Context,
+      # which makes the "current attributes hash" available implicitly.
+      #
+      # On exit, the attributes hash that was active before calling this method
+      # will be reactivated.
+      #
+      # @param [Span] span the span to activate
+      # @yield [Hash, Context] yields attributes hash and a context containing the
+      #   attributes hash to the block.
+      def with_attributes(attributes_hash)
+        attributes_hash = attributes.merge(attributes_hash)
+        Context.with_value(CURRENT_ATTRIBUTES_HASH, attributes_hash) { |c, h| yield h, c }
+      end
     end
   end
 end

--- a/instrumentation/redis/lib/opentelemetry/instrumentation/redis/patches/client.rb
+++ b/instrumentation/redis/lib/opentelemetry/instrumentation/redis/patches/client.rb
@@ -13,11 +13,11 @@ module OpenTelemetry
           def call(*args, &block)
             response = nil
 
+            attributes = client_attributes
+            attributes['db.statement'] = Utils.format_statement(args)
             tracer.in_span(
               Utils.format_command(args),
-              attributes: client_attributes.merge(
-                'db.statement' => Utils.format_statement(args)
-              ),
+              attributes: attributes,
               kind: :client
             ) do
               response = super(*args, &block)
@@ -29,11 +29,11 @@ module OpenTelemetry
           def call_pipeline(*args, &block)
             response = nil
 
+            attributes = client_attributes
+            attributes['db.statement'] = Utils.format_pipeline_statement(args)
             tracer.in_span(
               'pipeline',
-              attributes: client_attributes.merge(
-                'db.statement' => Utils.format_pipeline_statement(args)
-              ),
+              attributes: attributes,
               kind: :client
             ) do
               response = super(*args, &block)
@@ -48,13 +48,13 @@ module OpenTelemetry
             host = options[:host]
             port = options[:port]
 
-            {
+            OpenTelemetry::Instrumentation::Redis.attributes.merge(
               'db.type' => 'redis',
               'db.instance' => options[:db].to_s,
               'db.url' => "redis://#{host}:#{port}",
               'net.peer.name' => host,
               'net.peer.port' => port
-            }
+            )
           end
 
           def tracer

--- a/instrumentation/redis/test/opentelemetry/instrumentation/redis_test.rb
+++ b/instrumentation/redis/test/opentelemetry/instrumentation/redis_test.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+describe OpenTelemetry::Instrumentation::Redis do
+  let(:redis) { OpenTelemetry::Instrumentation::Redis }
+
+  describe '#attributes' do
+    let(:attributes) { { 'foo' => 'bar' } }
+
+    it 'returns an empty hash by default' do
+      _(redis.attributes).must_equal({})
+    end
+
+    it 'returns the current attributes hash' do
+      redis.with_attributes(attributes) do
+        _(redis.attributes).must_equal(attributes)
+      end
+    end
+
+    it 'returns the current attributes hash from the provided context' do
+      context = redis.context_with_attributes(attributes, parent_context: OpenTelemetry::Context.empty)
+      _(redis.attributes).wont_equal(attributes)
+      _(redis.attributes(context)).must_equal(attributes)
+    end
+  end
+
+  describe '#with_attributes' do
+    it 'yields the passed in attributes' do
+      redis.with_attributes('foo' => 'bar') do |attributes|
+        _(attributes).must_equal('foo' => 'bar')
+      end
+    end
+
+    it 'yields context containing attributes' do
+      redis.with_attributes('foo' => 'bar') do |attributes, context|
+        _(context).must_equal(OpenTelemetry::Context.current)
+        _(redis.attributes).must_equal(attributes)
+      end
+    end
+
+    it 'should reactivate the attributes after the block' do
+      redis.with_attributes('foo' => 'bar') do
+        _(redis.attributes).must_equal('foo' => 'bar')
+
+        redis.with_attributes('foo' => 'baz') do
+          _(redis.attributes).must_equal('foo' => 'baz')
+        end
+
+        _(redis.attributes).must_equal('foo' => 'bar')
+      end
+    end
+
+    it 'should merge attributes' do
+      redis.with_attributes(
+        'a' => '1',
+        'c' => '2'
+      ) do
+        _(redis.attributes).must_equal(
+          'a' => '1',
+          'c' => '2'
+        )
+
+        redis.with_attributes(
+          'a' => '0',
+          'b' => '1'
+        ) do
+          _(redis.attributes).must_equal(
+            'a' => '0',
+            'b' => '1',
+            'c' => '2'
+          )
+        end
+
+        _(redis.attributes).must_equal(
+          'a' => '1',
+          'c' => '2'
+        )
+      end
+    end
+  end
+
+  describe '#context_with_attributes' do
+    it 'returns a context containing attributes' do
+      ctx = redis.context_with_attributes('foo' => 'bar')
+      _(redis.attributes(ctx)).must_equal('foo' => 'bar')
+    end
+
+    it 'returns a context containing attributes' do
+      parent_ctx = OpenTelemetry::Context.empty.set_value('foo', 'bar')
+      ctx = redis.context_with_attributes({ 'bar' => 'baz' }, parent_context: parent_ctx)
+      _(redis.attributes(ctx)).must_equal('bar' => 'baz')
+      _(ctx.value('foo')).must_equal('bar')
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-ruby/issues/443 by adding the requested Redis context propagation support.

Unlike the HTTP client context implementation, there is only one supported Redis client gem, so I've implemented the Redis context propagation support in the Redis instrumentation gem rather than in the common gem. There is clearly a lot of duplication - the code is identical to the HTTP context propagation. The next time we implement this pattern, we should extract the common functionality to reduce duplication.

Possible follow-ups for context propagation:
* MySQL
* Dalli