### PR TITLE
fix: Implement SDK environment variables

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/config/trace_config.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/config/trace_config.rb
@@ -59,13 +59,13 @@ module OpenTelemetry
             case ENV['OTEL_TRACE_SAMPLER']
             when 'always_on' then Samplers::ALWAYS_ON
             when 'always_off' then Samplers::ALWAYS_OFF
-            when 'traceidratio' then Samplers.trace_id_ratio_based(Float(ENV['OTEL_TRACE_SAMPLER_ARG'], exception: false))
+            when 'traceidratio' then Samplers.trace_id_ratio_based(Float(ENV['OTEL_TRACE_SAMPLER_ARG']))
             when 'parentbased_always_on' then Samplers.parent_based(root: Samplers::ALWAYS_ON)
             when 'parentbased_always_off' then Samplers.parent_based(root: Samplers::ALWAYS_OFF)
-            when 'parentbased_traceidratio' then Samplers.parent_based(root: Samplers.trace_id_ratio_based(Float(ENV['OTEL_TRACE_SAMPLER_ARG'], exception: false)))
+            when 'parentbased_traceidratio' then Samplers.parent_based(root: Samplers.trace_id_ratio_based(Float(ENV['OTEL_TRACE_SAMPLER_ARG'])))
             else default_sampler
             end
-          rescue ArgumentError => e
+          rescue StandardError => e
             OpenTelemetry.handle_error(exception: e, message: "installing default sampler #{default_sampler.description}")
             default_sampler
           end

--- a/sdk/lib/opentelemetry/sdk/trace/config/trace_config.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/config/trace_config.rb
@@ -10,20 +10,6 @@ module OpenTelemetry
       module Config
         # Class that holds global trace parameters.
         class TraceConfig
-          DEFAULT_SAMPLER = Samplers.parent_based(root: Samplers::ALWAYS_ON)
-          DEFAULT_MAX_ATTRIBUTES_COUNT = 32
-          DEFAULT_MAX_EVENTS_COUNT = 128
-          DEFAULT_MAX_LINKS_COUNT = 32
-          DEFAULT_MAX_ATTRIBUTES_PER_EVENT = 32
-          DEFAULT_MAX_ATTRIBUTES_PER_LINK = 32
-
-          private_constant(:DEFAULT_SAMPLER,
-                           :DEFAULT_MAX_ATTRIBUTES_COUNT,
-                           :DEFAULT_MAX_EVENTS_COUNT,
-                           :DEFAULT_MAX_LINKS_COUNT,
-                           :DEFAULT_MAX_ATTRIBUTES_PER_EVENT,
-                           :DEFAULT_MAX_ATTRIBUTES_PER_LINK)
-
           # The global default sampler (see {Samplers}).
           attr_reader :sampler
 
@@ -46,12 +32,12 @@ module OpenTelemetry
           #
           # @return [TraceConfig] with the desired values.
           # @raise [ArgumentError] if any of the max numbers are not positive.
-          def initialize(sampler: DEFAULT_SAMPLER,
-                         max_attributes_count: DEFAULT_MAX_ATTRIBUTES_COUNT,
-                         max_events_count: DEFAULT_MAX_EVENTS_COUNT,
-                         max_links_count: DEFAULT_MAX_LINKS_COUNT,
-                         max_attributes_per_event: DEFAULT_MAX_ATTRIBUTES_PER_EVENT,
-                         max_attributes_per_link: DEFAULT_MAX_ATTRIBUTES_PER_LINK)
+          def initialize(sampler: sampler_from_environment(Samplers.parent_based(root: Samplers::ALWAYS_ON)),
+                         max_attributes_count: Integer(ENV.fetch('OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT', 1000)),
+                         max_events_count: Integer(ENV.fetch('OTEL_SPAN_EVENT_COUNT_LIMIT', 1000)),
+                         max_links_count: Integer(ENV.fetch('OTEL_SPAN_LINK_COUNT_LIMIT', 1000)),
+                         max_attributes_per_event: max_attributes_count,
+                         max_attributes_per_link: max_attributes_count)
             raise ArgumentError, 'max_attributes_count must be positive' unless max_attributes_count.positive?
             raise ArgumentError, 'max_events_count must be positive' unless max_events_count.positive?
             raise ArgumentError, 'max_links_count must be positive' unless max_links_count.positive?
@@ -67,6 +53,22 @@ module OpenTelemetry
           end
 
           # TODO: from_proto
+          private
+
+          def sampler_from_environment(default_sampler) # rubocop:disable Metrics/CyclomaticComplexity
+            case ENV['OTEL_TRACE_SAMPLER']
+            when 'always_on' then Samplers::ALWAYS_ON
+            when 'always_off' then Samplers::ALWAYS_OFF
+            when 'traceidratio' then Samplers.trace_id_ratio_based(Float(ENV['OTEL_TRACE_SAMPLER_ARG'], exception: false))
+            when 'parentbased_always_on' then Samplers.parent_based(root: Samplers::ALWAYS_ON)
+            when 'parentbased_always_off' then Samplers.parent_based(root: Samplers::ALWAYS_OFF)
+            when 'parentbased_traceidratio' then Samplers.parent_based(root: Samplers.trace_id_ratio_based(Float(ENV['OTEL_TRACE_SAMPLER_ARG'], exception: false)))
+            else default_sampler
+            end
+          rescue ArgumentError => e
+            OpenTelemetry.handle_error(exception: e, message: "installing default sampler #{default_sampler.description}")
+            default_sampler
+          end
 
           # The default {TraceConfig}.
           DEFAULT = new

--- a/sdk/lib/opentelemetry/sdk/trace/samplers/constant_sampler.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/samplers/constant_sampler.rb
@@ -19,12 +19,20 @@ module OpenTelemetry
             @description = description
           end
 
+          def ==(other)
+            @decision == other.decision && @description == other.description
+          end
+
           # @api private
           #
           # See {Samplers}.
           def should_sample?(trace_id:, parent_context:, links:, name:, kind:, attributes:)
             Result.new(decision: @decision, tracestate: OpenTelemetry::Trace.current_span(parent_context).context.tracestate)
           end
+
+          protected
+
+          attr_reader :decision
         end
       end
     end

--- a/sdk/lib/opentelemetry/sdk/trace/samplers/parent_based.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/samplers/parent_based.rb
@@ -26,6 +26,14 @@ module OpenTelemetry
             @local_parent_not_sampled = local_parent_not_sampled
           end
 
+          def ==(other)
+            @root == other.root &&
+              @remote_parent_sampled == other.remote_parent_sampled &&
+              @remote_parent_not_sampled == other.remote_parent_not_sampled &&
+              @local_parent_sampled == other.local_parent_sampled &&
+              @local_parent_not_sampled == other.local_parent_not_sampled
+          end
+
           # @api private
           #
           # See {Samplers}.
@@ -47,6 +55,10 @@ module OpenTelemetry
                        end
             delegate.should_sample?(trace_id: trace_id, parent_context: parent_context, links: links, name: name, kind: kind, attributes: attributes)
           end
+
+          protected
+
+          attr_reader :root, :remote_parent_sampled, :remote_parent_not_sampled, :local_parent_sampled, :local_parent_not_sampled
         end
       end
     end

--- a/sdk/lib/opentelemetry/sdk/trace/samplers/trace_id_ratio_based.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/samplers/trace_id_ratio_based.rb
@@ -20,6 +20,10 @@ module OpenTelemetry
             @description = format('TraceIdRatioBased{%.6f}', probability)
           end
 
+          def ==(other)
+            @description == other.description
+          end
+
           # @api private
           #
           # See {Samplers}.

--- a/sdk/test/opentelemetry/sdk/trace/config/trace_config_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/config/trace_config_test.rb
@@ -77,9 +77,13 @@ describe OpenTelemetry::SDK::Trace::Config::TraceConfig do
     end
 
     it 'requires OTEL_TRACE_SAMPLER_ARG for traceidratio' do
+      sampler = with_env('OTEL_TRACE_SAMPLER' => 'traceidratio') { trace_config.new.sampler }
+      _(sampler).must_equal trace_config::DEFAULT.sampler
     end
 
     it 'requires OTEL_TRACE_SAMPLER_ARG for parentbased_traceidratio' do
+      sampler = with_env('OTEL_TRACE_SAMPLER' => 'parentbased_traceidratio') { trace_config.new.sampler }
+      _(sampler).must_equal trace_config::DEFAULT.sampler
     end
   end
 end

--- a/sdk/test/opentelemetry/sdk/trace/config/trace_config_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/config/trace_config_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+describe OpenTelemetry::SDK::Trace::Config::TraceConfig do
+  let(:trace_config) { OpenTelemetry::SDK::Trace::Config::TraceConfig }
+  let(:samplers) { OpenTelemetry::SDK::Trace::Samplers }
+
+  describe '#initialize' do
+    it 'provides defaults' do
+      config = trace_config.new
+      _(config.sampler).must_equal samplers.parent_based(root: samplers::ALWAYS_ON)
+      _(config.max_attributes_count).must_equal 1000
+      _(config.max_events_count).must_equal 1000
+      _(config.max_links_count).must_equal 1000
+      _(config.max_attributes_per_event).must_equal 1000
+      _(config.max_attributes_per_link).must_equal 1000
+    end
+
+    it 'reflects environment variables' do
+      with_env('OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT' => '1',
+               'OTEL_SPAN_EVENT_COUNT_LIMIT' => '2',
+               'OTEL_SPAN_LINK_COUNT_LIMIT' => '3',
+               'OTEL_TRACE_SAMPLER' => 'always_on') do
+        config = trace_config.new
+        _(config.sampler).must_equal samplers::ALWAYS_ON
+        _(config.max_attributes_count).must_equal 1
+        _(config.max_events_count).must_equal 2
+        _(config.max_links_count).must_equal 3
+        _(config.max_attributes_per_event).must_equal 1
+        _(config.max_attributes_per_link).must_equal 1
+      end
+    end
+
+    it 'reflects explicit overrides' do
+      with_env('OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT' => '1',
+               'OTEL_SPAN_EVENT_COUNT_LIMIT' => '2',
+               'OTEL_SPAN_LINK_COUNT_LIMIT' => '3',
+               'OTEL_TRACE_SAMPLER' => 'always_on') do
+        config = trace_config.new(sampler: samplers::ALWAYS_OFF,
+                                  max_attributes_count: 10,
+                                  max_events_count: 11,
+                                  max_links_count: 12,
+                                  max_attributes_per_event: 13,
+                                  max_attributes_per_link: 14)
+        _(config.sampler).must_equal samplers::ALWAYS_OFF
+        _(config.max_attributes_count).must_equal 10
+        _(config.max_events_count).must_equal 11
+        _(config.max_links_count).must_equal 12
+        _(config.max_attributes_per_event).must_equal 13
+        _(config.max_attributes_per_link).must_equal 14
+      end
+    end
+
+    it 'configures samplers from environment' do
+      sampler = with_env('OTEL_TRACE_SAMPLER' => 'always_on') { trace_config.new.sampler }
+      _(sampler).must_equal samplers::ALWAYS_ON
+
+      sampler = with_env('OTEL_TRACE_SAMPLER' => 'always_off') { trace_config.new.sampler }
+      _(sampler).must_equal samplers::ALWAYS_OFF
+
+      sampler = with_env('OTEL_TRACE_SAMPLER' => 'traceidratio', 'OTEL_TRACE_SAMPLER_ARG' => '0.1') { trace_config.new.sampler }
+      _(sampler).must_equal samplers.trace_id_ratio_based(0.1)
+
+      sampler = with_env('OTEL_TRACE_SAMPLER' => 'parentbased_always_on') { trace_config.new.sampler }
+      _(sampler).must_equal samplers.parent_based(root: samplers::ALWAYS_ON)
+
+      sampler = with_env('OTEL_TRACE_SAMPLER' => 'parentbased_always_off') { trace_config.new.sampler }
+      _(sampler).must_equal samplers.parent_based(root: samplers::ALWAYS_OFF)
+
+      sampler = with_env('OTEL_TRACE_SAMPLER' => 'parentbased_traceidratio', 'OTEL_TRACE_SAMPLER_ARG' => '0.2') { trace_config.new.sampler }
+      _(sampler).must_equal samplers.parent_based(root: samplers.trace_id_ratio_based(0.2))
+    end
+
+    it 'requires OTEL_TRACE_SAMPLER_ARG for traceidratio' do
+    end
+
+    it 'requires OTEL_TRACE_SAMPLER_ARG for parentbased_traceidratio' do
+    end
+  end
+end


### PR DESCRIPTION
Fixes #525 and also implements `OTEL_SPAN_*_COUNT_LIMIT` environment variables.

Depends on #521.

Also needs tests.