### PR TITLE
feat: Add instrumentation config validation

### DIFF
--- a/api/lib/opentelemetry/instrumentation/base.rb
+++ b/api/lib/opentelemetry/instrumentation/base.rb
@@ -245,7 +245,7 @@ module OpenTelemetry
       # Invalid configuration values are logged, and replaced by the default.
       #
       # @param [Hash] config The user supplied config hash
-      def config_options(config)
+      def config_options(config) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         @options ||= {}
         config ||= {}
 

--- a/api/lib/opentelemetry/instrumentation/base.rb
+++ b/api/lib/opentelemetry/instrumentation/base.rb
@@ -271,9 +271,7 @@ module OpenTelemetry
         end
 
         dropped_config_keys = user_config.keys - validated_config.keys
-        unless dropped_config_keys.empty?
-          OpenTelemetry.logger.warn("Instrumentation #{name} ignored the following unknown configuration options #{dropped_config_keys}")
-        end
+        OpenTelemetry.logger.warn("Instrumentation #{name} ignored the following unknown configuration options #{dropped_config_keys}") unless dropped_config_keys.empty?
 
         validated_config
       end

--- a/api/lib/opentelemetry/instrumentation/base.rb
+++ b/api/lib/opentelemetry/instrumentation/base.rb
@@ -129,9 +129,12 @@ module OpenTelemetry
           @compatible_blk = blk
         end
 
-        # @param [String] name
-        # @param default The default value
-        # @param [Callable] validate A callable the returns a boolean
+        # The option method is used to define default configuration options
+        # for the instrumentation library. It requires a name, default value,
+        # and a validation callable to be provided.
+        # @param [String] name The name of the configuration option
+        # @param default The default value to be used, or to used if validation fails
+        # @param [Callable] validate A callable that validates the option value and returns a boolean
         def option(name, default:, validate:)
           raise ArgumentError, 'validate must be a callable' unless validate.respond_to?(:call)
 

--- a/api/lib/opentelemetry/instrumentation/base.rb
+++ b/api/lib/opentelemetry/instrumentation/base.rb
@@ -59,7 +59,7 @@ module OpenTelemetry
     # convention for environment variable name is the library name, upcased with
     # '::' replaced by underscores, OPENTELEMETRY shortened to OTEL_{LANG}, and '_ENABLED' appended.
     # For example: OTEL_RUBY_INSTRUMENTATION_SINATRA_ENABLED = false.
-    class Base
+    class Base # rubocop:disable Metrics/ClassLength
       class << self
         NAME_REGEX = /^(?:(?<namespace>[a-zA-Z0-9_:]+):{2})?(?<classname>[a-zA-Z0-9_]+)$/.freeze
         private_constant :NAME_REGEX
@@ -134,6 +134,7 @@ module OpenTelemetry
         # @param [Callable] validate A callable the returns a boolean
         def option(name, default:, validate:)
           raise ArgumentError, 'validate must be a callable' unless validate.respond_to?(:call)
+
           @options ||= []
           @options << { name: name, default: default, validate: validate }
         end
@@ -189,6 +190,7 @@ module OpenTelemetry
       def install(config = {})
         return true if installed?
         return false unless installable?(config)
+
         @config = config_options(config)
         instance_exec(@config, &@install_blk)
         @tracer ||= OpenTelemetry.tracer_provider.tracer(name, version)
@@ -249,16 +251,16 @@ module OpenTelemetry
           config_value = config[option_name]
 
           value = if config_value.nil?
-            option[:default]
-          elsif option[:validate].call(config_value)
-            config_value
-          else
-            OpenTelemetry.logger.warn(
-              "Instrumentation #{name} configuration option #{option_name} value=#{config_value} " \
-              "failed validation, falling back to default value=#{option[:default]}"
-            )
-            option[:default]
-          end
+                    option[:default]
+                  elsif option[:validate].call(config_value)
+                    config_value
+                  else
+                    OpenTelemetry.logger.warn(
+                      "Instrumentation #{name} configuration option #{option_name} value=#{config_value} " \
+                      "failed validation, falling back to default value=#{option[:default]}"
+                    )
+                    option[:default]
+                  end
 
           h[option_name] = value
         end

--- a/api/lib/opentelemetry/instrumentation/base.rb
+++ b/api/lib/opentelemetry/instrumentation/base.rb
@@ -266,6 +266,9 @@ module OpenTelemetry
                   end
 
           h[option_name] = value
+        rescue StandardError => e
+          OpenTelemetry.handle_error(exception: e, message: "Instrumentation #{name} unexpected configuration error")
+          h[option_name] = option[:default]
         end
       end
 

--- a/api/lib/opentelemetry/instrumentation/base.rb
+++ b/api/lib/opentelemetry/instrumentation/base.rb
@@ -142,7 +142,9 @@ module OpenTelemetry
         # and a validation callable to be provided.
         # @param [String] name The name of the configuration option
         # @param default The default value to be used, or to used if validation fails
-        # @param [Callable] validate A callable that validates the option value and returns a boolean
+        # @param [Callable, Symbol] validate Accepts a callable or a symbol that matches
+        # a key in the VALIDATORS hash.  The supported keys are, :array, :boolean,
+        # :callable, :integer, :string.
         def option(name, default:, validate:)
           validate = VALIDATORS[validate] || validate
           raise ArgumentError, "validate must be #{VALIDATORS.keys.join(', ')}, or a callable" unless validate.respond_to?(:call)

--- a/api/lib/opentelemetry/instrumentation/base.rb
+++ b/api/lib/opentelemetry/instrumentation/base.rb
@@ -64,13 +64,13 @@ module OpenTelemetry
         NAME_REGEX = /^(?:(?<namespace>[a-zA-Z0-9_:]+):{2})?(?<classname>[a-zA-Z0-9_]+)$/.freeze
         VALIDATORS = {
           array: ->(v) { v.is_a?(Array) },
-          boolean: ->(v) { v.is_a?(TrueClass) || v.is_a?(FalseClass) },
+          boolean: ->(v) { v == true || v == false }, # rubocop:disable Style/MultipleComparison
           callable: ->(v) { v.respond_to?(:call) },
           integer: ->(v) { v.is_a?(Integer) },
           string: ->(v) { v.is_a?(String) }
         }.freeze
 
-        private_constant :NAME_REGEX
+        private_constant :NAME_REGEX, :VALIDATORS
 
         private :new # rubocop:disable Style/AccessModifierDeclarations
 

--- a/api/test/opentelemetry/instrumentation/base_test.rb
+++ b/api/test/opentelemetry/instrumentation/base_test.rb
@@ -77,7 +77,7 @@ describe OpenTelemetry::Instrumentation::Base do
       end
     end
 
-    it 'raises argument errors when validate does not receive a callable' do
+    it 'raises argument errors when validate does not receive a callable or valid symbol' do
       _(-> { instrumentation.instance }).must_raise(ArgumentError)
     end
   end

--- a/api/test/opentelemetry/instrumentation/registry_test.rb
+++ b/api/test/opentelemetry/instrumentation/registry_test.rb
@@ -34,10 +34,12 @@ describe OpenTelemetry::Instrumentation::Registry do
       TestInstrumentation1 = Class.new(OpenTelemetry::Instrumentation::Base) do
         install { 1 + 1 }
         present { true }
+        option :a, default: 'c', validate: ->(v) { v.is_a?(String) }
       end
       TestInstrumentation2 = Class.new(OpenTelemetry::Instrumentation::Base) do
         install { 2 + 2 }
         present { true }
+        option :b, default: 'c', validate: ->(v) { v.is_a?(String) }
       end
       @instrumentation = [TestInstrumentation1, TestInstrumentation2]
       @instrumentation.each { |instrumentation| registry.register(instrumentation) }

--- a/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/instrumentation.rb
+++ b/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/instrumentation.rb
@@ -19,7 +19,7 @@ module OpenTelemetry
           defined?(::Dalli)
         end
 
-        option :peer_service, default: nil, validate: ->(v) { v.is_a?(String) }
+        option :peer_service, default: nil, validate: :string
 
         private
 

--- a/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/instrumentation.rb
+++ b/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/instrumentation.rb
@@ -19,6 +19,8 @@ module OpenTelemetry
           defined?(::Dalli)
         end
 
+        option :peer_service, default: nil, validate: ->(v) { v.is_a?(String) }
+
         private
 
         def require_dependencies

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
@@ -34,9 +34,9 @@ module OpenTelemetry
         # The schemas key expects an array of Schemas, and is used to specify
         # which schemas are to be instrumented. If this value is not supplied
         # the default behaviour is to instrument all schemas.
-        option :schemas, default: [], validate: ->(v) { v.is_a?(Array) }
-        option :enable_platform_field, default: false, validate: ->(v) { v.is_a?(TrueClass) || v.is_a?(FalseClass) }
-        option :enable_platform_authorized, default: false, validate: ->(v) { v.is_a?(TrueClass) || v.is_a?(FalseClass) }
+        option :schemas,                      default: [],    validate: ->(v) { v.is_a?(Array) }
+        option :enable_platform_field,        default: false, validate: ->(v) { v.is_a?(TrueClass) || v.is_a?(FalseClass) }
+        option :enable_platform_authorized,   default: false, validate: ->(v) { v.is_a?(TrueClass) || v.is_a?(FalseClass) }
         option :enable_platform_resolve_type, default: false, validate: ->(v) { v.is_a?(TrueClass) || v.is_a?(FalseClass) }
 
         private

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
@@ -35,9 +35,9 @@ module OpenTelemetry
         # which schemas are to be instrumented. If this value is not supplied
         # the default behaviour is to instrument all schemas.
         option :schemas,                      default: [],    validate: ->(v) { v.is_a?(Array) }
-        option :enable_platform_field,        default: false, validate: ->(v) { v.is_a?(TrueClass) || v.is_a?(FalseClass) }
-        option :enable_platform_authorized,   default: false, validate: ->(v) { v.is_a?(TrueClass) || v.is_a?(FalseClass) }
-        option :enable_platform_resolve_type, default: false, validate: ->(v) { v.is_a?(TrueClass) || v.is_a?(FalseClass) }
+        option :enable_platform_field,        default: false, validate: ->(v) { v == true || v == false }
+        option :enable_platform_authorized,   default: false, validate: ->(v) { v == true || v == false }
+        option :enable_platform_resolve_type, default: false, validate: ->(v) { v == true || v == false }
 
         private
 

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
@@ -11,6 +11,15 @@ module OpenTelemetry
     module GraphQL
       # The Instrumentation class contains logic to detect and install the GraphQL instrumentation
       class Instrumentation < OpenTelemetry::Instrumentation::Base
+        install do |config|
+          require_dependencies
+          install_tracer(config)
+        end
+
+        present do
+          defined?(::GraphQL)
+        end
+
         ## Supported configuration keys for the install config hash:
         #
         # The enable_platform_field key expects a boolean value,
@@ -25,19 +34,10 @@ module OpenTelemetry
         # The schemas key expects an array of Schemas, and is used to specify
         # which schemas are to be instrumented. If this value is not supplied
         # the default behaviour is to instrument all schemas.
-        install do |config|
-          require_dependencies
-          install_tracer(config)
-        end
-
-        present do
-          defined?(::GraphQL)
-        end
-
         option :schemas, default: [], validate: ->(v) { v.is_a?(Array) }
-        option :enable_platform_field, default: false, validate: ->(v) { v }
-        option :enable_platform_authorized, default: false, validate: ->(v) { v }
-        option :enable_platform_resolve_type, default: false, validate: ->(v) { v }
+        option :enable_platform_field, default: false, validate: ->(v) { v.is_a?(TrueClass) || v.is_a?(FalseClass) }
+        option :enable_platform_authorized, default: false, validate: ->(v) { v.is_a?(TrueClass) || v.is_a?(FalseClass) }
+        option :enable_platform_resolve_type, default: false, validate: ->(v) { v.is_a?(TrueClass) || v.is_a?(FalseClass) }
 
         private
 

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
@@ -34,10 +34,10 @@ module OpenTelemetry
         # The schemas key expects an array of Schemas, and is used to specify
         # which schemas are to be instrumented. If this value is not supplied
         # the default behaviour is to instrument all schemas.
-        option :schemas,                      default: [],    validate: ->(v) { v.is_a?(Array) }
-        option :enable_platform_field,        default: false, validate: ->(v) { v == true || v == false }
-        option :enable_platform_authorized,   default: false, validate: ->(v) { v == true || v == false }
-        option :enable_platform_resolve_type, default: false, validate: ->(v) { v == true || v == false }
+        option :schemas,                      default: [],    validate: :array
+        option :enable_platform_field,        default: false, validate: :boolean
+        option :enable_platform_authorized,   default: false, validate: :boolean
+        option :enable_platform_resolve_type, default: false, validate: :boolean
 
         private
 

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
@@ -34,7 +34,7 @@ module OpenTelemetry
           defined?(::GraphQL)
         end
 
-        option :schemas, default: nil, validate: ->(v) { v.is_a?(Array) }, allow_nil: true
+        option :schemas, default: [], validate: ->(v) { v.is_a?(Array) }
         option :enable_platform_field, default: false, validate: ->(v) { v }
         option :enable_platform_authorized, default: false, validate: ->(v) { v }
         option :enable_platform_resolve_type, default: false, validate: ->(v) { v }
@@ -46,7 +46,7 @@ module OpenTelemetry
         end
 
         def install_tracer(config = {})
-          if config[:schemas].nil? || config[:schemas].empty?
+          if config[:schemas].empty?
             ::GraphQL::Schema.tracer(Tracers::GraphQLTracer.new)
           else
             config[:schemas].each do |schema|

--- a/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
+++ b/instrumentation/graphql/lib/opentelemetry/instrumentation/graphql/instrumentation.rb
@@ -34,6 +34,11 @@ module OpenTelemetry
           defined?(::GraphQL)
         end
 
+        option :schemas, default: nil, validate: ->(v) { v.is_a?(Array) }, allow_nil: true
+        option :enable_platform_field, default: false, validate: ->(v) { v }
+        option :enable_platform_authorized, default: false, validate: ->(v) { v }
+        option :enable_platform_resolve_type, default: false, validate: ->(v) { v }
+
         private
 
         def require_dependencies

--- a/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/instrumentation.rb
+++ b/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/instrumentation.rb
@@ -19,6 +19,8 @@ module OpenTelemetry
           defined?(::Mysql2)
         end
 
+        option :peer_service, default: nil, validate: ->(v) { v.is_a?(String) }
+
         private
 
         def require_dependencies

--- a/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/instrumentation.rb
+++ b/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/instrumentation.rb
@@ -19,7 +19,7 @@ module OpenTelemetry
           defined?(::Mysql2)
         end
 
-        option :peer_service, default: nil, validate: ->(v) { v.is_a?(String) }
+        option :peer_service, default: nil, validate: :string
 
         private
 

--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/instrumentation.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/instrumentation.rb
@@ -25,8 +25,8 @@ module OpenTelemetry
         option :allowed_request_headers,  default: [],    validate: ->(v) { v.is_a?(Array) }
         option :allowed_response_headers, default: [],    validate: ->(v) { v.is_a?(Array) }
         option :application,              default: nil,   validate: ->(v) { v.respond_to?(:call) }
-        option :record_frontend_span,     default: false, validate: ->(v) { v.is_a?(TrueClass) || v.is_a?(FalseClass) }
-        option :retain_middleware_names,  default: false, validate: ->(v) { v }
+        option :record_frontend_span,     default: false, validate: ->(v) { v == true || v == false }
+        option :retain_middleware_names,  default: false, validate: ->(v) { v == true || v == false }
         option :untraced_endpoints,       default: [],    validate: ->(v) { v.is_a?(Array) }
         option :url_quantization,         default: nil,   validate: ->(v) { v.respond_to?(:call) }
 

--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/instrumentation.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/instrumentation.rb
@@ -22,6 +22,14 @@ module OpenTelemetry
           defined?(::Rack)
         end
 
+        option :allowed_request_headers,  default: [],    validate: ->(v) { v.is_a?(Array) }
+        option :allowed_response_headers, default: [],    validate: ->(v) { v.is_a?(Array) }
+        option :application,              default: nil,   validate: ->(v) { v.respond_to?(:call) }
+        option :record_frontend_span,     default: false, validate: ->(v) { v.is_a?(TrueClass) || v.is_a?(FalseClass) }
+        option :retain_middleware_names,  default: false, validate: ->(v) { v }
+        option :untraced_endpoints,       default: [],    validate: ->(v) { v.is_a?(Array) }
+        option :url_quantization,         default: nil,   validate: ->(v) { v.respond_to?(:call) }
+
         private
 
         def require_dependencies

--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/instrumentation.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/instrumentation.rb
@@ -22,13 +22,13 @@ module OpenTelemetry
           defined?(::Rack)
         end
 
-        option :allowed_request_headers,  default: [],    validate: ->(v) { v.is_a?(Array) }
-        option :allowed_response_headers, default: [],    validate: ->(v) { v.is_a?(Array) }
-        option :application,              default: nil,   validate: ->(v) { v.respond_to?(:call) }
-        option :record_frontend_span,     default: false, validate: ->(v) { v == true || v == false }
-        option :retain_middleware_names,  default: false, validate: ->(v) { v == true || v == false }
-        option :untraced_endpoints,       default: [],    validate: ->(v) { v.is_a?(Array) }
-        option :url_quantization,         default: nil,   validate: ->(v) { v.respond_to?(:call) }
+        option :allowed_request_headers,  default: [],    validate: :array
+        option :allowed_response_headers, default: [],    validate: :array
+        option :application,              default: nil,   validate: :callable
+        option :record_frontend_span,     default: false, validate: :boolean
+        option :retain_middleware_names,  default: false, validate: :boolean
+        option :untraced_endpoints,       default: [],    validate: :array
+        option :url_quantization,         default: nil,   validate: :callable
 
         private
 

--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
@@ -49,7 +49,7 @@ module OpenTelemetry
 
           def initialize(app)
             @app = app
-            @untraced_endpoints = config[:untraced_endpoints].is_a?(Array) ? config[:untraced_endpoints] : []
+            @untraced_endpoints = config[:untraced_endpoints]
           end
 
           def call(env) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength

--- a/instrumentation/redis/lib/opentelemetry/instrumentation/redis/instrumentation.rb
+++ b/instrumentation/redis/lib/opentelemetry/instrumentation/redis/instrumentation.rb
@@ -19,7 +19,7 @@ module OpenTelemetry
           defined?(::Redis)
         end
 
-        option :peer_service, default: nil, validate: ->(v) { v.is_a?(String) }
+        option :peer_service, default: nil, validate: :string
 
         private
 

--- a/instrumentation/redis/lib/opentelemetry/instrumentation/redis/instrumentation.rb
+++ b/instrumentation/redis/lib/opentelemetry/instrumentation/redis/instrumentation.rb
@@ -19,6 +19,8 @@ module OpenTelemetry
           defined?(::Redis)
         end
 
+        option :peer_service, default: nil, validate: ->(v) { v.is_a?(String) }
+
         private
 
         def require_dependencies

--- a/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/instrumentation.rb
+++ b/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/instrumentation.rb
@@ -27,11 +27,11 @@ module OpenTelemetry
           gem_version >= MINIMUM_VERSION
         end
 
-        option :enable_job_class_span_names, default: false, validate: ->(v) { v.is_a?(TrueClass) || v.is_a?(FalseClass) }
-        option :trace_launcher_heartbeat,    default: false, validate: ->(v) { v.is_a?(TrueClass) || v.is_a?(FalseClass) }
-        option :trace_poller_enqueue,        default: false, validate: ->(v) { v.is_a?(TrueClass) || v.is_a?(FalseClass) }
-        option :trace_poller_wait,           default: false, validate: ->(v) { v.is_a?(TrueClass) || v.is_a?(FalseClass) }
-        option :trace_processor_process_one, default: false, validate: ->(v) { v.is_a?(TrueClass) || v.is_a?(FalseClass) }
+        option :enable_job_class_span_names, default: false, validate: ->(v) { v == true || v == false }
+        option :trace_launcher_heartbeat,    default: false, validate: ->(v) { v == true || v == false }
+        option :trace_poller_enqueue,        default: false, validate: ->(v) { v == true || v == false }
+        option :trace_poller_wait,           default: false, validate: ->(v) { v == true || v == false }
+        option :trace_processor_process_one, default: false, validate: ->(v) { v == true || v == false }
 
         private
 

--- a/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/instrumentation.rb
+++ b/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/instrumentation.rb
@@ -27,11 +27,11 @@ module OpenTelemetry
           gem_version >= MINIMUM_VERSION
         end
 
-        option :enable_job_class_span_names, default: false, validate: ->(v) { v == true || v == false }
-        option :trace_launcher_heartbeat,    default: false, validate: ->(v) { v == true || v == false }
-        option :trace_poller_enqueue,        default: false, validate: ->(v) { v == true || v == false }
-        option :trace_poller_wait,           default: false, validate: ->(v) { v == true || v == false }
-        option :trace_processor_process_one, default: false, validate: ->(v) { v == true || v == false }
+        option :enable_job_class_span_names, default: false, validate: :boolean
+        option :trace_launcher_heartbeat,    default: false, validate: :boolean
+        option :trace_poller_enqueue,        default: false, validate: :boolean
+        option :trace_poller_wait,           default: false, validate: :boolean
+        option :trace_processor_process_one, default: false, validate: :boolean
 
         private
 

--- a/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/instrumentation.rb
+++ b/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/instrumentation.rb
@@ -27,6 +27,12 @@ module OpenTelemetry
           gem_version >= MINIMUM_VERSION
         end
 
+        option :enable_job_class_span_names, default: false, validate: ->(v) { v.is_a?(TrueClass) || v.is_a?(FalseClass) }
+        option :trace_launcher_heartbeat,    default: false, validate: ->(v) { v.is_a?(TrueClass) || v.is_a?(FalseClass) }
+        option :trace_poller_enqueue,        default: false, validate: ->(v) { v.is_a?(TrueClass) || v.is_a?(FalseClass) }
+        option :trace_poller_wait,           default: false, validate: ->(v) { v.is_a?(TrueClass) || v.is_a?(FalseClass) }
+        option :trace_processor_process_one, default: false, validate: ->(v) { v.is_a?(TrueClass) || v.is_a?(FalseClass) }
+
         private
 
         def gem_version

--- a/sdk/test/opentelemetry/sdk/configurator_test.rb
+++ b/sdk/test/opentelemetry/sdk/configurator_test.rb
@@ -205,7 +205,7 @@ describe OpenTelemetry::SDK::Configurator do
         TestInstrumentation = Class.new(OpenTelemetry::Instrumentation::Base) do
           install { 1 + 1 }
           present { true }
-          option :opt, default: false, validate: ->(v) { v }
+          option :opt, default: false, validate: :boolean
         end
       end
 

--- a/sdk/test/opentelemetry/sdk/configurator_test.rb
+++ b/sdk/test/opentelemetry/sdk/configurator_test.rb
@@ -205,6 +205,7 @@ describe OpenTelemetry::SDK::Configurator do
         TestInstrumentation = Class.new(OpenTelemetry::Instrumentation::Base) do
           install { 1 + 1 }
           present { true }
+          option :opt, default: false, validate: ->(v) { v }
         end
       end
 


### PR DESCRIPTION
During this weeks SIG I proposed adding a validation step of sorts to create a more structured interface for our instrumentation configuration.

This idea sparked from this comment chain https://github.com/open-telemetry/opentelemetry-ruby/pull/594#discussion_r568753846