### PR TITLE
"all" gem is missing ruby_kafka

### DIFF
--- a/instrumentation/all/Gemfile
+++ b/instrumentation/all/Gemfile
@@ -25,6 +25,7 @@ gem 'opentelemetry-instrumentation-rack', path: '../rack'
 gem 'opentelemetry-instrumentation-rails', path: '../rails'
 gem 'opentelemetry-instrumentation-redis', path: '../redis'
 gem 'opentelemetry-instrumentation-restclient', path: '../restclient'
+gem 'opentelemetry-instrumentation-ruby_kafka', path: '../ruby_kafka'
 gem 'opentelemetry-instrumentation-sidekiq', path: '../sidekiq'
 gem 'opentelemetry-instrumentation-sinatra', path: '../sinatra'
 

--- a/instrumentation/all/lib/opentelemetry/instrumentation/all.rb
+++ b/instrumentation/all/lib/opentelemetry/instrumentation/all.rb
@@ -19,6 +19,7 @@ require 'opentelemetry-instrumentation-rack'
 require 'opentelemetry-instrumentation-rails'
 require 'opentelemetry-instrumentation-redis'
 require 'opentelemetry-instrumentation-restclient'
+require 'opentelemetry-instrumentation-ruby_kafka'
 require 'opentelemetry-instrumentation-sidekiq'
 require 'opentelemetry-instrumentation-sinatra'
 

--- a/instrumentation/all/opentelemetry-instrumentation-all.gemspec
+++ b/instrumentation/all/opentelemetry-instrumentation-all.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-instrumentation-rails', '~> 0.12.0'
   spec.add_dependency 'opentelemetry-instrumentation-redis', '~> 0.12.0'
   spec.add_dependency 'opentelemetry-instrumentation-restclient', '~> 0.12.0'
+  spec.add_dependency 'opentelemetry-instrumentation-ruby_kafka', '~> 0.12.0'
   spec.add_dependency 'opentelemetry-instrumentation-sidekiq', '~> 0.12.0'
   spec.add_dependency 'opentelemetry-instrumentation-sinatra', '~> 0.12.0'
 


### PR DESCRIPTION
It would be nice if the release process could automatically update the `all` instrumentation gem so that this is not missed in the future.

Please cut a release (0.12.1?) after merging.