### PR TITLE
fix: remove incorrect TODO

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/span.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span.rb
@@ -279,9 +279,7 @@ module OpenTelemetry
           return if attrs.nil?
 
           excess = attrs.size - @trace_config.max_attributes_count
-          # TODO: with Ruby 2.5, replace with the more efficient
-          # attrs.shift(excess) if excess.positive?
-          excess.times { attrs.shift } if excess.positive?
+          attrs.shift(excess) if excess.positive?
           nil
         end
 

--- a/sdk/lib/opentelemetry/sdk/trace/span.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span.rb
@@ -279,7 +279,7 @@ module OpenTelemetry
           return if attrs.nil?
 
           excess = attrs.size - @trace_config.max_attributes_count
-          attrs.shift(excess) if excess.positive?
+          excess.times { attrs.shift } if excess.positive?
           nil
         end
 


### PR DESCRIPTION
This fixes a TODO in the codebase for a perf improvement that only works on Ruby 2.5 and above. We removed support for Ruby 2.4 awhile back, so we can use this enhancement now.