### PR TITLE
fix: leaky test

### DIFF
--- a/sdk/test/opentelemetry/sdk/configurator_test.rb
+++ b/sdk/test/opentelemetry/sdk/configurator_test.rb
@@ -47,6 +47,10 @@ describe OpenTelemetry::SDK::Configurator do
     describe 'when there is a resource key collision' do
       let(:expected_resource_attributes) { default_resource_attributes.merge('important_value' => '25') }
 
+      after do
+        OpenTelemetry::SDK::Resources::Resource.instance_variable_set(:@default, nil)
+      end
+
       it 'uses the user provided resources' do
         with_env('OTEL_RESOURCE_ATTRIBUTES' => 'important_value=100') do
           configurator.resource = OpenTelemetry::SDK::Resources::Resource.create('important_value' => '25')


### PR DESCRIPTION
This has been annoying for some time. The caching in `OpenTelemetry::SDK::Resources::Resource.default` means that the attributes from the environment variable can stick around between tests.