### PR TITLE
chore: Add Ruby 3.0 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
           - name: Ruby 2.7
             container: circleci/ruby:2.7-buster
             flags: --include-simple --include-appraisal --check-rubocop --check-yard
+          - name: Ruby 3.0
+            container: circleci/ruby:3.0-buster
+            flags: --include-simple --include-appraisal --exclude opentelemetry-exporter-otlp
           - name: JRuby
             container: circleci/jruby:latest
             flags: --include-simple --exclude opentelemetry-resource_detectors --exclude opentelemetry-exporter-otlp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
             flags: --include-simple --include-appraisal --check-rubocop --check-yard
           - name: Ruby 3.0
             container: circleci/ruby:3.0-buster
-            flags: --include-simple --include-appraisal --exclude opentelemetry-exporter-otlp --exclude opentelemetry-instrumentation-excon --exclude opentelemetry-instrumentation-faraday --exclude opentelemetry-instrumentation-graphql
+            flags: --include-simple --include-appraisal --exclude opentelemetry-exporter-otlp --exclude opentelemetry-instrumentation-excon --exclude opentelemetry-instrumentation-faraday --exclude opentelemetry-instrumentation-graphql --exclude opentelemetry-instrumentation-rails
           - name: JRuby
             container: circleci/jruby:latest
             flags: --include-simple --exclude opentelemetry-resource_detectors --exclude opentelemetry-exporter-otlp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
             flags: --include-simple --include-appraisal --check-rubocop --check-yard
           - name: Ruby 3.0
             container: circleci/ruby:3.0-buster
-            flags: --include-simple --include-appraisal --exclude opentelemetry-exporter-otlp --exclude opentelemetry-instrumentation-excon --exclude opentelemetry-instrumentation-faraday --exclude opentelemetry-instrumentation-graphql
+            flags: --include-simple --include-appraisal --exclude opentelemetry-exporter-otlp
           - name: JRuby
             container: circleci/jruby:latest
             flags: --include-simple --exclude opentelemetry-resource_detectors --exclude opentelemetry-exporter-otlp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
             flags: --include-simple --include-appraisal --check-rubocop --check-yard
           - name: Ruby 3.0
             container: circleci/ruby:3.0-buster
-            flags: --include-simple --include-appraisal --exclude opentelemetry-exporter-otlp
+            flags: --include-simple --include-appraisal --exclude opentelemetry-exporter-otlp --exclude opentelemetry-instrumentation-excon --exclude opentelemetry-instrumentation-faraday
           - name: JRuby
             container: circleci/jruby:latest
             flags: --include-simple --exclude opentelemetry-resource_detectors --exclude opentelemetry-exporter-otlp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
             flags: --include-simple --include-appraisal --check-rubocop --check-yard
           - name: Ruby 3.0
             container: circleci/ruby:3.0-buster
-            flags: --include-simple --include-appraisal --exclude opentelemetry-exporter-otlp --exclude opentelemetry-instrumentation-excon --exclude opentelemetry-instrumentation-faraday
+            flags: --include-simple --include-appraisal --exclude opentelemetry-exporter-otlp --exclude opentelemetry-instrumentation-excon --exclude opentelemetry-instrumentation-faraday --exclude opentelemetry-instrumentation-graphql
           - name: JRuby
             container: circleci/jruby:latest
             flags: --include-simple --exclude opentelemetry-resource_detectors --exclude opentelemetry-exporter-otlp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
             flags: --include-simple --include-appraisal --check-rubocop --check-yard
           - name: Ruby 3.0
             container: circleci/ruby:3.0-buster
-            flags: --include-simple --include-appraisal --exclude opentelemetry-exporter-otlp --exclude opentelemetry-instrumentation-excon --exclude opentelemetry-instrumentation-faraday --exclude opentelemetry-instrumentation-graphql --exclude opentelemetry-instrumentation-rails
+            flags: --include-simple --include-appraisal --exclude opentelemetry-exporter-otlp --exclude opentelemetry-instrumentation-excon --exclude opentelemetry-instrumentation-faraday --exclude opentelemetry-instrumentation-graphql
           - name: JRuby
             container: circleci/jruby:latest
             flags: --include-simple --exclude opentelemetry-resource_detectors --exclude opentelemetry-exporter-otlp

--- a/common/test/opentelemetry/common/http_client_context_test.rb
+++ b/common/test/opentelemetry/common/http_client_context_test.rb
@@ -86,7 +86,7 @@ describe OpenTelemetry::Common::HTTP::ClientContext do
 
   describe '#context_with_attributes' do
     it 'returns a context containing attributes' do
-      ctx = client_context.context_with_attributes('foo' => 'bar')
+      ctx = client_context.context_with_attributes({ 'foo' => 'bar' })
       _(client_context.attributes(ctx)).must_equal('foo' => 'bar')
     end
 

--- a/common/test/opentelemetry/common/http_client_context_test.rb
+++ b/common/test/opentelemetry/common/http_client_context_test.rb
@@ -86,8 +86,9 @@ describe OpenTelemetry::Common::HTTP::ClientContext do
 
   describe '#context_with_attributes' do
     it 'returns a context containing attributes' do
-      ctx = client_context.context_with_attributes({ 'foo' => 'bar' })
-      _(client_context.attributes(ctx)).must_equal('foo' => 'bar')
+      attrs = { 'foo' => 'bar' }
+      ctx = client_context.context_with_attributes(attrs)
+      _(client_context.attributes(ctx)).must_equal(attrs)
     end
 
     it 'returns a context containing attributes' do

--- a/instrumentation/excon/Appraisals
+++ b/instrumentation/excon/Appraisals
@@ -4,6 +4,8 @@ appraise 'excon-0.71' do
   gem 'excon', '~> 0.71.0'
 end
 
-appraise 'excon-0.64' do
-  gem 'excon', '~> 0.64.0'
-end
+# Disabling excon 0.64 for now because it seems to be incompatible with Ruby 3.
+# TODO: Decide whether we still need to test against it.
+# appraise 'excon-0.64' do
+#   gem 'excon', '~> 0.64.0'
+# end

--- a/instrumentation/excon/Appraisals
+++ b/instrumentation/excon/Appraisals
@@ -4,6 +4,7 @@ appraise 'excon-0.71' do
   gem 'excon', '~> 0.71.0'
 end
 
+# Incompatible with Ruby 3.0.0 (https://bugs.ruby-lang.org/issues/10499)
 appraise 'excon-0.64' do
   gem 'excon', '~> 0.64.0'
-end
+end if RUBY_VERSION < '3'

--- a/instrumentation/excon/Appraisals
+++ b/instrumentation/excon/Appraisals
@@ -5,6 +5,8 @@ appraise 'excon-0.71' do
 end
 
 # Incompatible with Ruby 3.0.0 (https://bugs.ruby-lang.org/issues/10499)
-appraise 'excon-0.64' do
-  gem 'excon', '~> 0.64.0'
-end if RUBY_VERSION < '3'
+if RUBY_VERSION < '3'
+  appraise 'excon-0.64' do
+    gem 'excon', '~> 0.64.0'
+  end
+end

--- a/instrumentation/excon/Appraisals
+++ b/instrumentation/excon/Appraisals
@@ -4,8 +4,6 @@ appraise 'excon-0.71' do
   gem 'excon', '~> 0.71.0'
 end
 
-# Disabling excon 0.64 for now because it seems to be incompatible with Ruby 3.
-# TODO: Decide whether we still need to test against it.
-# appraise 'excon-0.64' do
-#   gem 'excon', '~> 0.64.0'
-# end
+appraise 'excon-0.64' do
+  gem 'excon', '~> 0.64.0'
+end

--- a/instrumentation/faraday/Appraisals
+++ b/instrumentation/faraday/Appraisals
@@ -9,15 +9,19 @@ appraise 'faraday-1.0' do
 end
 
 # Incompatible with Ruby 3.0.0 (https://bugs.ruby-lang.org/issues/10499)
-appraise 'faraday-0.17' do
-  gem 'faraday', '0.17.0'
-end if RUBY_VERSION < '3'
+if RUBY_VERSION < '3'
+  appraise 'faraday-0.17' do
+    gem 'faraday', '0.17.0'
+  end
+end
 
 appraise 'faraday-0.16' do
   gem 'faraday', '0.16.2'
 end
 
 # Incompatible with Ruby 3.0.0 (https://bugs.ruby-lang.org/issues/10499)
-appraise 'faraday-0.13' do
-  gem 'faraday', '0.13.1'
-end if RUBY_VERSION < '3'
+if RUBY_VERSION < '3'
+  appraise 'faraday-0.13' do
+    gem 'faraday', '0.13.1'
+  end
+end

--- a/instrumentation/faraday/Appraisals
+++ b/instrumentation/faraday/Appraisals
@@ -8,14 +8,16 @@ appraise 'faraday-1.0' do
   gem 'faraday', '~> 1.0.0'
 end
 
+# Incompatible with Ruby 3.0.0 (https://bugs.ruby-lang.org/issues/10499)
 appraise 'faraday-0.17' do
   gem 'faraday', '0.17.0'
-end
+end if RUBY_VERSION < '3'
 
 appraise 'faraday-0.16' do
   gem 'faraday', '0.16.2'
 end
 
+# Incompatible with Ruby 3.0.0 (https://bugs.ruby-lang.org/issues/10499)
 appraise 'faraday-0.13' do
   gem 'faraday', '0.13.1'
-end
+end if RUBY_VERSION < '3'

--- a/instrumentation/graphql/Appraisals
+++ b/instrumentation/graphql/Appraisals
@@ -12,6 +12,9 @@ appraise 'graphql-1.10' do
   gem 'graphql', '~> 1.10.0'
 end
 
-appraise 'graphql-1.9' do
-  gem 'graphql', '~> 1.9.0'
+# Incompatible with Ruby 3.0.0 (https://bugs.ruby-lang.org/issues/10499)
+if RUBY_VERSION < '3'
+  appraise 'graphql-1.9' do
+    gem 'graphql', '~> 1.9.0'
+  end
 end

--- a/instrumentation/rails/Appraisals
+++ b/instrumentation/rails/Appraisals
@@ -4,11 +4,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-if RUBY_VERSION < '3'
-  appraise 'rails-5.2' do
-    gem 'rails', '~> 5.2.0'
-  end
-end
+# Rails 5.2 is incompatible with Ruby 3.
+appraise 'rails-5.2' do
+  gem 'rails', '~> 5.2.0'
+end if RUBY_VERSION < '3'
 
 appraise 'rails-6.0' do
   gem 'rails', '~> 6.0.0'

--- a/instrumentation/rails/Appraisals
+++ b/instrumentation/rails/Appraisals
@@ -5,9 +5,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Rails 5.2 is incompatible with Ruby 3.
-appraise 'rails-5.2' do
-  gem 'rails', '~> 5.2.0'
-end if RUBY_VERSION < '3'
+if RUBY_VERSION < '3'
+  appraise 'rails-5.2' do
+    gem 'rails', '~> 5.2.0'
+  end
+end
 
 appraise 'rails-6.0' do
   gem 'rails', '~> 6.0.0'

--- a/instrumentation/rails/Appraisals
+++ b/instrumentation/rails/Appraisals
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-if RUBY_VERSION < "3"
+if RUBY_VERSION < '3'
   appraise 'rails-5.2' do
     gem 'rails', '~> 5.2.0'
   end

--- a/instrumentation/rails/Appraisals
+++ b/instrumentation/rails/Appraisals
@@ -4,8 +4,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-appraise 'rails-5.2' do
-  gem 'rails', '~> 5.2.0'
+if RUBY_VERSION < "3"
+  appraise 'rails-5.2' do
+    gem 'rails', '~> 5.2.0'
+  end
 end
 
 appraise 'rails-6.0' do

--- a/instrumentation/redis/test/opentelemetry/instrumentation/redis_test.rb
+++ b/instrumentation/redis/test/opentelemetry/instrumentation/redis_test.rb
@@ -86,8 +86,9 @@ describe OpenTelemetry::Instrumentation::Redis do
 
   describe '#context_with_attributes' do
     it 'returns a context containing attributes' do
-      ctx = redis.context_with_attributes('foo' => 'bar')
-      _(redis.attributes(ctx)).must_equal('foo' => 'bar')
+      attrs = { 'foo' => 'bar' }
+      ctx = redis.context_with_attributes(attrs)
+      _(redis.attributes(ctx)).must_equal(attrs)
     end
 
     it 'returns a context containing attributes' do

--- a/instrumentation/ruby_kafka/Appraisals
+++ b/instrumentation/ruby_kafka/Appraisals
@@ -8,8 +8,10 @@ appraise 'ruby-kafka-1.3.0' do
   gem 'ruby-kafka', '~> 1.3.0'
 end
 
-appraise 'ruby-kafka-1.2.0' do
-  gem 'ruby-kafka', '~> 1.2.0'
+if RUBY_VERSION < '3'
+  appraise 'ruby-kafka-1.2.0' do
+    gem 'ruby-kafka', '~> 1.2.0'
+  end
 end
 
 appraise 'ruby-kafka-1.1.0' do

--- a/instrumentation/ruby_kafka/Appraisals
+++ b/instrumentation/ruby_kafka/Appraisals
@@ -8,16 +8,17 @@ appraise 'ruby-kafka-1.3.0' do
   gem 'ruby-kafka', '~> 1.3.0'
 end
 
+# Producer test is timing out on Ruby 3
 if RUBY_VERSION < '3'
   appraise 'ruby-kafka-1.2.0' do
     gem 'ruby-kafka', '~> 1.2.0'
   end
-end
 
-appraise 'ruby-kafka-1.1.0' do
-  gem 'ruby-kafka', '~> 1.1.0'
-end
+  appraise 'ruby-kafka-1.1.0' do
+    gem 'ruby-kafka', '~> 1.1.0'
+  end
 
-appraise 'ruby-kafka-1.0.0' do
-  gem 'ruby-kafka', '~> 1.0.0'
+  appraise 'ruby-kafka-1.0.0' do
+    gem 'ruby-kafka', '~> 1.0.0'
+  end
 end

--- a/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/patches/producer_test.rb
+++ b/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/patches/producer_test.rb
@@ -63,7 +63,7 @@ describe OpenTelemetry::Instrumentation::RubyKafka::Patches::Producer do
       async_producer.deliver_messages
 
       # Wait for the async calls to produce spans
-      wait_for(error_message: 'Max wait time exceeded for async producer') { EXPORTER.finished_spans.size.positive? }
+      wait_for(error_message: 'Max wait time exceeded for async producer', retry_delay: 1.0) { EXPORTER.finished_spans.size.positive? }
 
       _(spans.first.name).must_equal("#{async_topic} send")
       _(spans.first.kind).must_equal(:producer)

--- a/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/patches/producer_test.rb
+++ b/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/patches/producer_test.rb
@@ -63,7 +63,7 @@ describe OpenTelemetry::Instrumentation::RubyKafka::Patches::Producer do
       async_producer.deliver_messages
 
       # Wait for the async calls to produce spans
-      wait_for(error_message: 'Max wait time exceeded for async producer', retry_delay: 1.0) { EXPORTER.finished_spans.size.positive? }
+      wait_for(error_message: 'Max wait time exceeded for async producer') { EXPORTER.finished_spans.size.positive? }
 
       _(spans.first.name).must_equal("#{async_topic} send")
       _(spans.first.kind).must_equal(:producer)

--- a/instrumentation/sinatra/Appraisals
+++ b/instrumentation/sinatra/Appraisals
@@ -4,8 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-appraise 'sinatra-2.0' do
-  gem 'sinatra', '2.0.7'
+appraise 'sinatra-2.1' do
+  gem 'sinatra', '2.1.0'
 end
 
 appraise 'sinatra-1.4' do

--- a/instrumentation/sinatra/gemfiles/sinatra_2.1.gemfile
+++ b/instrumentation/sinatra/gemfiles/sinatra_2.1.gemfile
@@ -3,9 +3,10 @@
 source "https://rubygems.org"
 
 gem "opentelemetry-api", path: "../../../api"
-gem "sinatra", "2.0.7"
+gem "sinatra", "2.1.0"
 
 group :test do
+  gem "opentelemetry-common", path: "../../../common"
   gem "opentelemetry-sdk", path: "../../../sdk"
 end
 


### PR DESCRIPTION
Closes #533 

Caveats:

* Currently, the Ruby 3.0 test omits the otlp exporter, because google-protobuf is not yet compatible with Ruby 3.
* The Ruby 3.0 test also omits versions of ruby-kafka older than 1.3 because of an unexplained test failure. It's possible the libraries are incompatible with Ruby 3, but I'd like to get a separate opinion on that since I'm not familiar with ruby-kafka.

Notes:

* Updated Appraisals of excon, faraday, and graphql instrumentation to omit versions that run afoul of what appears to be a Ruby 3 regression (https://bugs.ruby-lang.org/issues/10499)
* Updated the Appraisal for instrumentation-rails to omit Rails 5.2 under Ruby 3 because of keyword argument compatibility.
* Updated the Appraisal of sinatra to use 2.1 instead of 2.0.7 because of Ruby 3 keyword argument compatibility.
* Fixed test cases in common and instrumentation-redis that ran afoul of Ruby 3's keyword argument change.