### PR TITLE
fix: Mongo Instrumenter: Do not send nil attributes

### DIFF
--- a/instrumentation/mongo/lib/opentelemetry/instrumentation/mongo/subscriber.rb
+++ b/instrumentation/mongo/lib/opentelemetry/instrumentation/mongo/subscriber.rb
@@ -71,7 +71,7 @@ module OpenTelemetry
             'db.statement' => CommandSerializer.new(event.command).serialize,
             'net.peer.name' => event.address.host,
             'net.peer.port' => event.address.port
-          }
+          }.compact
         end
 
         def get_collection(command)

--- a/instrumentation/mongo/test/opentelemetry/instrumentation/mongo/subscriber_test.rb
+++ b/instrumentation/mongo/test/opentelemetry/instrumentation/mongo/subscriber_test.rb
@@ -281,7 +281,7 @@ describe OpenTelemetry::Instrumentation::Mongo::Subscriber do
     it 'has operation-specific properties' do
       _(span.name).must_equal 'dropDatabase'
       _(span.attributes['db.operation']).must_equal 'dropDatabase'
-      assert_nil(span.attributes['db.mongodb.collection'])
+      refute(span.attributes.key?('db.mongodb.collection'))
       refute(span.attributes.key?('db.statement'))
     end
   end

--- a/instrumentation/mongo/test/opentelemetry/instrumentation/mongo/subscriber_test.rb
+++ b/instrumentation/mongo/test/opentelemetry/instrumentation/mongo/subscriber_test.rb
@@ -61,7 +61,7 @@ describe OpenTelemetry::Instrumentation::Mongo::Subscriber do
         _(span.name).must_equal 'artists.insert'
         _(span.attributes['db.operation']).must_equal 'insert'
         _(span.attributes['db.mongodb.collection']).must_equal 'artists'
-        assert_nil(span.attributes['db.statement'])
+        refute(span.attributes.key?('db.statement'))
       end
     end
 
@@ -75,7 +75,7 @@ describe OpenTelemetry::Instrumentation::Mongo::Subscriber do
         _(span.name).must_equal 'people.insert'
         _(span.attributes['db.operation']).must_equal 'insert'
         _(span.attributes['db.mongodb.collection']).must_equal 'people'
-        assert_nil(span.attributes['db.statement'])
+        refute(span.attributes.key?('db.statement'))
       end
     end
   end
@@ -99,7 +99,7 @@ describe OpenTelemetry::Instrumentation::Mongo::Subscriber do
         _(span.name).must_equal 'people.insert'
         _(span.attributes['db.operation']).must_equal 'insert'
         _(span.attributes['db.mongodb.collection']).must_equal 'people'
-        assert_nil(span.attributes['db.statement'])
+        refute(span.attributes.key?('db.statement'))
       end
     end
   end
@@ -124,7 +124,7 @@ describe OpenTelemetry::Instrumentation::Mongo::Subscriber do
       _(span.name).must_equal 'people.find'
       _(span.attributes['db.operation']).must_equal 'find'
       _(span.attributes['db.mongodb.collection']).must_equal 'people'
-      assert_nil(span.attributes['db.statement'])
+      refute(span.attributes.key?('db.statement'))
     end
   end
 
@@ -282,7 +282,7 @@ describe OpenTelemetry::Instrumentation::Mongo::Subscriber do
       _(span.name).must_equal 'dropDatabase'
       _(span.attributes['db.operation']).must_equal 'dropDatabase'
       assert_nil(span.attributes['db.mongodb.collection'])
-      assert_nil(span.attributes['db.statement'])
+      refute(span.attributes.key?('db.statement'))
     end
   end
 
@@ -295,7 +295,7 @@ describe OpenTelemetry::Instrumentation::Mongo::Subscriber do
       _(span.name).must_equal 'artists.drop'
       _(span.attributes['db.operation']).must_equal 'drop'
       _(span.attributes['db.mongodb.collection']).must_equal 'artists'
-      assert_nil(span.attributes['db.statement'])
+      refute(span.attributes.key?('db.statement'))
       _(span.events.size).must_equal 1
       _(span.events[0].name).must_equal 'exception'
       _(span.events[0].timestamp).must_be_kind_of Time


### PR DESCRIPTION
In current Mongo Instrumenter, there are cases `db.statement` and `db.mongodb.collection` can be nil. Nil is not an allowed wire value type for OTEL, so it must be removed.

```
ERROR -- : OpenTelemetry error: invalid attribute value type NilClass
```