### PR TITLE
feat: add optional attributes to record_exception

### DIFF
--- a/api/lib/opentelemetry/trace/span.rb
+++ b/api/lib/opentelemetry/trace/span.rb
@@ -85,9 +85,13 @@ module OpenTelemetry
       # can be recorded on a span.
       #
       # @param [Exception] exception The exception to recorded
+      # @param [optional Hash{String => String, Numeric, Boolean, Array<String, Numeric, Boolean>}]
+      #   attributes One or more key:value pairs, where the keys must be
+      #   strings and the values may be (array of) string, boolean or numeric
+      #   type.
       #
       # @return [void]
-      def record_exception(exception); end
+      def record_exception(exception, attributes: nil); end
 
       # Sets the Status to the Span
       #

--- a/api/test/opentelemetry/trace/span_test.rb
+++ b/api/test/opentelemetry/trace/span_test.rb
@@ -52,6 +52,9 @@ describe OpenTelemetry::Trace::Span do
     it 'returns nil' do
       _(span.record_exception(StandardError.new('oops'))).must_be_nil
     end
+    it 'accepts attributes' do
+      _(span.record_exception(StandardError.new('oops'), attributes: { 'foo' => 'bar' })).must_be_nil
+    end
   end
 
   describe '#finish' do

--- a/sdk/lib/opentelemetry/sdk/trace/span.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span.rb
@@ -120,15 +120,20 @@ module OpenTelemetry
         # can be recorded on a span.
         #
         # @param [Exception] exception The exception to be recorded
+        # @param [optional Hash{String => String, Numeric, Boolean, Array<String, Numeric, Boolean>}]
+        #   attributes One or more key:value pairs, where the keys must be
+        #   strings and the values may be (array of) string, boolean or numeric
+        #   type.
         #
         # @return [void]
-        def record_exception(exception)
-          add_event('exception',
-                    attributes: {
-                      'exception.type' => exception.class.to_s,
-                      'exception.message' => exception.message,
-                      'exception.stacktrace' => exception.full_message(highlight: false, order: :top)
-                    })
+        def record_exception(exception, attributes: nil)
+          event_attributes = {
+            'exception.type' => exception.class.to_s,
+            'exception.message' => exception.message,
+            'exception.stacktrace' => exception.full_message(highlight: false, order: :top)
+          }
+          event_attributes.merge!(attributes) unless attributes.nil?
+          add_event('exception', attributes: event_attributes)
         end
 
         # Sets the Status to the Span

--- a/sdk/test/opentelemetry/sdk/trace/span_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/span_test.rb
@@ -208,6 +208,20 @@ describe OpenTelemetry::SDK::Trace::Span do
       _(ev.attributes['exception.stacktrace']).must_equal(error.full_message(highlight: false, order: :top))
     end
 
+    it 'merges optional attributes' do
+      span.record_exception(error, attributes: { 'exception.type' => 'foo', 'bar' => 'baz' })
+      events = span.events
+      _(events.size).must_equal(1)
+
+      ev = events[0]
+
+      _(ev.name).must_equal('exception')
+      _(ev.attributes['exception.type']).must_equal('foo')
+      _(ev.attributes['exception.message']).must_equal(error.message)
+      _(ev.attributes['exception.stacktrace']).must_equal(error.full_message(highlight: false, order: :top))
+      _(ev.attributes['bar']).must_equal('baz')
+    end
+
     it 'records multiple errors' do
       3.times { span.record_exception(error) }
       events = span.events


### PR DESCRIPTION
This implements the [optional attributes to `record_exception`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#record-exception) required by the spec.