### PR TITLE
fix: conditionally append path to collector endpoint

### DIFF
--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -37,6 +37,11 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       end
     end
 
+    it 'uses endpoints path if provided' do
+      exp = OpenTelemetry::Exporter::OTLP::Exporter.new(endpoint: 'https://localhost/custom/path')
+      _(exp.instance_variable_get(:@path)).must_equal '/custom/path'
+    end
+
     it 'only allows gzip compression or none' do
       assert_raises ArgumentError do
         OpenTelemetry::Exporter::OTLP::Exporter.new(compression: 'flate')
@@ -80,7 +85,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       end
       _(exp.instance_variable_get(:@headers)).must_equal('x' => 'y')
       _(exp.instance_variable_get(:@timeout)).must_equal 12.0
-      _(exp.instance_variable_get(:@path)).must_equal '/v1/trace'
+      _(exp.instance_variable_get(:@path)).must_equal ''
       _(exp.instance_variable_get(:@compression)).must_equal 'gzip'
       http = exp.instance_variable_get(:@http)
       _(http.ca_file).must_equal '/baz'


### PR DESCRIPTION
A recent change to the otlp exporter unconditionally appends `/v1/trace` to the provided endpoint. This prevents the possibility of exporting spans to any other path using in-code configuration. This was likely due to a recent change in the spec that reads:

> Target to which the exporter is going to send spans or metrics. The endpoint MUST be a valid URL with scheme (http or https) and host, and MAY contain a port and path. A scheme of https indicates a secure connection. When using OTEL_EXPORTER_OTLP_ENDPOINT with OTLP/HTTP, exporters SHOULD follow the collector convention of appending the version and signal to the path (e.g. v1/traces or v1/metrics). The per-signal endpoint configuration options take precedence and can be used to override this behavior.

There is a general `OTLP_EXPORTER_OTLP_ENDPOINT` configuration that is meant to be used for both spans and metrics. OTLP/HTTP requires a path, so when the general configuration is used, a path must be appended to it. However, more specific configuration such as `OTLP_EXPORTER_OTLP_SPAN_ENDPOINT` should take precedence and a path should not be appended. The OTLP exporter that we have is a trace exporter and the `endpoint` argument is a span endpoint, and should not have `/v1/trace` appended to it by default. This PR makes that change, but still respects the more general configuration, which is currently only settable by environment variable.
