### PR TITLE
fix: Only include user agent when present

### DIFF
--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
@@ -101,13 +101,14 @@ module OpenTelemetry
           end
 
           def request_span_attributes(env:)
-            {
+            attributes = {
               'http.method' => env['REQUEST_METHOD'],
               'http.host' => env['HTTP_HOST'] || 'unknown',
               'http.scheme' => env['rack.url_scheme'],
               'http.target' => fullpath(env),
-              'http.user_agent' => env['HTTP_USER_AGENT']
-            }.merge(allowed_request_headers(env))
+            }
+            attributes['http.user_agent'] = env['HTTP_USER_AGENT'] if env['HTTP_USER_AGENT']
+            attributes.merge(allowed_request_headers(env))
           end
 
           # e.g., "/webshop/articles/4?s=1":

--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
@@ -105,7 +105,7 @@ module OpenTelemetry
               'http.method' => env['REQUEST_METHOD'],
               'http.host' => env['HTTP_HOST'] || 'unknown',
               'http.scheme' => env['rack.url_scheme'],
-              'http.target' => fullpath(env),
+              'http.target' => fullpath(env)
             }
             attributes['http.user_agent'] = env['HTTP_USER_AGENT'] if env['HTTP_USER_AGENT']
             attributes.merge(allowed_request_headers(env))


### PR DESCRIPTION
I noticed this when testing an application with the rack instrumentation.

I'm not sure how prevalent a missing user agent would be, but this becomes noisy quickly in the event that it is omitted.

![image](https://user-images.githubusercontent.com/23463253/104509611-84c3e300-55af-11eb-8356-e40f0b03d529.png)
