### PR TITLE
fix(api): Eliminate warning about Random::DEFAULT on Ruby 3.0

### DIFF
--- a/api/lib/opentelemetry/trace.rb
+++ b/api/lib/opentelemetry/trace.rb
@@ -16,7 +16,7 @@ module OpenTelemetry
     # Random number generator for generating IDs. This is an object that can
     # respond to `#bytes` and uses the system PRNG. The current logic is
     # compatible with Ruby 2.5 (which does not implement the `Random.bytes`
-    # class method) and with Ruby 3.0+ (which deprecates `Random::DEFAULT`). 
+    # class method) and with Ruby 3.0+ (which deprecates `Random::DEFAULT`).
     # When we drop support for Ruby 2.5, this can simply be replaced with
     # the class `Random`.
     #

--- a/api/lib/opentelemetry/trace.rb
+++ b/api/lib/opentelemetry/trace.rb
@@ -13,7 +13,17 @@ module OpenTelemetry
 
     CURRENT_SPAN_KEY = Context.create_key('current-span')
 
-    private_constant :CURRENT_SPAN_KEY
+    # Random number generator for generating IDs. This is an object that can
+    # respond to `#bytes` and uses the system PRNG. The current logic is
+    # compatible with Ruby 2.5 (which does not implement the `Random.bytes`
+    # class method) and with Ruby 3.0+ (which deprecates `Random::DEFAULT`). 
+    # When we drop support for Ruby 2.5, this can simply be replaced with
+    # the class `Random`.
+    #
+    # @return [#bytes]
+    RANDOM = Random.respond_to?(:bytes) ? Random : Random::DEFAULT
+
+    private_constant :CURRENT_SPAN_KEY, :RANDOM
 
     # An invalid trace identifier, a 16-byte string with all zero bytes.
     INVALID_TRACE_ID = ("\0" * 16).b
@@ -27,7 +37,7 @@ module OpenTelemetry
     # @return [String] a valid trace ID.
     def generate_trace_id
       loop do
-        id = Random::DEFAULT.bytes(16)
+        id = RANDOM.bytes(16)
         return id unless id == INVALID_TRACE_ID
       end
     end
@@ -38,7 +48,7 @@ module OpenTelemetry
     # @return [String] a valid span ID.
     def generate_span_id
       loop do
-        id = Random::DEFAULT.bytes(8)
+        id = RANDOM.bytes(8)
         return id unless id == INVALID_SPAN_ID
       end
     end


### PR DESCRIPTION
Fix a warning reported in #533 by choosing a random number provider based on the implemented methods.