### PR TITLE
feat: add untraced wrapper to common utils

### DIFF
--- a/common/lib/opentelemetry/common/utilities.rb
+++ b/common/lib/opentelemetry/common/utilities.rb
@@ -45,6 +45,10 @@ module OpenTelemetry
 
         placeholder
       end
+
+      def untraced
+        OpenTelemetry::Trace.with_span(OpenTelemetry::Trace::Span.new) { yield }
+      end
     end
   end
 end

--- a/exporter/jaeger/lib/opentelemetry/exporter/jaeger/collector_exporter.rb
+++ b/exporter/jaeger/lib/opentelemetry/exporter/jaeger/collector_exporter.rb
@@ -45,7 +45,7 @@ module OpenTelemetry
             @transport.write(@serializer.serialize(batch))
           end
 
-          untraced do
+          OpenTelemetry::Common::Utilities.untraced do
             @transport.flush
           end
           SUCCESS
@@ -72,10 +72,6 @@ module OpenTelemetry
           false
         rescue URI::InvalidURIError
           true
-        end
-
-        def untraced
-          OpenTelemetry::Trace.with_span(OpenTelemetry::Trace::Span.new) { yield }
         end
 
         def encoded_batches(span_data)

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -120,7 +120,7 @@ module OpenTelemetry
           retry_count = 0
           timeout ||= @timeout
           start_time = Time.now
-          untraced do # rubocop:disable Metrics/BlockLength
+          OpenTelemetry::Common::Utilities.untraced do # rubocop:disable Metrics/BlockLength
             request = Net::HTTP::Post.new(@path)
             request.body = if @compression == 'gzip'
                              request.add_field('Content-Encoding', 'gzip')
@@ -177,10 +177,6 @@ module OpenTelemetry
 
         def handle_redirect(location)
           # TODO: figure out destination and reinitialize @http and @path
-        end
-
-        def untraced
-          OpenTelemetry::Trace.with_span(OpenTelemetry::Trace::Span.new) { yield }
         end
 
         def measure_request_duration


### PR DESCRIPTION
Makes the `untraced` method available as part of common utils.