### PR TITLE
docs: updated gem name to match gemspec

### DIFF
--- a/resource_detectors/README.md
+++ b/resource_detectors/README.md
@@ -1,6 +1,6 @@
 # Opentelemetry::Resource::Detectors
 
-The `opentelemetry-resource-detectors` gem provides resource detectors for OpenTelemetry.
+The `opentelemetry-resource_detectors` gem provides resource detectors for OpenTelemetry.
 
 ## What is OpenTelemetry?
 
@@ -18,10 +18,10 @@ Install the gem using:
 
 ```
 gem install opentelemetry-sdk
-gem install opentelemetry-resource-detectors
+gem install opentelemetry-resource_detectors
 ```
 
-Or, if you use Bundler, include `opentelemetry-sdk` and `opentelemetry-resource-detectors` in your `Gemfile`.
+Or, if you use Bundler, include `opentelemetry-sdk` and `opentelemetry-resource_detectors` in your `Gemfile`.
 
 ```rb
 require 'opentelemetry/sdk'
@@ -40,10 +40,10 @@ end
 
 ## How can I get involved?
 
-The `opentelemetry-resource-detectors` gem source is on github, along with related gems.
+The `opentelemetry-resource_detectors` gem source is on github, along with related gems.
 
 The OpenTelemetry Ruby gems are maintained by the OpenTelemetry-Ruby special interest group (SIG). You can get involved by joining us on our gitter channel or attending our weekly meeting. See the meeting calendar for dates and times. For more information on this and other language SIGs, see the OpenTelemetry community page.
 
 ## License
 
-The `opentelemetry-resource-detectors` gem is distributed under the Apache 2.0 license. See LICENSE for more information.
+The `opentelemetry-resource_detectors` gem is distributed under the Apache 2.0 license. See LICENSE for more information.


### PR DESCRIPTION
Reading the docs I caught an error in the README, so I did a fix to match the published gem.