### PR TITLE
feat: provide default resource in SDK

### DIFF
--- a/exporter/jaeger/lib/opentelemetry/exporter/jaeger/encoder.rb
+++ b/exporter/jaeger/lib/opentelemetry/exporter/jaeger/encoder.rb
@@ -30,10 +30,11 @@ module OpenTelemetry
           OpenTelemetry::Trace::SpanKind::PRODUCER => 'producer',
           OpenTelemetry::Trace::SpanKind::CONSUMER => 'consumer'
         }.freeze
-        private_constant(:EMPTY_ARRAY, :LONG, :DOUBLE, :STRING, :BOOL, :KEY, :TYPE, :TYPE_MAP, :KIND_MAP)
+        DEFAULT_SERVICE_NAME = OpenTelemetry::SDK::Resources::Resource.default.attribute_enumerator.find { |k, _| k == 'service.name' }&.last || 'unknown_service'
+        private_constant(:EMPTY_ARRAY, :LONG, :DOUBLE, :STRING, :BOOL, :KEY, :TYPE, :TYPE_MAP, :KIND_MAP, :DEFAULT_SERVICE_NAME)
 
         def encoded_process(resource)
-          service_name = 'unknown'
+          service_name = DEFAULT_SERVICE_NAME
           tags = resource&.attribute_enumerator&.select do |key, value|
             service_name = value if key == 'service.name'
             key != 'service.name'

--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -27,7 +27,7 @@ module OpenTelemetry
         @text_map_injectors = nil
         @span_processors = []
         @use_mode = USE_MODE_UNSPECIFIED
-        @resource = Resources::Resource.telemetry_sdk.merge(Resources::Resource.process)
+        @resource = Resources::Resource.default
         @id_generator = OpenTelemetry::Trace
       end
 

--- a/sdk/lib/opentelemetry/sdk/resources/resource.rb
+++ b/sdk/lib/opentelemetry/sdk/resources/resource.rb
@@ -31,7 +31,7 @@ module OpenTelemetry
           end
 
           def default
-            @default_resource ||= telemetry_sdk.merge(process).merge(create(Constants::SERVICE_RESOURCE[:name] => 'unknown_service'))
+            @default ||= telemetry_sdk.merge(process).merge(create(Constants::SERVICE_RESOURCE[:name] => 'unknown_service'))
           end
 
           def telemetry_sdk

--- a/sdk/lib/opentelemetry/sdk/resources/resource.rb
+++ b/sdk/lib/opentelemetry/sdk/resources/resource.rb
@@ -30,6 +30,10 @@ module OpenTelemetry
             new(frozen_attributes)
           end
 
+          def default
+            @default_resource ||= telemetry_sdk.merge(process).merge(create(Constants::SERVICE_RESOURCE[:name] => 'unknown_service'))
+          end
+
           def telemetry_sdk
             resource_attributes = {
               Constants::TELEMETRY_SDK_RESOURCE[:name] => 'opentelemetry',

--- a/sdk/test/opentelemetry/sdk/configurator_test.rb
+++ b/sdk/test/opentelemetry/sdk/configurator_test.rb
@@ -17,7 +17,8 @@ describe OpenTelemetry::SDK::Configurator do
       'process.command' => $PROGRAM_NAME,
       'process.runtime.name' => RUBY_ENGINE,
       'process.runtime.version' => RUBY_VERSION,
-      'process.runtime.description' => RUBY_DESCRIPTION
+      'process.runtime.description' => RUBY_DESCRIPTION,
+      'service.name' => 'unknown_service'
     }
   end
 

--- a/sdk/test/opentelemetry/sdk/resources/resource_test.rb
+++ b/sdk/test/opentelemetry/sdk/resources/resource_test.rb
@@ -41,6 +41,30 @@ describe OpenTelemetry::SDK::Resources::Resource do
     end
   end
 
+  describe '.default' do
+    it 'contains telemetry sdk attributes' do
+      resource_attributes = Resource.default.attribute_enumerator.to_h
+      _(resource_attributes).must_include('telemetry.sdk.name')
+      _(resource_attributes).must_include('telemetry.sdk.language')
+      _(resource_attributes).must_include('telemetry.sdk.version')
+    end
+
+    it 'contains process attributes' do
+      resource_attributes = Resource.default.attribute_enumerator.to_h
+      _(resource_attributes).must_include('process.pid')
+      _(resource_attributes).must_include('process.command')
+      _(resource_attributes).must_include('process.runtime.name')
+      _(resource_attributes).must_include('process.runtime.version')
+      _(resource_attributes).must_include('process.runtime.description')
+    end
+
+    it 'contains a default value for service.name' do
+      resource_attributes = Resource.default.attribute_enumerator.to_h
+      _(resource_attributes).must_include('service.name')
+      _(resource_attributes['service.name']).must_equal('unknown_service')
+    end
+  end
+
   describe '.telemetry_sdk' do
     it 'returns a resource for the telemetry sdk' do
       resource_attributes = Resource.telemetry_sdk.attribute_enumerator.to_h


### PR DESCRIPTION
Fixes #518 and implements changes from https://github.com/open-telemetry/opentelemetry-specification/pull/1294.

Specifically, this exposes `OpenTelemetry::SDK::Resources::Resource.default` as a default resource to be attached to the tracer provider and ensures that this resource contains the default `service.name` attributes with the value `unknown_service`. The Jaeger exporter has been updated to use the service name from this default resource if the resource attached to spans does not contain the `service.name` attribute.