### PR TITLE
fix: allow env var override of service.name

### DIFF
--- a/sdk/lib/opentelemetry/sdk/resources/resource.rb
+++ b/sdk/lib/opentelemetry/sdk/resources/resource.rb
@@ -31,7 +31,7 @@ module OpenTelemetry
           end
 
           def default
-            @default ||= telemetry_sdk.merge(process).merge(create(Constants::SERVICE_RESOURCE[:name] => 'unknown_service'))
+            @default ||= create(Constants::SERVICE_RESOURCE[:name] => 'unknown_service').merge(process).merge(telemetry_sdk)
           end
 
           def telemetry_sdk

--- a/sdk/test/opentelemetry/sdk/resources/resource_test.rb
+++ b/sdk/test/opentelemetry/sdk/resources/resource_test.rb
@@ -42,6 +42,10 @@ describe OpenTelemetry::SDK::Resources::Resource do
   end
 
   describe '.default' do
+    after do
+      Resource.instance_variable_set(:@default, nil)
+    end
+
     it 'contains telemetry sdk attributes' do
       resource_attributes = Resource.default.attribute_enumerator.to_h
       _(resource_attributes).must_include('telemetry.sdk.name')
@@ -62,6 +66,14 @@ describe OpenTelemetry::SDK::Resources::Resource do
       resource_attributes = Resource.default.attribute_enumerator.to_h
       _(resource_attributes).must_include('service.name')
       _(resource_attributes['service.name']).must_equal('unknown_service')
+    end
+
+    it 'allows overriding the default service.name with the environment variable' do
+      with_env('OTEL_RESOURCE_ATTRIBUTES' => 'service.name=svc') do
+        resource_attributes = Resource.default.attribute_enumerator.to_h
+        _(resource_attributes).must_include('service.name')
+        _(resource_attributes['service.name']).must_equal('svc')
+      end
     end
   end
 

--- a/sdk/test/opentelemetry/sdk/resources/resource_test.rb
+++ b/sdk/test/opentelemetry/sdk/resources/resource_test.rb
@@ -42,6 +42,10 @@ describe OpenTelemetry::SDK::Resources::Resource do
   end
 
   describe '.default' do
+    before do
+      Resource.instance_variable_set(:@default, nil)
+    end
+
     after do
       Resource.instance_variable_set(:@default, nil)
     end


### PR DESCRIPTION
Bug reported in Gitter by @mat-rumian:

> Looks like setting service name by environment variable `export OTEL_RESOURCE_ATTRIBUTES=service.name=test` doesn't work - I'm getting `unknown_service`. (BatchSpanProcessor)