### PR TITLE
fix: Include http.status_text only if reason_phrase is present in the response

### DIFF
--- a/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
+++ b/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
@@ -50,7 +50,7 @@ module OpenTelemetry
 
           def trace_response(span, response)
             span.set_attribute('http.status_code', response.status)
-            span.set_attribute('http.status_text', response.reason_phrase)
+            span.set_attribute('http.status_text', response.reason_phrase) if response.reason_phrase
             span.status = OpenTelemetry::Trace::Status.http_to_status(
               response.status
             )

--- a/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
+++ b/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
@@ -81,5 +81,12 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
         "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
       )
     end
+
+    it 'sets the reason phrase' do
+      stub_request(:any, 'example.com').to_return(status: [500, 'Internal Server Error'])
+      ::Faraday.new('http://example.com').get('/')
+
+      _(span.attributes['http.status_text']).must_equal 'Internal Server Error'
+    end
   end
 end


### PR DESCRIPTION
We noticed the error `OpenTelemetry error: invalid attribute value type NilClass` appearing frequently in our logs after the addition of Faraday instrumentation to our project.  This fix will skip the addition of attribute if it is nil in the response.