### PR TITLE
fix: rack current_span

### DIFF
--- a/instrumentation/rack/Gemfile
+++ b/instrumentation/rack/Gemfile
@@ -11,6 +11,8 @@ gemspec
 gem 'opentelemetry-api', path: '../../api'
 
 group :test do
+  gem 'byebug'
   gem 'opentelemetry-common', path: '../../common'
   gem 'opentelemetry-sdk', path: '../../sdk'
+  gem 'pry-byebug'
 end

--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack.rb
@@ -22,7 +22,7 @@ module OpenTelemetry
       #   {Span} from. Defaults to Context.current
       def current_span(context = nil)
         context ||= Context.current
-        context.value(CURRENT_SPAN_KEY) || Span::INVALID
+        context.value(CURRENT_SPAN_KEY) || OpenTelemetry::Trace::Span::INVALID
       end
 
       # Returns a context containing the span, derived from the optional parent

--- a/instrumentation/rack/test/test_helper.rb
+++ b/instrumentation/rack/test/test_helper.rb
@@ -8,6 +8,7 @@ require 'rack'
 
 require 'opentelemetry/sdk'
 
+require 'pry'
 require 'minitest/autorun'
 require 'webmock/minitest'
 


### PR DESCRIPTION
Fixes namespacing on `Span::INVALID`