### PR TITLE
fix!: allow samplers to modify tracestate

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/samplers.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/samplers.rb
@@ -38,18 +38,11 @@ module OpenTelemetry
       #   to the {Span} to be created. Can be nil.
       # @return [Result] The sampling result.
       module Samplers
-        RECORD_AND_SAMPLE = Result.new(decision: Decision::RECORD_AND_SAMPLE)
-        DROP = Result.new(decision: Decision::DROP)
-        RECORD_ONLY = Result.new(decision: Decision::RECORD_ONLY)
-        SAMPLING_HINTS = [Decision::DROP, Decision::RECORD_ONLY, Decision::RECORD_AND_SAMPLE].freeze
-
-        private_constant(:RECORD_AND_SAMPLE, :DROP, :RECORD_ONLY, :SAMPLING_HINTS)
-
         # Returns a {Result} with {Decision::RECORD_AND_SAMPLE}.
-        ALWAYS_ON = ConstantSampler.new(result: RECORD_AND_SAMPLE, description: 'AlwaysOnSampler')
+        ALWAYS_ON = ConstantSampler.new(decision: Decision::RECORD_AND_SAMPLE, description: 'AlwaysOnSampler')
 
         # Returns a {Result} with {Decision::DROP}.
-        ALWAYS_OFF = ConstantSampler.new(result: DROP, description: 'AlwaysOffSampler')
+        ALWAYS_OFF = ConstantSampler.new(decision: Decision::DROP, description: 'AlwaysOffSampler')
 
         # Returns a new sampler. It delegates to samplers according to the following rules:
         #

--- a/sdk/lib/opentelemetry/sdk/trace/samplers/constant_sampler.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/samplers/constant_sampler.rb
@@ -10,12 +10,12 @@ module OpenTelemetry
       module Samplers
         # @api private
         #
-        # Implements a sampler returning a constant result.
+        # Implements a sampler returning a result with a constant decision.
         class ConstantSampler
           attr_reader :description
 
-          def initialize(result:, description:)
-            @result = result
+          def initialize(decision:, description:)
+            @decision = decision
             @description = description
           end
 
@@ -23,8 +23,7 @@ module OpenTelemetry
           #
           # See {Samplers}.
           def should_sample?(trace_id:, parent_context:, links:, name:, kind:, attributes:)
-            # All arguments ignored for sampling decision.
-            @result
+            Result.new(decision: @decision, tracestate: OpenTelemetry::Trace.current_span(parent_context).context.tracestate)
           end
         end
       end

--- a/sdk/lib/opentelemetry/sdk/trace/samplers/result.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/samplers/result.rb
@@ -17,10 +17,15 @@ module OpenTelemetry
           DECISIONS = [Decision::RECORD_ONLY, Decision::DROP, Decision::RECORD_AND_SAMPLE].freeze
           private_constant(:EMPTY_HASH, :DECISIONS)
 
-          # Returns a frozen hash of attributes to be attached span.
+          # Returns a frozen hash of attributes to be attached to the span.
           #
           # @return [Hash{String => String, Numeric, Boolean, Array<String, Numeric, Boolean>}]
           attr_reader :attributes
+
+          # Returns a Tracestate to be associated with the span.
+          #
+          # @return [Tracestate]
+          attr_reader :tracestate
 
           # Returns a new sampling result with the specified decision and
           # attributes.
@@ -30,9 +35,15 @@ module OpenTelemetry
           # @param [optional Hash{String => String, Numeric, Boolean, Array<String, Numeric, Boolean>}]
           #   attributes A frozen or freezable hash containing attributes to be
           #   attached to the span.
-          def initialize(decision:, attributes: nil)
+          # @param [Tracestate] tracestate A Tracestate that will be associated
+          #   with the Span through the new SpanContext. If the sampler returns
+          #   an empty Tracestate here, the Tracestate will be cleared, so
+          #   samplers SHOULD normally return the passed-in Tracestate if they
+          #   do not intend to change it.
+          def initialize(decision:, attributes: nil, tracestate:)
             @decision = decision
             @attributes = attributes.freeze || EMPTY_HASH
+            @tracestate = tracestate
           end
 
           # Returns true if this span should be sampled.

--- a/sdk/lib/opentelemetry/sdk/trace/samplers/trace_id_ratio_based.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/samplers/trace_id_ratio_based.rb
@@ -24,12 +24,11 @@ module OpenTelemetry
           #
           # See {Samplers}.
           def should_sample?(trace_id:, parent_context:, links:, name:, kind:, attributes:)
-            # Ignored for sampling decision: parent_context:, links, name, kind, attributes.
-
+            tracestate = OpenTelemetry::Trace.current_span(parent_context).context.tracestate
             if sample?(trace_id)
-              RECORD_AND_SAMPLE
+              Result.new(decision: Decision::RECORD_AND_SAMPLE, tracestate: tracestate)
             else
-              DROP
+              Result.new(decision: Decision::DROP, tracestate: tracestate)
             end
           end
 

--- a/sdk/lib/opentelemetry/sdk/trace/tracer.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/tracer.rb
@@ -40,21 +40,20 @@ module OpenTelemetry
           parent_span_context = OpenTelemetry::Trace.current_span(with_parent).context
           if parent_span_context.valid?
             parent_span_id = parent_span_context.span_id
-            tracestate = parent_span_context.tracestate
             trace_id = parent_span_context.trace_id
           end
           trace_id ||= OpenTelemetry::Trace.generate_trace_id
           sampler = tracer_provider.active_trace_config.sampler
           result = sampler.should_sample?(trace_id: trace_id, parent_context: with_parent, links: links, name: name, kind: kind, attributes: attributes)
-          internal_create_span(result, name, kind, trace_id, parent_span_id, attributes, links, start_timestamp, tracestate, with_parent)
+          internal_create_span(result, name, kind, trace_id, parent_span_id, attributes, links, start_timestamp, with_parent)
         end
 
         private
 
-        def internal_create_span(result, name, kind, trace_id, parent_span_id, attributes, links, start_timestamp, tracestate, parent_context) # rubocop:disable Metrics/AbcSize
+        def internal_create_span(result, name, kind, trace_id, parent_span_id, attributes, links, start_timestamp, parent_context) # rubocop:disable Metrics/AbcSize
           if result.recording? && !tracer_provider.stopped?
             trace_flags = result.sampled? ? OpenTelemetry::Trace::TraceFlags::SAMPLED : OpenTelemetry::Trace::TraceFlags::DEFAULT
-            context = OpenTelemetry::Trace::SpanContext.new(trace_id: trace_id, trace_flags: trace_flags, tracestate: tracestate)
+            context = OpenTelemetry::Trace::SpanContext.new(trace_id: trace_id, trace_flags: trace_flags, tracestate: result.tracestate)
             attributes = attributes&.merge(result.attributes) || result.attributes
             Span.new(
               context,

--- a/sdk/test/opentelemetry/sdk/trace/samplers/result_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/samplers/result_test.rb
@@ -37,6 +37,13 @@ describe OpenTelemetry::SDK::Trace::Samplers::Result do
     end
   end
 
+  describe '#tracestate' do
+    it 'reflects the value passed in' do
+      tracestate = Object.new
+      _(Result.new(decision: Decision::RECORD_AND_SAMPLE, tracestate: tracestate).tracestate).must_equal(tracestate)
+    end
+  end
+
   describe '#initialize' do
     it 'accepts Decision constants' do
       _(Result.new(decision: Decision::RECORD_ONLY, tracestate: nil)).wont_be_nil

--- a/sdk/test/opentelemetry/sdk/trace/samplers/result_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/samplers/result_test.rb
@@ -12,11 +12,11 @@ describe OpenTelemetry::SDK::Trace::Samplers::Result do
 
   describe '#attributes' do
     it 'is empty by default' do
-      _(Result.new(decision: Decision::RECORD_ONLY).attributes).must_equal({})
+      _(Result.new(decision: Decision::RECORD_ONLY, tracestate: nil).attributes).must_equal({})
     end
 
     it 'is an empty hash when initialized with nil' do
-      _(Result.new(decision: Decision::RECORD_ONLY, attributes: nil).attributes).must_equal({})
+      _(Result.new(decision: Decision::RECORD_ONLY, attributes: nil, tracestate: nil).attributes).must_equal({})
     end
 
     it 'reflects values passed in' do
@@ -24,58 +24,58 @@ describe OpenTelemetry::SDK::Trace::Samplers::Result do
         'foo' => 'bar',
         'bar' => 'baz'
       }
-      _(Result.new(decision: Decision::RECORD_ONLY, attributes: attributes).attributes).must_equal(attributes)
+      _(Result.new(decision: Decision::RECORD_ONLY, attributes: attributes, tracestate: nil).attributes).must_equal(attributes)
     end
 
     it 'returns a frozen hash' do
-      _(Result.new(decision: Decision::RECORD_ONLY, attributes: { 'foo' => 'bar' }).attributes).must_be(:frozen?)
+      _(Result.new(decision: Decision::RECORD_ONLY, attributes: { 'foo' => 'bar' }, tracestate: nil).attributes).must_be(:frozen?)
     end
 
     it 'allows array-valued attributes' do
       attributes = { 'foo' => [1, 2, 3] }
-      _(Result.new(decision: Decision::RECORD_ONLY, attributes: attributes).attributes).must_equal(attributes)
+      _(Result.new(decision: Decision::RECORD_ONLY, attributes: attributes, tracestate: nil).attributes).must_equal(attributes)
     end
   end
 
   describe '#initialize' do
     it 'accepts Decision constants' do
-      _(Result.new(decision: Decision::RECORD_ONLY)).wont_be_nil
-      _(Result.new(decision: Decision::RECORD_AND_SAMPLE)).wont_be_nil
-      _(Result.new(decision: Decision::DROP)).wont_be_nil
+      _(Result.new(decision: Decision::RECORD_ONLY, tracestate: nil)).wont_be_nil
+      _(Result.new(decision: Decision::RECORD_AND_SAMPLE, tracestate: nil)).wont_be_nil
+      _(Result.new(decision: Decision::DROP, tracestate: nil)).wont_be_nil
     end
 
     it 'replaces invalid decisions with default' do
-      _(Result.new(decision: nil)).wont_be_nil
-      _(Result.new(decision: true)).wont_be_nil
-      _(Result.new(decision: :ok)).wont_be_nil
+      _(Result.new(decision: nil, tracestate: nil)).wont_be_nil
+      _(Result.new(decision: true, tracestate: nil)).wont_be_nil
+      _(Result.new(decision: :ok, tracestate: nil)).wont_be_nil
     end
   end
 
   describe '#sampled?' do
     it 'returns true when decision is RECORD_AND_SAMPLE' do
-      _(Result.new(decision: Decision::RECORD_AND_SAMPLE)).must_be :sampled?
+      _(Result.new(decision: Decision::RECORD_AND_SAMPLE, tracestate: nil)).must_be :sampled?
     end
 
     it 'returns false when decision is RECORD_ONLY' do
-      _(Result.new(decision: Decision::RECORD_ONLY)).wont_be :sampled?
+      _(Result.new(decision: Decision::RECORD_ONLY, tracestate: nil)).wont_be :sampled?
     end
 
     it 'returns false when decision is DROP' do
-      _(Result.new(decision: Decision::DROP)).wont_be :sampled?
+      _(Result.new(decision: Decision::DROP, tracestate: nil)).wont_be :sampled?
     end
   end
 
   describe '#recording?' do
     it 'returns true when decision is RECORD_AND_SAMPLE' do
-      _(Result.new(decision: Decision::RECORD_AND_SAMPLE)).must_be :recording?
+      _(Result.new(decision: Decision::RECORD_AND_SAMPLE, tracestate: nil)).must_be :recording?
     end
 
     it 'returns true when decision is RECORD_ONLY' do
-      _(Result.new(decision: Decision::RECORD_ONLY)).must_be :recording?
+      _(Result.new(decision: Decision::RECORD_ONLY, tracestate: nil)).must_be :recording?
     end
 
     it 'returns false when decision is DROP' do
-      _(Result.new(decision: Decision::DROP)).wont_be :recording?
+      _(Result.new(decision: Decision::DROP, tracestate: nil)).wont_be :recording?
     end
   end
 end

--- a/sdk/test/opentelemetry/sdk/trace/tracer_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/tracer_test.rb
@@ -15,7 +15,7 @@ describe OpenTelemetry::SDK::Trace::Tracer do
     OpenTelemetry.tracer_provider.tracer('component-tracer', '1.0.0')
   end
   let(:record_sampler) do
-    Samplers::ConstantSampler.new(result: Result.new(decision: Decision::RECORD_ONLY), description: 'RecordSampler')
+    Samplers::ConstantSampler.new(decision: Decision::RECORD_ONLY, description: 'RecordSampler')
   end
 
   describe '#name' do
@@ -73,7 +73,7 @@ describe OpenTelemetry::SDK::Trace::Tracer do
       trace_id = OpenTelemetry::Trace.generate_trace_id
       kind = Minitest::Mock.new
       attributes = Minitest::Mock.new
-      result = Result.new(decision: Decision::DROP)
+      result = Result.new(decision: Decision::DROP, tracestate: nil)
       mock_sampler = Minitest::Mock.new
       mock_sampler.expect(:should_sample?, result) do |args|
         args[:trace_id] == trace_id &&
@@ -116,7 +116,7 @@ describe OpenTelemetry::SDK::Trace::Tracer do
     it 'creates a span with sampler attributes added after supplied attributes' do
       sampler_attributes = { '1' => 1 }
       mock_sampler = Minitest::Mock.new
-      result = Result.new(decision: Decision::RECORD_ONLY, attributes: sampler_attributes)
+      result = Result.new(decision: Decision::RECORD_ONLY, attributes: sampler_attributes, tracestate: nil)
       mock_sampler.expect(:should_sample?, result, [Hash])
       activate_trace_config TraceConfig.new(sampler: mock_sampler)
       span = tracer.start_root_span('op', attributes: { '1' => 0, '2' => 2 })
@@ -212,7 +212,7 @@ describe OpenTelemetry::SDK::Trace::Tracer do
       name = 'span'
       kind = Minitest::Mock.new
       attributes = Minitest::Mock.new
-      result = Result.new(decision: Decision::DROP)
+      result = Result.new(decision: Decision::DROP, tracestate: nil)
       mock_sampler = Minitest::Mock.new
       mock_sampler.expect(:should_sample?, result, [{ trace_id: span_context.trace_id, parent_context: context, links: links, name: name, kind: kind, attributes: attributes }])
       activate_trace_config TraceConfig.new(sampler: mock_sampler)
@@ -253,7 +253,7 @@ describe OpenTelemetry::SDK::Trace::Tracer do
     it 'creates a span with sampler attributes added after supplied attributes' do
       sampler_attributes = { '1' => 1 }
       mock_sampler = Minitest::Mock.new
-      result = Result.new(decision: Decision::RECORD_ONLY, attributes: sampler_attributes)
+      result = Result.new(decision: Decision::RECORD_ONLY, attributes: sampler_attributes, tracestate: nil)
       mock_sampler.expect(:should_sample?, result, [Hash])
       activate_trace_config TraceConfig.new(sampler: mock_sampler)
       span = tracer.start_span('op', with_parent: context, attributes: { '1' => 0, '2' => 2 })


### PR DESCRIPTION
Fixes: #469 

A few notes:
- We now have to allocate an object for the `Result` on every call to `should_sample?`. This is unavoidable because the result has to wrap the tracestate from the parent context.
- I'll implement `Tracestate` in the API in a separate PR.
- This is a breaking change because it adds an extra required argument to `Result#initialize`.