### PR TITLE
fix: Remove unused kwarg from otlp exporter retry

### DIFF
--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -162,7 +162,7 @@ module OpenTelemetry
           OpenTelemetry::Trace.with_span(OpenTelemetry::Trace::Span.new) { yield }
         end
 
-        def backoff?(retry_after: nil, retry_count:, reason:)
+        def backoff?(retry_after: nil, retry_count:)
           return false if retry_count > RETRY_COUNT
 
           sleep_interval = nil

--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -108,6 +108,13 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       _(result).must_equal(SUCCESS)
     end
 
+    it 'retries on timeout' do
+      stub_request(:post, 'https://localhost:55681/v1/trace').to_timeout.then.to_return(status: 200)
+      span_data = create_span_data
+      result = exporter.export([span_data])
+      _(result).must_equal(SUCCESS)
+    end
+
     it 'returns FAILURE when shutdown' do
       exporter.shutdown
       result = exporter.export(nil)


### PR DESCRIPTION
The OTLP exporter was raising on backoffs, this corrects the error and adds a test coverage. 