### PR TITLE
fix: Delayed Job Instrumenter: coerce message ID to string

### DIFF
--- a/instrumentation/delayed_job/lib/opentelemetry/instrumentation/delayed_job/plugins/tracer_plugin.rb
+++ b/instrumentation/delayed_job/lib/opentelemetry/instrumentation/delayed_job/plugins/tracer_plugin.rb
@@ -20,7 +20,7 @@ module OpenTelemetry
               attributes['messaging.operation'] = 'send'
               tracer.in_span("#{job_queue(job)} send", attributes: attributes, kind: :producer) do |span|
                 yield job
-                span.set_attribute('messaging.message_id', job.id)
+                span.set_attribute('messaging.message_id', job.id.to_s)
                 add_events(span, job)
               end
             end
@@ -32,7 +32,7 @@ module OpenTelemetry
               attributes['messaging.delayed_job.attempts'] = job.attempts if job.attempts
               attributes['messaging.delayed_job.locked_by'] = job.locked_by if job.locked_by
               attributes['messaging.operation'] = 'process'
-              attributes['messaging.message_id'] = job.id
+              attributes['messaging.message_id'] = job.id.to_s
               tracer.in_span("#{job_queue(job)} process", attributes: attributes, kind: :consumer) do |span|
                 add_events(span, job)
                 yield job

--- a/instrumentation/delayed_job/test/opentelemetry/instrumentation/delayed_job/plugins/tracer_plugin_test.rb
+++ b/instrumentation/delayed_job/test/opentelemetry/instrumentation/delayed_job/plugins/tracer_plugin_test.rb
@@ -76,7 +76,7 @@ describe OpenTelemetry::Instrumentation::DelayedJob::Plugins::TracerPlugin do
       _(span.attributes['messaging.delayed_job.name']).must_equal 'BasicPayload'
       _(span.attributes['messaging.delayed_job.priority']).must_equal 0
       _(span.attributes['messaging.operation']).must_equal 'send'
-      _(span.attributes['messaging.message_id']).must_be_kind_of Integer
+      _(span.attributes['messaging.message_id']).must_be_kind_of String
 
       _(span.events.size).must_equal 2
       _(span.events[0].name).must_equal 'created_at'
@@ -140,7 +140,7 @@ describe OpenTelemetry::Instrumentation::DelayedJob::Plugins::TracerPlugin do
       _(span.attributes['messaging.delayed_job.attempts']).must_equal 0
       _(span.attributes['messaging.delayed_job.locked_by']).must_be_kind_of String
       _(span.attributes['messaging.operation']).must_equal 'process'
-      _(span.attributes['messaging.message_id']).must_be_kind_of Integer
+      _(span.attributes['messaging.message_id']).must_be_kind_of String
 
       _(span.events.size).must_equal 3
       _(span.events[0].name).must_equal 'created_at'


### PR DESCRIPTION
When using DelayedJob with Mongo, the ID used in `messaging.message_id` is are not `Integer` type but `BSON::ObjectId`. This is not an allowed wire type for OTEL. To remedy this (and for potentially other DBs) I'm coercing message_id to string.

```
ERROR -- : OpenTelemetry error: invalid attribute value type BSON::ObjectId
```