### PR TITLE
feat: Structured error handling

### DIFF
--- a/api/lib/opentelemetry/instrumentation/registry.rb
+++ b/api/lib/opentelemetry/instrumentation/registry.rb
@@ -79,8 +79,7 @@ module OpenTelemetry
           OpenTelemetry.logger.warn "Instrumentation: #{instrumentation.name} failed to install"
         end
       rescue => e # rubocop:disable Style/RescueStandardError
-        OpenTelemetry.logger.warn "Instrumentation: #{instrumentation.name} unhandled exception " \
-                                  "during install #{e}: #{e.backtrace}"
+        OpenTelemetry.handle_error(exception: e, message: "Instrumentation: #{instrumentation.name} unhandled exception during install: #{e.backtrace}")
       end
     end
   end

--- a/exporter/jaeger/lib/opentelemetry/exporter/jaeger/collector_exporter.rb
+++ b/exporter/jaeger/lib/opentelemetry/exporter/jaeger/collector_exporter.rb
@@ -50,7 +50,7 @@ module OpenTelemetry
           end
           SUCCESS
         rescue StandardError => e
-          OpenTelemetry.logger.error("unexpected error in Jaeger::CollectorExporter#export - #{e}")
+          OpenTelemetry.handle_error(exception: e, message: 'unexpected error in Jaeger::CollectorExporter#export')
           FAILURE
         end
 

--- a/sdk/lib/opentelemetry/sdk.rb
+++ b/sdk/lib/opentelemetry/sdk.rb
@@ -18,6 +18,11 @@ module OpenTelemetry
   module SDK
     extend self
 
+    # ConfigurationError is an exception type used to wrap configuration errors
+    # passed to OpenTelemetry.error_handler. This can be used to distinguish
+    # errors reported during SDK configuration.
+    ConfigurationError = Class.new(OpenTelemetry::Error)
+
     # Configures SDK and instrumentation
     #
     # @yieldparam [Configurator] configurator Yields a configurator to the
@@ -57,6 +62,12 @@ module OpenTelemetry
       configurator = Configurator.new
       yield configurator if block_given?
       configurator.configure
+    rescue StandardError
+      begin
+        raise ConfigurationError
+      rescue ConfigurationError => e
+        OpenTelemetry.handle_error(exception: e, message: 'unexpected configuration error')
+      end
     end
   end
 end

--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -16,7 +16,7 @@ module OpenTelemetry
       private_constant :USE_MODE_UNSPECIFIED, :USE_MODE_ONE, :USE_MODE_ALL
 
       attr_writer :logger, :http_extractors, :http_injectors, :text_map_extractors,
-                  :text_map_injectors
+                  :text_map_injectors, :error_handler
 
       def initialize
         @instrumentation_names = []
@@ -32,6 +32,10 @@ module OpenTelemetry
 
       def logger
         @logger ||= OpenTelemetry.logger
+      end
+
+      def error_handler
+        @error_handler ||= OpenTelemetry.error_handler
       end
 
       # Accepts a resource object that is merged with the default telemetry sdk
@@ -110,6 +114,7 @@ module OpenTelemetry
       #   - install instrumentation
       def configure
         OpenTelemetry.logger = logger
+        OpenTelemetry.error_handler = error_handler
         OpenTelemetry.baggage = Baggage::Manager.new
         configure_propagation
         configure_span_processors

--- a/sdk/lib/opentelemetry/sdk/internal.rb
+++ b/sdk/lib/opentelemetry/sdk/internal.rb
@@ -45,7 +45,17 @@ module OpenTelemetry
       end
 
       def valid_attributes?(attrs)
-        attrs.nil? || attrs.all? { |k, v| valid_key?(k) && valid_value?(v) }
+        attrs.nil? || attrs.all? do |k, v|
+          if !valid_key?(k)
+            OpenTelemetry.handle_error(message: "invalid attribute key type #{v.class}")
+            false
+          elsif !valid_value?(v)
+            OpenTelemetry.handle_error(message: "invalid attribute value type #{v.class}")
+            false
+          else
+            true
+          end
+        end
       end
     end
   end

--- a/sdk/lib/opentelemetry/sdk/resources/resource.rb
+++ b/sdk/lib/opentelemetry/sdk/resources/resource.rb
@@ -22,7 +22,7 @@ module OpenTelemetry
           def create(attributes = {})
             frozen_attributes = attributes.each_with_object({}) do |(k, v), memo|
               raise ArgumentError, 'attribute keys must be strings' unless k.is_a?(String)
-              raise ArgumentError, 'attribute values must be strings, integers, floats, or booleans' unless Internal.valid_value?(v)
+              raise ArgumentError, 'attribute values must be (array of) strings, integers, floats, or booleans' unless Internal.valid_value?(v)
 
               memo[-k] = v.freeze
             end.freeze

--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -187,7 +187,7 @@ module OpenTelemetry
               @metrics_reporter.add_to_counter('otel.bsp.export.success')
               @metrics_reporter.add_to_counter('otel.bsp.exported_spans', increment: batch.size)
             else
-              OpenTelemetry.logger.error("Unable to export #{batch.size} spans")
+              OpenTelemetry.handle_error(message: "Unable to export #{batch.size} spans")
               @metrics_reporter.add_to_counter('otel.bsp.export.failure')
               report_dropped_spans(batch.size, reason: 'export-failure')
             end

--- a/sdk/lib/opentelemetry/sdk/trace/export/simple_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/simple_span_processor.rb
@@ -57,7 +57,7 @@ module OpenTelemetry
 
             @span_exporter&.export([span.to_span_data])
           rescue => e # rubocop:disable Style/RescueStandardError
-            OpenTelemetry.logger.error("unexpected error in span.on_finish - #{e}")
+            OpenTelemetry.handle_error(exception: e, message: 'unexpected error in span.on_finish')
           end
 
           # Export all ended spans to the configured `Exporter` that have not yet


### PR DESCRIPTION
Replaces #207 
Replaces #465 
Fixes #464 
Fixes #203 (maybe?)

This introduces a configurable error handling mechanism to the API, handles configuration errors by wrapping them in a `ConfigurationError` and passing it to the error handler, and validates attribute types when finishing an SDK span.

### TODO
- [x] tests
- [x] ~~decide whether we should have a distinguished error type for attribute validation errors, to allow an error handler to ignore or otherwise control logging volume~~ punting this to a later PR