### PR TITLE
fix!: spec compliance for OTLP exporter

### DIFF
--- a/exporter/otlp/README.md
+++ b/exporter/otlp/README.md
@@ -40,7 +40,7 @@ OpenTelemetry::SDK.configure do |c|
   c.add_span_processor(
     OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
       exporter: OpenTelemetry::Exporter::OTLP::Exporter.new(
-        host: 'localhost', port: 55680
+        endpoint: 'http://localhost:55680'
       )
     )
   )

--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -22,7 +22,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       _(http.ca_file).must_be_nil
       _(http.use_ssl?).must_equal true
       _(http.address).must_equal 'localhost'
-      _(http.port).must_equal 55_681
+      _(http.port).must_equal 4317
     end
 
     it 'refuses invalid headers' do
@@ -48,17 +48,16 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
     end
 
     it 'sets parameters from the environment' do
-      exp = with_env('OTEL_EXPORTER_OTLP_ENDPOINT' => 'localhost:1234/v2/trace',
-                     'OTEL_EXPORTER_OTLP_INSECURE' => 'true',
+      exp = with_env('OTEL_EXPORTER_OTLP_ENDPOINT' => 'http://localhost:1234',
                      'OTEL_EXPORTER_OTLP_CERTIFICATE' => '/foo/bar',
-                     'OTEL_EXPORTER_OTLP_HEADERS' => 'a:b,c:d',
+                     'OTEL_EXPORTER_OTLP_HEADERS' => 'a=b,c=d',
                      'OTEL_EXPORTER_OTLP_COMPRESSION' => 'gzip',
                      'OTEL_EXPORTER_OTLP_TIMEOUT' => '11') do
         OpenTelemetry::Exporter::OTLP::Exporter.new
       end
       _(exp.instance_variable_get(:@headers)).must_equal('a' => 'b', 'c' => 'd')
       _(exp.instance_variable_get(:@timeout)).must_equal 11.0
-      _(exp.instance_variable_get(:@path)).must_equal '/v2/trace'
+      _(exp.instance_variable_get(:@path)).must_equal '/v1/trace'
       _(exp.instance_variable_get(:@compression)).must_equal 'gzip'
       http = exp.instance_variable_get(:@http)
       _(http.ca_file).must_equal '/foo/bar'
@@ -68,14 +67,12 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
     end
 
     it 'prefers explicit parameters rather than the environment' do
-      exp = with_env('OTEL_EXPORTER_OTLP_ENDPOINT' => 'localhost:1234/v2/trace',
-                     'OTEL_EXPORTER_OTLP_INSECURE' => 'true',
+      exp = with_env('OTEL_EXPORTER_OTLP_ENDPOINT' => 'https://localhost:1234',
                      'OTEL_EXPORTER_OTLP_CERTIFICATE' => '/foo/bar',
                      'OTEL_EXPORTER_OTLP_HEADERS' => 'a:b,c:d',
                      'OTEL_EXPORTER_OTLP_COMPRESSION' => 'flate',
                      'OTEL_EXPORTER_OTLP_TIMEOUT' => '11') do
-        OpenTelemetry::Exporter::OTLP::Exporter.new(endpoint: 'localhost:4321/v3/trace',
-                                                    insecure: 'false',
+        OpenTelemetry::Exporter::OTLP::Exporter.new(endpoint: 'http://localhost:4321',
                                                     certificate_file: '/baz',
                                                     headers: { 'x' => 'y' },
                                                     compression: 'gzip',
@@ -83,11 +80,11 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       end
       _(exp.instance_variable_get(:@headers)).must_equal('x' => 'y')
       _(exp.instance_variable_get(:@timeout)).must_equal 12.0
-      _(exp.instance_variable_get(:@path)).must_equal '/v3/trace'
+      _(exp.instance_variable_get(:@path)).must_equal '/v1/trace'
       _(exp.instance_variable_get(:@compression)).must_equal 'gzip'
       http = exp.instance_variable_get(:@http)
       _(http.ca_file).must_equal '/baz'
-      _(http.use_ssl?).must_equal true
+      _(http.use_ssl?).must_equal false
       _(http.address).must_equal 'localhost'
       _(http.port).must_equal 4321
     end
@@ -104,27 +101,27 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       skip unless ENV['TRACING_INTEGRATION_TEST']
       WebMock.disable_net_connect!(allow: 'localhost')
       span_data = create_span_data
-      exporter = OpenTelemetry::Exporter::OTLP::Exporter.new(insecure: true, compression: 'gzip')
+      exporter = OpenTelemetry::Exporter::OTLP::Exporter.new(endpoint: 'http://localhost:4317', compression: 'gzip')
       result = exporter.export([span_data])
       _(result).must_equal(SUCCESS)
     end
 
     it 'retries on timeout' do
-      stub_request(:post, 'https://localhost:55681/v1/trace').to_timeout.then.to_return(status: 200)
+      stub_request(:post, 'https://localhost:4317/v1/trace').to_timeout.then.to_return(status: 200)
       span_data = create_span_data
       result = exporter.export([span_data])
       _(result).must_equal(SUCCESS)
     end
 
     it 'returns TIMEOUT on timeout' do
-      stub_request(:post, 'https://localhost:55681/v1/trace').to_return(status: 200)
+      stub_request(:post, 'https://localhost:4317/v1/trace').to_return(status: 200)
       span_data = create_span_data
       result = exporter.export([span_data], timeout: 0)
       _(result).must_equal(TIMEOUT)
     end
 
     it 'returns TIMEOUT on timeout after retrying' do
-      stub_request(:post, 'https://localhost:55681/v1/trace').to_timeout.then.to_raise('this should not be reached')
+      stub_request(:post, 'https://localhost:4317/v1/trace').to_timeout.then.to_raise('this should not be reached')
       span_data = create_span_data
 
       @retry_count = 0
@@ -148,14 +145,14 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
     end
 
     it 'exports a span_data' do
-      stub_request(:post, 'https://localhost:55681/v1/trace').to_return(status: 200)
+      stub_request(:post, 'https://localhost:4317/v1/trace').to_return(status: 200)
       span_data = create_span_data
       result = exporter.export([span_data])
       _(result).must_equal(SUCCESS)
     end
 
     it 'exports a span from a tracer' do
-      stub_post = stub_request(:post, 'https://localhost:55681/v1/trace').to_return(status: 200)
+      stub_post = stub_request(:post, 'https://localhost:4317/v1/trace').to_return(status: 200)
       processor = OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(exporter: exporter, max_queue_size: 1, max_export_batch_size: 1)
       OpenTelemetry.tracer_provider.add_span_processor(processor)
       OpenTelemetry.tracer_provider.tracer.start_root_span('foo').finish
@@ -166,7 +163,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
     it 'compresses with gzip if enabled' do
       exporter = OpenTelemetry::Exporter::OTLP::Exporter.new(compression: 'gzip')
       etsr = nil
-      stub_post = stub_request(:post, 'https://localhost:55681/v1/trace').to_return do |request|
+      stub_post = stub_request(:post, 'https://localhost:4317/v1/trace').to_return do |request|
         etsr = Opentelemetry::Proto::Collector::Trace::V1::ExportTraceServiceRequest.decode(Zlib.gunzip(request.body))
         { status: 200 }
       end
@@ -180,7 +177,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
 
     it 'batches per resource' do
       etsr = nil
-      stub_post = stub_request(:post, 'https://localhost:55681/v1/trace').to_return do |request|
+      stub_post = stub_request(:post, 'https://localhost:4317/v1/trace').to_return do |request|
         etsr = Opentelemetry::Proto::Collector::Trace::V1::ExportTraceServiceRequest.decode(request.body)
         { status: 200 }
       end
@@ -196,7 +193,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
     end
 
     it 'translates all the things' do
-      stub_request(:post, 'https://localhost:55681/v1/trace').to_return(status: 200)
+      stub_request(:post, 'https://localhost:4317/v1/trace').to_return(status: 200)
       processor = OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(exporter: exporter)
       tracer = OpenTelemetry.tracer_provider.tracer('tracer', 'v0.0.1')
       other_tracer = OpenTelemetry.tracer_provider.tracer('other_tracer')
@@ -357,7 +354,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
         )
       )
 
-      assert_requested(:post, 'https://localhost:55681/v1/trace') do |req|
+      assert_requested(:post, 'https://localhost:4317/v1/trace') do |req|
         req.body == encoded_etsr
       end
     end


### PR DESCRIPTION
This improves spec compliance for the OTLP exporter, based on recent changes to https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/protocol/exporter.md

This is a breaking change in several ways:
1. The `insecure:` argument to the initializer and the `OTEL_EXPORTER_OTLP_SPAN_INSECURE` and `OTEL_EXPORTER_OTLP_INSECURE ` environment variables are no longer supported.
2. The `endpoint:` argument and the `OTEL_EXPORTER_OTLP_SPAN_ENDPOINT` and `OTEL_EXPORTER_OTLP_ENDPOINT` environment variables used to expect a full URL without the scheme. They now expect a URL with the scheme but without the path.
3. The exporter implicitly and unconditionally appends `/v1/traces` to the URL.
4. The format of additional headers provided via the `OTEL_EXPORTER_OTLP_HEADERS` or `OTEL_EXPORTER_OTLP_SPAN_HEADERS` environment variables has changes from using `:` to separate keys and values to use of `=` as key-value separator.