### PR TITLE
feat: Add instrumentation boilerplate generator

### DIFF
--- a/.instrumentation_generator/instrumentation_generator.rb
+++ b/.instrumentation_generator/instrumentation_generator.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'thor'
+
+class InstrumentationGenerator < Thor::Group
+  include Thor::Actions
+
+  source_root File.dirname(__FILE__)
+  argument :instrumentation_name
+
+  def root_files
+    template('templates/rubocop.yml.tt', "#{instrumentation_path}/.rubocop.yml")
+    template('templates/yardopts.tt', "#{instrumentation_path}/yardopts.tt")
+    template('templates/Appraisals', "#{instrumentation_path}/Appraisal")
+    template('templates/CHANGELOG.md.tt', "#{instrumentation_path}/CHANGELOG.md")
+    template('templates/Gemfile', "#{instrumentation_path}/Gemfile")
+    template('templates/LICENSE', "#{instrumentation_path}/LICENSE")
+    template('templates/gemspec.tt', "#{instrumentation_path}/#{instrumentation_gem_name}.gemspec")
+    template('templates/Rakefile', "#{instrumentation_path}/Rakefile")
+    template('templates/Readme.md.tt', "#{instrumentation_path}/README.md")
+  end
+
+  def lib_files
+    template('templates/lib/entrypoint.rb', "#{instrumentation_path}/lib/#{instrumentation_gem_name}.rb")
+    template('templates/lib/instrumentation.rb.tt', "#{instrumentation_path}/lib/opentelemetry/instrumentation.rb")
+    template('templates/lib/instrumentation/instrumentation_name.rb.tt', "#{instrumentation_path}/lib/opentelemetry/instrumentation/#{instrumentation_name}.rb")
+    template('templates/lib/instrumentation/instrumentation_name/instrumentation.rb.tt', "#{instrumentation_path}/lib/opentelemetry/instrumentation/#{instrumentation_name}/instrumentation.rb")
+    template('templates/lib/instrumentation/instrumentation_name/version.rb.tt', "#{instrumentation_path}/lib/opentelemetry/instrumentation/#{instrumentation_name}/version.rb")
+  end
+
+  def test_files
+    template('templates/test/test_helper.rb', "#{instrumentation_path}/test/test_helper.rb")
+    template('templates/test/instrumentation.rb', "#{instrumentation_path}/test/#{instrumentation_path}/instrumentation_test.rb")
+  end
+
+  private
+
+  def instrumentation_path
+    "instrumentation/#{instrumentation_name}"
+  end
+
+  def instrumentation_gem_name
+    "opentelemetry-instrumentation-#{instrumentation_name}"
+  end
+
+  def pascal_cased_instrumentation_name
+    instrumentation_name.split('_').collect(&:capitalize).join
+  end
+end

--- a/.instrumentation_generator/instrumentation_generator.rb
+++ b/.instrumentation_generator/instrumentation_generator.rb
@@ -55,4 +55,8 @@ class InstrumentationGenerator < Thor::Group
   def pascal_cased_instrumentation_name
     instrumentation_name.split('_').collect(&:capitalize).join
   end
+
+  def humanized_instrumentation_name
+    instrumentation_name.split('_').collect(&:capitalize).join(' ')
+  end
 end

--- a/.instrumentation_generator/instrumentation_generator.rb
+++ b/.instrumentation_generator/instrumentation_generator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2020 OpenTelemetry Authors
+# Copyright The OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.instrumentation_generator/instrumentation_generator.rb
+++ b/.instrumentation_generator/instrumentation_generator.rb
@@ -4,6 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require_relative '../api/lib/opentelemetry/version'
 require 'thor'
 
 class InstrumentationGenerator < Thor::Group
@@ -14,7 +15,7 @@ class InstrumentationGenerator < Thor::Group
 
   def root_files
     template('templates/rubocop.yml.tt', "#{instrumentation_path}/.rubocop.yml")
-    template('templates/yardopts.tt', "#{instrumentation_path}/yardopts.tt")
+    template('templates/yardopts.tt', "#{instrumentation_path}/.yardopts")
     template('templates/Appraisals', "#{instrumentation_path}/Appraisal")
     template('templates/CHANGELOG.md.tt', "#{instrumentation_path}/CHANGELOG.md")
     template('templates/Gemfile', "#{instrumentation_path}/Gemfile")
@@ -38,6 +39,10 @@ class InstrumentationGenerator < Thor::Group
   end
 
   private
+
+  def opentelemetry_version
+    OpenTelemetry::VERSION
+  end
 
   def instrumentation_path
     "instrumentation/#{instrumentation_name}"

--- a/.instrumentation_generator/templates/Appraisals
+++ b/.instrumentation_generator/templates/Appraisals
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2020 OpenTelemetry Authors
+# Copyright The OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.instrumentation_generator/templates/Appraisals
+++ b/.instrumentation_generator/templates/Appraisals
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+## TODO: Include the supported version to be tested here.
+## Example:
+# appraise 'rack-2.1' do
+#   gem 'rack', '~> 2.1.2'
+# end
+
+# appraise 'rack-2.0' do
+#   gem 'rack', '2.0.8'
+# end
+

--- a/.instrumentation_generator/templates/CHANGELOG.md.tt
+++ b/.instrumentation_generator/templates/CHANGELOG.md.tt
@@ -1,0 +1,1 @@
+# Release History: <%= instrumentation_gem_name %>

--- a/.instrumentation_generator/templates/Gemfile
+++ b/.instrumentation_generator/templates/Gemfile
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source 'https://rubygems.org'
+
+gemspec
+
+gem 'opentelemetry-api', path: '../../api'
+
+group :test do
+  gem 'opentelemetry-common', path: '../../common'
+  gem 'opentelemetry-sdk', path: '../../sdk'
+end

--- a/.instrumentation_generator/templates/Gemfile
+++ b/.instrumentation_generator/templates/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2020 OpenTelemetry Authors
+# Copyright The OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.instrumentation_generator/templates/LICENSE
+++ b/.instrumentation_generator/templates/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2020 OpenTelemetry Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.instrumentation_generator/templates/LICENSE
+++ b/.instrumentation_generator/templates/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 OpenTelemetry Authors
+   Copyright The OpenTelemetry Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/.instrumentation_generator/templates/Rakefile
+++ b/.instrumentation_generator/templates/Rakefile
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+require 'yard'
+require 'rubocop/rake_task'
+
+RuboCop::RakeTask.new
+
+Rake::TestTask.new :test do |t|
+  t.libs << 'test'
+  t.libs << 'lib'
+  t.test_files = FileList['test/**/*_test.rb']
+end
+
+YARD::Rake::YardocTask.new do |t|
+  t.stats_options = ['--list-undoc']
+end
+
+if RUBY_ENGINE == 'truffleruby'
+  task default: %i[test]
+else
+  task default: %i[test rubocop yard]
+end

--- a/.instrumentation_generator/templates/Readme.md.tt
+++ b/.instrumentation_generator/templates/Readme.md.tt
@@ -1,0 +1,52 @@
+# OpenTelemetry <%= pascal_cased_instrumentation_name %> Instrumentation
+
+Todo: Add a description.
+
+## How do I get started?
+
+Install the gem using:
+
+```
+gem install opentelemetry-instrumentation-<%= instrumentation_name %>
+```
+
+Or, if you use [bundler][bundler-home], include `opentelemetry-instrumentation-<%= instrumentation_name %>` in your `Gemfile`.
+
+## Usage
+
+To use the instrumentation, call `use` with the name of the instrumentation:
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::<%= pascal_cased_instrumentation_name %>'
+end
+```
+
+Alternatively, you can also call `use_all` to install all the available instrumentation.
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use_all
+end
+```
+
+## Examples
+
+Example usage can be seen in the `./example/trace_demonstration.rb` file [here](https://github.com/open-telemetry/opentelemetry-ruby/blob/master/instrumentation/<%= instrumentation_name %>/example/trace_demonstration.rb)
+
+## How can I get involved?
+
+The `opentelemetry-instrumentation-<%= instrumentation_name %>` gem source is [on github][repo-github], along with related gems including `opentelemetry-api` and `opentelemetry-sdk`.
+
+The OpenTelemetry Ruby gems are maintained by the OpenTelemetry-Ruby special interest group (SIG). You can get involved by joining us on our [gitter channel][ruby-gitter] or attending our weekly meeting. See the [meeting calendar][community-meetings] for dates and times. For more information on this and other language SIGs, see the OpenTelemetry [community page][ruby-sig].
+
+## License
+
+The `opentelemetry-instrumentation-<%= instrumentation_name %>` gem is distributed under the Apache 2.0 license. See [LICENSE][license-github] for more information.
+
+[bundler-home]: https://bundler.io
+[repo-github]: https://github.com/open-telemetry/opentelemetry-ruby
+[license-github]: https://github.com/open-telemetry/opentelemetry-ruby/blob/master/LICENSE
+[ruby-sig]: https://github.com/open-telemetry/community#ruby-sig
+[community-meetings]: https://github.com/open-telemetry/community#community-meetings
+[ruby-gitter]: https://gitter.im/open-telemetry/opentelemetry-ruby

--- a/.instrumentation_generator/templates/gemspec.tt
+++ b/.instrumentation_generator/templates/gemspec.tt
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2020 OpenTelemetry Authors
+# Copyright The OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.instrumentation_generator/templates/gemspec.tt
+++ b/.instrumentation_generator/templates/gemspec.tt
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'opentelemetry/instrumentation/<%= instrumentation_name %>/version'
+
+Gem::Specification.new do |spec|
+  spec.name        = 'opentelemetry-instrumentation-<%= instrumentation_name %>'
+  spec.version     = OpenTelemetry::Instrumentation::<%= pascal_cased_instrumentation_name %>::VERSION
+  spec.authors     = ['OpenTelemetry Authors']
+  spec.email       = ['cncf-opentelemetry-contributors@lists.cncf.io']
+
+  spec.summary     = '<%= pascal_cased_instrumentation_name %> instrumentation for the OpenTelemetry framework'
+  spec.description = '<%= pascal_cased_instrumentation_name %> instrumentation for the OpenTelemetry framework'
+  spec.homepage    = 'https://github.com/open-telemetry/opentelemetry-ruby'
+  spec.license     = 'Apache-2.0'
+
+  spec.files = ::Dir.glob('lib/**/*.rb') +
+               ::Dir.glob('*.md') +
+               ['LICENSE', '.yardopts']
+  spec.require_paths = ['lib']
+  spec.required_ruby_version = '>= 2.5.0'
+
+  spec.add_dependency 'opentelemetry-api', '~> 0.8.0'
+
+  spec.add_development_dependency 'appraisal', '~> 2.2.0'
+  spec.add_development_dependency 'bundler', '>= 1.17'
+  spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'opentelemetry-sdk', '~> 0.0'
+  spec.add_development_dependency 'rake', '~> 12.3.3'
+  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'simplecov', '~> 0.17.1'
+  spec.add_development_dependency 'webmock', '~> 3.7.6'
+  spec.add_development_dependency 'yard', '~> 0.9'
+  spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-<%= instrumentation_name %>/v#{OpenTelemetry::Instrumentation::<%= pascal_cased_instrumentation_name %>::VERSION}/file.CHANGELOG.html"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/master/instrumentation/<%= instrumentation_name %>'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/issues'
+    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-<%= instrumentation_name %>/v#{OpenTelemetry::Instrumentation::<%= pascal_cased_instrumentation_name %>::VERSION}"
+  end
+end

--- a/.instrumentation_generator/templates/gemspec.tt
+++ b/.instrumentation_generator/templates/gemspec.tt
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.5.0'
 
-  spec.add_dependency 'opentelemetry-api', '~> 0.8.0'
+  spec.add_dependency 'opentelemetry-api', '~> <%= opentelemetry_version %>'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '>= 1.17'

--- a/.instrumentation_generator/templates/lib/entrypoint.rb
+++ b/.instrumentation_generator/templates/lib/entrypoint.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require_relative './opentelemetry/instrumentation'

--- a/.instrumentation_generator/templates/lib/entrypoint.rb
+++ b/.instrumentation_generator/templates/lib/entrypoint.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2020 OpenTelemetry Authors
+# Copyright The OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.instrumentation_generator/templates/lib/instrumentation.rb.tt
+++ b/.instrumentation_generator/templates/lib/instrumentation.rb.tt
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2020 OpenTelemetry Authors
+# Copyright The OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.instrumentation_generator/templates/lib/instrumentation.rb.tt
+++ b/.instrumentation_generator/templates/lib/instrumentation.rb.tt
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# OpenTelemetry is an open source observability framework, providing a
+# general-purpose API, SDK, and related tools required for the instrumentation
+# of cloud-native software, frameworks, and libraries.
+#
+# The OpenTelemetry module provides global accessors for telemetry objects.
+# See the documentation for the `opentelemetry-api` gem for details.
+module OpenTelemetry
+  # Instrumentation should be able to handle the case when the library is not installed on a user's system.
+  module Instrumentation
+  end
+end
+
+require_relative './instrumentation/<%= instrumentation_name %>'

--- a/.instrumentation_generator/templates/lib/instrumentation/instrumentation_name.rb.tt
+++ b/.instrumentation_generator/templates/lib/instrumentation/instrumentation_name.rb.tt
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry'
+
+module OpenTelemetry
+  module Instrumentation
+    # Contains the OpenTelemetry instrumentation for the <%= pascal_cased_instrumentation_name %> gem
+    module <%= pascal_cased_instrumentation_name %>
+    end
+  end
+end
+
+require_relative './<%= instrumentation_name %>/instrumentation'
+require_relative './<%= instrumentation_name %>/version'

--- a/.instrumentation_generator/templates/lib/instrumentation/instrumentation_name.rb.tt
+++ b/.instrumentation_generator/templates/lib/instrumentation/instrumentation_name.rb.tt
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2020 OpenTelemetry Authors
+# Copyright The OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.instrumentation_generator/templates/lib/instrumentation/instrumentation_name/instrumentation.rb.tt
+++ b/.instrumentation_generator/templates/lib/instrumentation/instrumentation_name/instrumentation.rb.tt
@@ -11,7 +11,7 @@ module OpenTelemetry
     module <%= pascal_cased_instrumentation_name %>
       # The Instrumentation class contains logic to detect and install the <%= pascal_cased_instrumentation_name %> instrumentation
       class Instrumentation < OpenTelemetry::Instrumentation::Base
-        install do |config|
+        install do |_config|
           require_dependencies
         end
 

--- a/.instrumentation_generator/templates/lib/instrumentation/instrumentation_name/instrumentation.rb.tt
+++ b/.instrumentation_generator/templates/lib/instrumentation/instrumentation_name/instrumentation.rb.tt
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2020 OpenTelemetry Authors
+# Copyright The OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.instrumentation_generator/templates/lib/instrumentation/instrumentation_name/instrumentation.rb.tt
+++ b/.instrumentation_generator/templates/lib/instrumentation/instrumentation_name/instrumentation.rb.tt
@@ -17,7 +17,7 @@ module OpenTelemetry
 
         present do
           # TODO: Replace true with a definition check of the gem being instrumented
-          # Exampe: `defined?(::Rack)`
+          # Example: `defined?(::Rack)`
           true
         end
 

--- a/.instrumentation_generator/templates/lib/instrumentation/instrumentation_name/instrumentation.rb.tt
+++ b/.instrumentation_generator/templates/lib/instrumentation/instrumentation_name/instrumentation.rb.tt
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry'
+
+module OpenTelemetry
+  module Instrumentation
+    module <%= pascal_cased_instrumentation_name %>
+      # The Instrumentation class contains logic to detect and install the <%= pascal_cased_instrumentation_name %> instrumentation
+      class Instrumentation < OpenTelemetry::Instrumentation::Base
+        install do |config|
+          require_dependencies
+        end
+
+        present do
+          # TODO: Replace true with a definition check of the gem being instrumented
+          # Exampe: `defined?(::Rack)`
+          true
+        end
+
+        private
+
+        def require_dependencies
+          # TODO: Include instrumentation dependencies
+        end
+      end
+    end
+  end
+end

--- a/.instrumentation_generator/templates/lib/instrumentation/instrumentation_name/version.rb.tt
+++ b/.instrumentation_generator/templates/lib/instrumentation/instrumentation_name/version.rb.tt
@@ -7,7 +7,7 @@
 module OpenTelemetry
   module Instrumentation
     module <%= pascal_cased_instrumentation_name %>
-      VERSION = '0.0.0'
+      VERSION = '<%= opentelemetry_version %>'
     end
   end
 end

--- a/.instrumentation_generator/templates/lib/instrumentation/instrumentation_name/version.rb.tt
+++ b/.instrumentation_generator/templates/lib/instrumentation/instrumentation_name/version.rb.tt
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2019 OpenTelemetry Authors
+# Copyright The OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.instrumentation_generator/templates/lib/instrumentation/instrumentation_name/version.rb.tt
+++ b/.instrumentation_generator/templates/lib/instrumentation/instrumentation_name/version.rb.tt
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Copyright 2019 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Instrumentation
+    module <%= pascal_cased_instrumentation_name %>
+      VERSION = '0.0.0'
+    end
+  end
+end

--- a/.instrumentation_generator/templates/rubocop.yml.tt
+++ b/.instrumentation_generator/templates/rubocop.yml.tt
@@ -1,0 +1,27 @@
+AllCops:
+  TargetRubyVersion: "2.5.0"
+
+Bundler/OrderedGems:
+  Exclude:
+    - gemfiles/**/*
+Lint/UnusedMethodArgument:
+  Enabled: false
+Metrics/AbcSize:
+  Max: 18
+Metrics/LineLength:
+  Enabled: false
+Metrics/MethodLength:
+  Max: 20
+Metrics/ParameterLists:
+  Enabled: false
+Naming/FileName:
+  Exclude:
+    - "lib/opentelemetry-instrumentation-<%= instrumentation_name %>.rb"
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - gemfiles/**/*
+Style/ModuleFunction:
+  Enabled: false
+Style/StringLiterals:
+  Exclude:
+    - gemfiles/**/*

--- a/.instrumentation_generator/templates/test/instrumentation.rb.tt
+++ b/.instrumentation_generator/templates/test/instrumentation.rb.tt
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+require_relative '../../../lib/opentelemetry/instrumentation/<%= instrumentation_name %>'
+
+describe OpenTelemetry::Instrumentation::<%= pascal_cased_instrumentation_name %> do
+  let(:instrumentation) { OpenTelemetry::Instrumentation::<%= pascal_cased_instrumentation_name %>::Instrumentation.instance }
+
+  it 'has #name' do
+    _(instrumentation.name).must_equal 'OpenTelemetry::Instrumentation::<%= pascal_cased_instrumentation_name %>'
+  end
+
+  it 'has #version' do
+    _(instrumentation.version).wont_be_nil
+    _(instrumentation.version).wont_be_empty
+  end
+
+  describe '#install' do
+    it 'accepts argument' do
+      instrumentation.install({})
+    end
+  end
+end

--- a/.instrumentation_generator/templates/test/instrumentation.rb.tt
+++ b/.instrumentation_generator/templates/test/instrumentation.rb.tt
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2020 OpenTelemetry Authors
+# Copyright The OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.instrumentation_generator/templates/test/test_helper.rb
+++ b/.instrumentation_generator/templates/test/test_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2020 OpenTelemetry Authors
+# Copyright The OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.instrumentation_generator/templates/test/test_helper.rb
+++ b/.instrumentation_generator/templates/test/test_helper.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Copyright 2020 OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry/sdk'
+
+require 'minitest/autorun'
+require 'webmock/minitest'
+
+# global opentelemetry-sdk setup:
+EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
+span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
+
+OpenTelemetry::SDK.configure do |c|
+  c.add_span_processor span_processor
+end

--- a/.instrumentation_generator/templates/yardopts.tt
+++ b/.instrumentation_generator/templates/yardopts.tt
@@ -1,0 +1,9 @@
+--no-private
+--title=OpenTelemetry <%= instrumentation_name %> Instrumentation
+--markup=markdown
+--main=README.md
+./lib/opentelemetry/instrumentation/**/*.rb
+./lib/opentelemetry/instrumentation.rb
+-
+README.md
+CHANGELOG.md

--- a/.instrumentation_generator/templates/yardopts.tt
+++ b/.instrumentation_generator/templates/yardopts.tt
@@ -1,5 +1,5 @@
 --no-private
---title=OpenTelemetry <%= instrumentation_name %> Instrumentation
+--title=OpenTelemetry <%= humanized_instrumentation_name %> Instrumentation
 --markup=markdown
 --main=README.md
 ./lib/opentelemetry/instrumentation/**/*.rb

--- a/bin/instrumentation_generator
+++ b/bin/instrumentation_generator
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require_relative '../.instrumentation_generator/instrumentation_generator'
+
+InstrumentationGenerator.start(ARGV)


### PR DESCRIPTION
Usage `bin/instrumentation_generator amazing_gem`

```
MacBook-Pro ~/s/f/opentelemetry-ruby> bin/instrumentation_generator amazing_gem
      create  instrumentation/amazing_gem/.rubocop.yml
      create  instrumentation/amazing_gem/.yardopts
      create  instrumentation/amazing_gem/Appraisal
      create  instrumentation/amazing_gem/CHANGELOG.md
      create  instrumentation/amazing_gem/Gemfile
      create  instrumentation/amazing_gem/LICENSE
      create  instrumentation/amazing_gem/opentelemetry-instrumentation-amazing_gem.gemspec
      create  instrumentation/amazing_gem/Rakefile
      create  instrumentation/amazing_gem/README.md
      create  instrumentation/amazing_gem/lib/opentelemetry-instrumentation-amazing_gem.rb
      create  instrumentation/amazing_gem/lib/opentelemetry/instrumentation.rb
      create  instrumentation/amazing_gem/lib/opentelemetry/instrumentation/amazing_gem.rb
      create  instrumentation/amazing_gem/lib/opentelemetry/instrumentation/amazing_gem/instrumentation.rb
      create  instrumentation/amazing_gem/lib/opentelemetry/instrumentation/amazing_gem/version.rb
      create  instrumentation/amazing_gem/test/test_helper.rb
      create  instrumentation/amazing_gem/test/instrumentation/amazing_gem/instrumentation_test.rb
```

You can see the output here https://github.com/open-telemetry/opentelemetry-ruby/pull/497