### PR TITLE
fix: rails tests

### DIFF
--- a/instrumentation/rails/Appraisals
+++ b/instrumentation/rails/Appraisals
@@ -5,9 +5,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 appraise 'rails-5.2' do
-  gem 'rails', '~> 5.2'
+  gem 'rails', '~> 5.2.0'
 end
 
 appraise 'rails-6.0' do
-  gem 'rails', '~> 6.0'
+  gem 'rails', '~> 6.0.0'
 end

--- a/instrumentation/rails/Appraisals
+++ b/instrumentation/rails/Appraisals
@@ -11,3 +11,7 @@ end
 appraise 'rails-6.0' do
   gem 'rails', '~> 6.0.0'
 end
+
+appraise 'rails-6.1' do
+  gem 'rails', '~> 6.1.0'
+end

--- a/instrumentation/rails/gemfiles/rails_5.2.gemfile
+++ b/instrumentation/rails/gemfiles/rails_5.2.gemfile
@@ -6,7 +6,11 @@ gem "opentelemetry-api", path: "../../../api"
 gem "rails", "~> 5.2"
 
 group :test do
+  gem "byebug"
+  gem "opentelemetry-common", path: "../../../common"
+  gem "opentelemetry-instrumentation-rack", path: "../../../instrumentation/rack"
   gem "opentelemetry-sdk", path: "../../../sdk"
+  gem "pry-byebug"
 end
 
 gemspec path: "../"

--- a/instrumentation/rails/gemfiles/rails_6.0.gemfile
+++ b/instrumentation/rails/gemfiles/rails_6.0.gemfile
@@ -6,7 +6,11 @@ gem "opentelemetry-api", path: "../../../api"
 gem "rails", "~> 6.0"
 
 group :test do
+  gem "byebug"
+  gem "opentelemetry-common", path: "../../../common"
+  gem "opentelemetry-instrumentation-rack", path: "../../../instrumentation/rack"
   gem "opentelemetry-sdk", path: "../../../sdk"
+  gem "pry-byebug"
 end
 
 gemspec path: "../"

--- a/instrumentation/rails/gemfiles/rails_6.0.gemfile
+++ b/instrumentation/rails/gemfiles/rails_6.0.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "opentelemetry-api", path: "../../../api"
-gem "rails", "~> 6.0"
+gem "rails", "~> 6.0.0"
 
 group :test do
   gem "byebug"

--- a/instrumentation/rails/gemfiles/rails_6.1.gemfile
+++ b/instrumentation/rails/gemfiles/rails_6.1.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "opentelemetry-api", path: "../../../api"
-gem "rails", "~> 5.2.0"
+gem "rails", "~> 6.1.0"
 
 group :test do
   gem "byebug"

--- a/instrumentation/rails/test/opentelemetry/instrumentation/rails/patches/action_controller/metal_test.rb
+++ b/instrumentation/rails/test/opentelemetry/instrumentation/rails/patches/action_controller/metal_test.rb
@@ -66,6 +66,18 @@ describe OpenTelemetry::Instrumentation::Rails::Patches::ActionController::Metal
     end
   end
 
+  describe 'when the application does not have the tracing rack middleware' do
+    let(:rails_app) { AppConfig.initialize_app(remove_rack_tracer_middleware: true) }
+
+    it 'does something' do
+      get '/ok'
+
+      _(last_response.body).must_equal 'actually ok'
+      _(last_response.ok?).must_equal true
+      _(spans.size).must_equal(0)
+    end
+  end
+
   def app
     rails_app
   end

--- a/instrumentation/rails/test/test_helpers/app_config.rb
+++ b/instrumentation/rails/test/test_helpers/app_config.rb
@@ -26,6 +26,8 @@ module AppConfig
     case Rails.version
     when /^6\.0/
       apply_rails_6_0_configs(new_app)
+    when /^6\.1/
+      apply_rails_6_1_configs(new_app)
     end
 
     remove_rack_middleware(new_app) if remove_rack_tracer_middleware
@@ -70,5 +72,10 @@ module AppConfig
     application.config.hosts << 'example.org'
     # Creates a lot of deprecation warnings on subsequent app initializations if not explicitly set.
     application.config.action_view.finalize_compiled_template_methods = ActionView::Railtie::NULL_OPTION
+  end
+
+  def apply_rails_6_1_configs(application)
+    # Required in Rails 6
+    application.config.hosts << 'example.org'
   end
 end

--- a/instrumentation/rails/test/test_helpers/app_config.rb
+++ b/instrumentation/rails/test/test_helpers/app_config.rb
@@ -13,7 +13,7 @@ require 'test_helpers/routes'
 module AppConfig
   extend self
 
-  def initialize_app(use_exceptions_app: false, add_middlewares: true)
+  def initialize_app(use_exceptions_app: false, remove_rack_tracer_middleware: false)
     new_app = Application.new
     new_app.config.secret_key_base = 'secret_key_base'
 
@@ -28,6 +28,7 @@ module AppConfig
       apply_rails_6_0_configs(new_app)
     end
 
+    remove_rack_middleware(new_app) if remove_rack_tracer_middleware
     add_exceptions_app(new_app) if use_exceptions_app
     add_middlewares(new_app)
 
@@ -39,6 +40,12 @@ module AppConfig
   end
 
   private
+
+  def remove_rack_middleware(application)
+    application.middleware.delete(
+      OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware
+    )
+  end
 
   def add_exceptions_app(application)
     application.config.exceptions_app = lambda do |env|


### PR DESCRIPTION
Fixes appraisals to use the versions originally intended to be tested, also adds rails `6.1` to the appraisals.