### PR TITLE
fix: semantic conventions db.type -> db.system

### DIFF
--- a/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
+++ b/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
@@ -73,7 +73,7 @@ module OpenTelemetry
             port = query_options[:port].to_s
 
             {
-              'db.type' => 'mysql',
+              'db.system' => 'mysql',
               'db.instance' => database_name,
               'db.url' => "mysql://#{host}:#{port}",
               'net.peer.name' => host,

--- a/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
+++ b/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
@@ -61,7 +61,7 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
       client.query('SELECT 1')
 
       _(span.name).must_equal 'select'
-      _(span.attributes['db.type']).must_equal 'mysql'
+      _(span.attributes['db.system']).must_equal 'mysql'
       _(span.attributes['db.instance']).must_equal 'mysql'
       _(span.attributes['db.statement']).must_equal 'SELECT 1'
       _(span.attributes['db.url']).must_equal "mysql://#{host}:#{port}"
@@ -75,7 +75,7 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
       end.must_raise Mysql2::Error
 
       _(span.name).must_equal 'select'
-      _(span.attributes['db.type']).must_equal 'mysql'
+      _(span.attributes['db.system']).must_equal 'mysql'
       _(span.attributes['db.instance']).must_equal 'mysql'
       _(span.attributes['db.statement']).must_equal 'SELECT INVALID'
       _(span.attributes['db.url']).must_equal "mysql://#{host}:#{port}"
@@ -98,7 +98,7 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
       client.query(explain_sql)
 
       _(span.name).must_equal 'explain'
-      _(span.attributes['db.type']).must_equal 'mysql'
+      _(span.attributes['db.system']).must_equal 'mysql'
       _(span.attributes['db.instance']).must_equal 'mysql'
       _(span.attributes['db.statement']).must_equal explain_sql
       _(span.attributes['db.url']).must_equal "mysql://#{host}:#{port}"
@@ -112,7 +112,7 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
       end.must_raise Mysql2::Error
 
       _(span.name).must_equal 'mysql.mysql'
-      _(span.attributes['db.type']).must_equal 'mysql'
+      _(span.attributes['db.system']).must_equal 'mysql'
       _(span.attributes['db.instance']).must_equal 'mysql'
       _(span.attributes['db.statement']).must_equal 'DESELECT 1'
       _(span.attributes['db.url']).must_equal "mysql://#{host}:#{port}"

--- a/instrumentation/redis/lib/opentelemetry/instrumentation/redis/patches/client.rb
+++ b/instrumentation/redis/lib/opentelemetry/instrumentation/redis/patches/client.rb
@@ -49,7 +49,7 @@ module OpenTelemetry
             port = options[:port]
 
             OpenTelemetry::Instrumentation::Redis.attributes.merge(
-              'db.type' => 'redis',
+              'db.system' => 'redis',
               'db.instance' => options[:db].to_s,
               'db.url' => "redis://#{host}:#{port}",
               'net.peer.name' => host,

--- a/instrumentation/redis/test/opentelemetry/instrumentation/redis/instrumentation_test.rb
+++ b/instrumentation/redis/test/opentelemetry/instrumentation/redis/instrumentation_test.rb
@@ -36,7 +36,7 @@ describe OpenTelemetry::Instrumentation::Redis::Instrumentation do
       ::Redis.new.auth('password')
 
       _(span.name).must_equal 'AUTH'
-      _(span.attributes['db.type']).must_equal 'redis'
+      _(span.attributes['db.system']).must_equal 'redis'
       _(span.attributes['db.instance']).must_equal '0'
       _(span.attributes['db.statement']).must_equal 'AUTH ?'
       _(span.attributes['db.url']).must_equal 'redis://127.0.0.1:6379'
@@ -53,7 +53,7 @@ describe OpenTelemetry::Instrumentation::Redis::Instrumentation do
 
       set_span = exporter.finished_spans.first
       _(set_span.name).must_equal 'SET'
-      _(set_span.attributes['db.type']).must_equal 'redis'
+      _(set_span.attributes['db.system']).must_equal 'redis'
       _(set_span.attributes['db.instance']).must_equal '0'
       _(set_span.attributes['db.statement']).must_equal(
         'SET K ' + 'x' * 47 + '...'
@@ -64,7 +64,7 @@ describe OpenTelemetry::Instrumentation::Redis::Instrumentation do
 
       get_span = exporter.finished_spans.last
       _(get_span.name).must_equal 'GET'
-      _(get_span.attributes['db.type']).must_equal 'redis'
+      _(get_span.attributes['db.system']).must_equal 'redis'
       _(get_span.attributes['db.instance']).must_equal '0'
       _(get_span.attributes['db.statement']).must_equal 'GET K'
       _(get_span.attributes['db.url']).must_equal 'redis://127.0.0.1:6379'
@@ -82,7 +82,7 @@ describe OpenTelemetry::Instrumentation::Redis::Instrumentation do
 
       set_span = exporter.finished_spans.first
       _(set_span.name).must_equal 'SET'
-      _(set_span.attributes['db.type']).must_equal 'redis'
+      _(set_span.attributes['db.system']).must_equal 'redis'
       _(set_span.attributes['db.instance']).must_equal '0'
       _(set_span.attributes['db.statement']).must_equal('SET K x')
       _(set_span.attributes['db.url']).must_equal 'redis://127.0.0.1:6379'
@@ -98,7 +98,7 @@ describe OpenTelemetry::Instrumentation::Redis::Instrumentation do
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'THIS_IS_NOT_A_REDIS_FUNC'
-      _(span.attributes['db.type']).must_equal 'redis'
+      _(span.attributes['db.system']).must_equal 'redis'
       _(span.attributes['db.instance']).must_equal '0'
       _(span.attributes['db.statement']).must_equal(
         'THIS_IS_NOT_A_REDIS_FUNC THIS_IS_NOT_A_VALID_ARG'
@@ -123,7 +123,7 @@ describe OpenTelemetry::Instrumentation::Redis::Instrumentation do
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'pipeline'
-      _(span.attributes['db.type']).must_equal 'redis'
+      _(span.attributes['db.system']).must_equal 'redis'
       _(span.attributes['db.instance']).must_equal '0'
       _(span.attributes['db.statement']).must_equal "SET v1 0\nINCR v1\nGET v1"
       _(span.attributes['db.url']).must_equal 'redis://example.com:8321'


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/database.md#connection-level-attributes