### PR TITLE
Add caller location where Faraday was called. (Draft: for Discussion)

### DIFF
--- a/api/lib/opentelemetry/instrumentation.rb
+++ b/api/lib/opentelemetry/instrumentation.rb
@@ -6,6 +6,7 @@
 
 require 'opentelemetry/instrumentation/registry'
 require 'opentelemetry/instrumentation/base'
+require 'opentelemetry/instrumentation/caller_locations'
 
 module OpenTelemetry
   # The instrumentation module contains functionality to register and install

--- a/api/lib/opentelemetry/instrumentation/caller_locations.rb
+++ b/api/lib/opentelemetry/instrumentation/caller_locations.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Instrumentation
+    # The instrumentation CallerLocations contains a reusable function to add caller information to instrumentations
+    class CallerLocations
+      def self.detect_caller_location
+        if ENV['OTEL_EXPORTER_ADD_CALLER_LOCATION']
+          cleaned_up_trace = caller_locations.delete_if { |loc| loc.absolute_path.match('/.rvm/gems/') }
+          non_gem_first_line = cleaned_up_trace.last
+          {
+            'code.lineno' => non_gem_first_line.lineno,
+            'code.filepath' => non_gem_first_line.absolute_path,
+            'code.function' => non_gem_first_line.base_label
+          }
+        else
+          {}
+        end
+      end
+    end
+  end
+end

--- a/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
+++ b/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
@@ -49,6 +49,10 @@ module OpenTelemetry
           end
 
           def trace_response(span, response)
+            caller_of_faraday = caller_locations[12]
+            span.set_attribute('code.lineno', caller_of_faraday.lineno)
+            span.set_attribute('code.absolute_path', caller_of_faraday.absolute_path)
+            span.set_attribute('code.base_label', caller_of_faraday.base_label)
             span.set_attribute('http.status_code', response.status)
             span.set_attribute('http.status_text', response.reason_phrase)
             span.status = OpenTelemetry::Trace::Status.http_to_status(

--- a/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
+++ b/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
@@ -49,10 +49,7 @@ module OpenTelemetry
           end
 
           def trace_response(span, response)
-            caller_of_faraday = caller_locations[12]
-            span.set_attribute('code.lineno', caller_of_faraday.lineno)
-            span.set_attribute('code.absolute_path', caller_of_faraday.absolute_path)
-            span.set_attribute('code.base_label', caller_of_faraday.base_label)
+            CallerLocations.detect_caller_location.each { |k, v| span.set_attribute(k, v) }
             span.set_attribute('http.status_code', response.status)
             span.set_attribute('http.status_text', response.reason_phrase)
             span.status = OpenTelemetry::Trace::Status.http_to_status(

--- a/instrumentation/faraday/opentelemetry-instrumentation-faraday.gemspec
+++ b/instrumentation/faraday/opentelemetry-instrumentation-faraday.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'faraday', '~> 0.17.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 0.0'
+  spec.add_development_dependency 'rspec-mocks'
   spec.add_development_dependency 'rubocop', '~> 0.73.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'

--- a/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
+++ b/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
@@ -44,6 +44,8 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
   describe 'first span' do
     before do
       instrumentation.install
+      allow(ENV).to receive(:[]).with(anything).and_call_original
+      allow(ENV).to receive(:[]).with('OTEL_EXPORTER_ADD_CALLER_LOCATION').and_return(true)
     end
 
     it 'has http 200 attributes' do
@@ -56,8 +58,9 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
       _(response.env.request_headers['Traceparent']).must_equal(
         "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
       )
-      _(span.attributes['code.lineno']).must_equal 50
-      _(span.attributes['code.absolute_path']).must_equal __FILE__
+      _(span.attributes['code.filepath']).must_equal __FILE__
+      _(span.attributes['code.lineno']).must_equal 52
+      _(span.attributes['code.function']).must_equal '<top (required)>'
     end
 
     it 'has http.status_code 404' do
@@ -70,8 +73,9 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
       _(response.env.request_headers['Traceparent']).must_equal(
         "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
       )
-      _(span.attributes['code.lineno']).must_equal 64
-      _(span.attributes['code.absolute_path']).must_equal __FILE__
+      _(span.attributes['code.filepath']).must_equal __FILE__
+      _(span.attributes['code.lineno']).must_equal 67
+      _(span.attributes['code.function']).must_equal '<top (required)>'
     end
 
     it 'has http.status_code 500' do
@@ -84,8 +88,9 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
       _(response.env.request_headers['Traceparent']).must_equal(
         "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
       )
-      _(span.attributes['code.lineno']).must_equal 78
-      _(span.attributes['code.absolute_path']).must_equal __FILE__
+      _(span.attributes['code.filepath']).must_equal __FILE__
+      _(span.attributes['code.lineno']).must_equal 82
+      _(span.attributes['code.function']).must_equal '<top (required)>'
     end
   end
 end

--- a/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
+++ b/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
@@ -56,6 +56,8 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
       _(response.env.request_headers['Traceparent']).must_equal(
         "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
       )
+      _(span.attributes['code.lineno']).must_equal 50
+      _(span.attributes['code.absolute_path']).must_equal __FILE__
     end
 
     it 'has http.status_code 404' do
@@ -68,6 +70,8 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
       _(response.env.request_headers['Traceparent']).must_equal(
         "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
       )
+      _(span.attributes['code.lineno']).must_equal 64
+      _(span.attributes['code.absolute_path']).must_equal __FILE__
     end
 
     it 'has http.status_code 500' do
@@ -80,6 +84,8 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
       _(response.env.request_headers['Traceparent']).must_equal(
         "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
       )
+      _(span.attributes['code.lineno']).must_equal 78
+      _(span.attributes['code.absolute_path']).must_equal __FILE__
     end
   end
 end

--- a/instrumentation/faraday/test/test_helper.rb
+++ b/instrumentation/faraday/test/test_helper.rb
@@ -9,6 +9,7 @@ require 'faraday'
 require 'opentelemetry/sdk'
 
 require 'minitest/autorun'
+require 'rspec/mocks/minitest_integration'
 require 'webmock/minitest'
 
 # global opentelemetry-sdk setup:


### PR DESCRIPTION
I am interested to see the location where a call is made within the metadata.

I thought of doing something like this. which would work for apps calling Faraday directly. But I think most people wraps Faraday into their own client.

would there be a better way to report the location within the application? 

would removing all lines that contains `gems` from the `caller` array be an option?