### PR TITLE
Fix Jaeger exporter with nil values

### DIFF
--- a/exporter/jaeger/lib/opentelemetry/exporter/jaeger/encoder.rb
+++ b/exporter/jaeger/lib/opentelemetry/exporter/jaeger/encoder.rb
@@ -43,9 +43,13 @@ module OpenTelemetry
         end
 
         def encoded_tags(attributes)
-          attributes&.map do |key, value|
-            encoded_tag(key, value)
-          end || EMPTY_ARRAY
+          if attributes
+            attributes.find_all { |_key, value| value }.map do |key, value|
+              encoded_tag(key, value)
+            end
+          else
+            EMPTY_ARRAY
+          end
         end
 
         def encoded_tag(key, value)

--- a/exporter/jaeger/test/opentelemetry/exporters/jaeger/encoder_test.rb
+++ b/exporter/jaeger/test/opentelemetry/exporters/jaeger/encoder_test.rb
@@ -85,6 +85,14 @@ describe OpenTelemetry::Exporter::Jaeger::Encoder do
     )
   end
 
+  it 'ignores nil values' do
+    attributes = { 'a_nil' => nil }
+    span_data = create_span_data(attributes: attributes)
+    encoded_span = Encoder.encoded_span(span_data)
+    _(encoded_span.tags.length).must_equal(0)
+  end
+
+
   describe 'instrumentation library' do
     it 'encodes library and version when set' do
       lib = OpenTelemetry::SDK::InstrumentationLibrary.new('mylib', '0.1.0')


### PR DESCRIPTION
When there's a `nil` value in the span data attributes Jaeger exporter will fail with a following error: `unexpected error in Jaeger::CollectorExporter#export - Unknown key given to OpenTelemetry::Exporter::Jaeger::Thrift::Tag.new:`. It's unexpected and hard to track down as the error does not even give the key name. It's also quite common in Ruby apps to not check for `nil` values when setting them as an attribute - a common practice is to either conver them to empty strings or ignore them.

This PR ignores `nil` attributes, but an alternative (empty strings) could also be implemented.