### PR TITLE
Fix protobuf version dependency

### DIFF
--- a/exporter/otlp/opentelemetry-exporter-otlp.gemspec
+++ b/exporter/otlp/opentelemetry-exporter-otlp.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.5.0'
 
-  spec.add_dependency 'google-protobuf', '>= 3.7.0', '< 4'
+  spec.add_dependency 'google-protobuf', '~> 3.7'
   spec.add_dependency 'opentelemetry-api', '~> 0.12.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.12.0'
 

--- a/exporter/otlp/opentelemetry-exporter-otlp.gemspec
+++ b/exporter/otlp/opentelemetry-exporter-otlp.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.5.0'
 
-  spec.add_dependency 'google-protobuf', '>= 3.4.1.1', '< 4'
+  spec.add_dependency 'google-protobuf', '>= 3.7.0', '< 4'
   spec.add_dependency 'opentelemetry-api', '~> 0.12.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.12.0'
 


### PR DESCRIPTION
Some of the compiled *_pb.rb files included for OTLP exporter is having `add_file` method and its definition is available only from [google-protobuf >= 3.7.0](https://github.com/protocolbuffers/protobuf/blob/v3.7.0/ruby/ext/google/protobuf_c/defs.c#L2124)
```ruby
  Google::Protobuf::DescriptorPool.generated_pool.build do
    add_file("{path_to_proto_file}", :syntax => :proto3) do
      ...
    end
  end
  ```
  
  `add_file` is currently used in the below files:
- https://github.com/open-telemetry/opentelemetry-ruby/blob/master/exporter/otlp/lib/opentelemetry/proto/collector/trace/v1/trace_service_pb.rb#L8
- https://github.com/open-telemetry/opentelemetry-ruby/blob/master/exporter/otlp/lib/opentelemetry/proto/common/v1/common_pb.rb#L7
- https://github.com/open-telemetry/opentelemetry-ruby/blob/master/exporter/otlp/lib/opentelemetry/proto/resource/v1/resource_pb.rb
- https://github.com/open-telemetry/opentelemetry-ruby/blob/master/exporter/otlp/lib/opentelemetry/proto/trace/v1/trace_pb.rb#L9
  