### PR TITLE
fix: use port 443 for secure connections

### DIFF
--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -42,9 +42,11 @@ module OpenTelemetry
           raise ArgumentError, "unsupported compression key #{compression}" unless compression.nil? || compression == 'gzip'
           raise ArgumentError, 'headers must be comma-separated k:v pairs or a Hash' unless valid_headers?(headers)
 
-          uri = URI "http://#{endpoint}"
+          use_ssl = insecure.to_s.downcase == 'false'
+          scheme = use_ssl ? 'https://' : 'http://'
+          uri = URI("#{scheme}#{endpoint}")
           @http = Net::HTTP.new(uri.host, uri.port)
-          @http.use_ssl = insecure.to_s.downcase == 'false'
+          @http.use_ssl = use_ssl
           @http.ca_file = certificate_file unless certificate_file.nil?
           @http.keep_alive_timeout = KEEP_ALIVE_TIMEOUT
 

--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -91,6 +91,14 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       _(http.address).must_equal 'localhost'
       _(http.port).must_equal 4321
     end
+
+    it 'uses the port 443 for secure connections by default' do
+      exp = OpenTelemetry::Exporter::OTLP::Exporter.new(endpoint: 'localhost/v1/trace', insecure: 'false')
+      http = exp.instance_variable_get(:@http)
+      _(http.use_ssl?).must_equal true
+      _(http.address).must_equal 'localhost'
+      _(http.port).must_equal 443
+    end
   end
 
   describe '#export' do


### PR DESCRIPTION
When the `insecure` flag it set to `false` and the port is not specified in the endpoint parameter, the http client will end up using SSL but on the port 80.

Please let me know if I need to update other files like changelog, version etc.

I've not signed the CNCF CLA yet because I'm not sure how we ought to handle this in our company. Opening the PR now to get feedback in the meantime.