### PR TITLE
fix(sdk): Fix several BatchSpanProcessor errors related to fork safety

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -137,7 +137,6 @@ module OpenTelemetry
           def shutdown(timeout: nil)
             start_time = Time.now
             thread = lock do
-              reset_on_fork(restart_thread: false)
               @keep_running = false
               @condition.signal
               @thread

--- a/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
@@ -185,6 +185,11 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
 
       _(bsp.instance_variable_get(:@spans).size).must_equal(1)
     end
+
+    it 'works if the thread is not running' do
+      bsp = BatchSpanProcessor.new(exporter: TestExporter.new, start_thread_on_boot: false)
+      bsp.shutdown(timeout: 0)
+    end
   end
 
   describe 'lifecycle' do
@@ -290,17 +295,40 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
     end
 
     describe 'when a process fork occurs' do
-      it 'creates new work thread' do
+      it 'creates new work thread when on_finish is called' do
         parent_pid = bsp.instance_variable_get(:@pid)
         parent_work_thread_id = bsp.instance_variable_get(:@thread).object_id
         Process.stub(:pid, parent_pid + rand(1..10)) do
           # Start a new span on the forked process and export it.
           bsp.on_finish(TestSpan.new)
-          bsp.shutdown
           current_pid = bsp.instance_variable_get(:@pid)
           current_work_thread_id = bsp.instance_variable_get(:@thread).object_id
           _(parent_pid).wont_equal current_pid
           _(parent_work_thread_id).wont_equal current_work_thread_id
+        end
+      end
+
+      it 'creates new work thread when force_flush' do
+        parent_pid = bsp.instance_variable_get(:@pid)
+        parent_work_thread_id = bsp.instance_variable_get(:@thread).object_id
+        Process.stub(:pid, parent_pid + rand(1..10)) do
+          # Force flush on the forked process.
+          bsp.force_flush
+          current_pid = bsp.instance_variable_get(:@pid)
+          current_work_thread_id = bsp.instance_variable_get(:@thread).object_id
+          _(parent_pid).wont_equal current_pid
+          _(parent_work_thread_id).wont_equal current_work_thread_id
+        end
+      end
+
+      it 'shuts down gracefully if the thread has not yet been restarted' do
+        parent_pid = bsp.instance_variable_get(:@pid)
+        parent_work_thread = bsp.instance_variable_get(:@thread)
+        Process.stub(:pid, parent_pid + rand(1..10)) do
+          # Simulate the thread being disconnected
+          parent_work_thread.stub(:join, proc { raise 'Tried to join disconnected thread!' }) do
+            bsp.shutdown
+          end
         end
       end
     end

--- a/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
@@ -320,17 +320,6 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
           _(parent_work_thread_id).wont_equal current_work_thread_id
         end
       end
-
-      it 'shuts down gracefully if the thread has not yet been restarted' do
-        parent_pid = bsp.instance_variable_get(:@pid)
-        parent_work_thread = bsp.instance_variable_get(:@thread)
-        Process.stub(:pid, parent_pid + rand(1..10)) do
-          # Simulate the thread being disconnected
-          parent_work_thread.stub(:join, proc { raise 'Tried to join disconnected thread!' }) do
-            bsp.shutdown
-          end
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
This fixes several issues that I noticed when running Ruby 3.0 tests.

### Removed the call to `reset_on_fork` from the thread worker code.

This call is redundant because worker threads go away in a forked child process. In fact, the presence of the call is causing the fork safety test to flake (https://github.com/open-telemetry/opentelemetry-ruby/runs/1642237548). AFAICT the sequence of events is this:

* BatchSpanProcessor initializes, and the worker thread starts up.
* The test stubs `Process.pid` (simulating a fork)
* If we're unlucky in the timing, the worker thread runs `reset_on_fork(restart_thread: false)` _at this point_. This causes `@pid` to update, but _not_ `@thread`. (Note that this would never happen in a real system because the forked child process would not run the worker thread, but it can happen in the test simulation.)
* Now, back in the main test thread, `on_finish` is called, which calls `reset_on_fork`. This is _supposed_ to update `@pid` _and_ restart the `@thread`. But since the worker thread has already updated `@pid`, this call to `reset_on_fork` returns early, and the `@thread` never gets restarted. Hence, we fail the expectation that the thread ID has changed.

### Removed `restart_thread: false` in the `reset_on_fork` call in `force_flush`

I believe this setting is incorrect. Any time we detect that we've moved into a child process (i.e. any time `reset_on_fork` determines that `@pid` has changed, except for the special case of `start_thread_on_boot == false`), we _must_ restart the worker thread. This is regardless of whether the detection happens in `on_finish` or `force_flush`.

The failure mode is the following:

* We start up on a FaaS system.
* BatchSpanProcessor initializes. (Doesn't matter whether we start a worker thread at this point.)
* We fork the process (e.g. Unicorn prefork). Now, `@pid` is wrong, and the child process has no worker thread.
* The first request happens, and it so happens that _no_ spans are generated. That is, `on_finish` is _not_ called, and neither is `reset_on_fork`.
* The FaaS system calls `force_flush` in preparation to dial CPU allocation back to zero. This calls `reset_on_fork(restart_thread: false)` which updates `@pid` but does _not_ start a worker thread.
* Now, for the rest of the life of this child process, it is impossible for a worker thread to start, because `@pid` now matches, and the only way to get a thread is for `@pid` to be wrong. Hence, this process never exports its spans.

### Checked if a thread exists before joining in `shutdown`

Modified `shutdown` to call `@thread.join` only if `@thread` is non-nil.

The failure mode was any call to `shutdown` on a `BatchSpanProcessor` that was started with `start_thread_on_boot: false`. In this case, the initial call to `reset_on_fork` intentionally does not create a thread, but then this process *never* creates a thread. Hence `@thread` is still `nil` when `shutdown` is called.

Note: we do not need to handle the forked child process case here. If `shutdown` is called in a child process, and the thread has not yet been reconstituted (i.e. `reset_on_fork` has not yet executed), then the `@thread` object will simply be in a "dead" thread state, and joining on it is still safe.