### PR TITLE
fix!: streamline processor pipeline

### DIFF
--- a/exporter/jaeger/README.md
+++ b/exporter/jaeger/README.md
@@ -35,7 +35,7 @@ require 'opentelemetry/exporter/jaeger'
 OpenTelemetry::SDK.configure do |c|
   c.add_span_processor(
     OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
-      exporter: OpenTelemetry::Exporter::Jaeger::AgentExporter.new(host: '127.0.0.1', port: 6831)
+      OpenTelemetry::Exporter::Jaeger::AgentExporter.new(host: '127.0.0.1', port: 6831)
       # Alternatively, for the collector exporter:
       # exporter: OpenTelemetry::Exporter::Jaeger::CollectorExporter.new(endpoint: 'http://192.168.0.1:14268/api/traces')
     )

--- a/exporter/jaeger/test/opentelemetry/exporters/jaeger/agent_exporter_test.rb
+++ b/exporter/jaeger/test/opentelemetry/exporters/jaeger/agent_exporter_test.rb
@@ -57,7 +57,7 @@ describe OpenTelemetry::Exporter::Jaeger::AgentExporter do
       socket = UDPSocket.new
       socket.bind('127.0.0.1', 0)
       exporter = OpenTelemetry::Exporter::Jaeger::AgentExporter.new(host: '127.0.0.1', port: socket.addr[1])
-      processor = OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(exporter: exporter, max_queue_size: 1, max_export_batch_size: 1)
+      processor = OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(exporter, max_queue_size: 1, max_export_batch_size: 1)
       OpenTelemetry.tracer_provider.add_span_processor(processor)
       OpenTelemetry.tracer_provider.tracer.start_root_span('foo').finish
       OpenTelemetry.tracer_provider.shutdown

--- a/exporter/jaeger/test/opentelemetry/exporters/jaeger/collector_exporter_test.rb
+++ b/exporter/jaeger/test/opentelemetry/exporters/jaeger/collector_exporter_test.rb
@@ -115,7 +115,7 @@ describe OpenTelemetry::Exporter::Jaeger::CollectorExporter do
     it 'exports a span from a tracer' do
       stub_post = stub_request(:post, DEFAULT_JAEGER_COLLECTOR_ENDPOINT).to_return(status: 200)
       exporter = OpenTelemetry::Exporter::Jaeger::CollectorExporter.new
-      processor = OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(exporter: exporter, max_queue_size: 1, max_export_batch_size: 1)
+      processor = OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(exporter, max_queue_size: 1, max_export_batch_size: 1)
       OpenTelemetry.tracer_provider.add_span_processor(processor)
       OpenTelemetry.tracer_provider.tracer.start_root_span('foo').finish
       OpenTelemetry.tracer_provider.shutdown

--- a/exporter/otlp/README.md
+++ b/exporter/otlp/README.md
@@ -39,7 +39,7 @@ require 'opentelemetry/exporter/otlp'
 OpenTelemetry::SDK.configure do |c|
   c.add_span_processor(
     OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
-      exporter: OpenTelemetry::Exporter::OTLP::Exporter.new(
+      OpenTelemetry::Exporter::OTLP::Exporter.new(
         endpoint: 'http://localhost:55680'
       )
     )

--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -158,7 +158,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
 
     it 'exports a span from a tracer' do
       stub_post = stub_request(:post, 'https://localhost:4317/v1/traces').to_return(status: 200)
-      processor = OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(exporter: exporter, max_queue_size: 1, max_export_batch_size: 1)
+      processor = OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(exporter, max_queue_size: 1, max_export_batch_size: 1)
       OpenTelemetry.tracer_provider.add_span_processor(processor)
       OpenTelemetry.tracer_provider.tracer.start_root_span('foo').finish
       OpenTelemetry.tracer_provider.shutdown
@@ -167,9 +167,8 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
 
     it 'compresses with gzip if enabled' do
       exporter = OpenTelemetry::Exporter::OTLP::Exporter.new(compression: 'gzip')
-      etsr = nil
       stub_post = stub_request(:post, 'https://localhost:4317/v1/traces').to_return do |request|
-        etsr = Opentelemetry::Proto::Collector::Trace::V1::ExportTraceServiceRequest.decode(Zlib.gunzip(request.body))
+        Opentelemetry::Proto::Collector::Trace::V1::ExportTraceServiceRequest.decode(Zlib.gunzip(request.body))
         { status: 200 }
       end
 
@@ -199,7 +198,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
 
     it 'translates all the things' do
       stub_request(:post, 'https://localhost:4317/v1/traces').to_return(status: 200)
-      processor = OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(exporter: exporter)
+      processor = OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(exporter)
       tracer = OpenTelemetry.tracer_provider.tracer('tracer', 'v0.0.1')
       other_tracer = OpenTelemetry.tracer_provider.tracer('other_tracer')
 

--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -28,7 +28,8 @@ module OpenTelemetry
         class BatchSpanProcessor # rubocop:disable Metrics/ClassLength
           # Returns a new instance of the {BatchSpanProcessor}.
           #
-          # @param [SpanExporter] exporter
+          # @param [SpanExporter] exporter the (duck type) SpanExporter to where the
+          #   recorded Spans are pushed after batching.
           # @param [Numeric] exporter_timeout the delay interval between two
           #   consecutive exports. Defaults to the value of the OTEL_BSP_EXPORT_TIMEOUT
           #   environment variable, if set, or 30,000 (30 seconds).
@@ -43,7 +44,7 @@ module OpenTelemetry
           #   variable, if set, or 512.
           #
           # @return a new instance of the {BatchSpanProcessor}.
-          def initialize(exporter:,
+          def initialize(exporter,
                          exporter_timeout: Float(ENV.fetch('OTEL_BSP_EXPORT_TIMEOUT', 30_000)),
                          schedule_delay: Float(ENV.fetch('OTEL_BSP_SCHEDULE_DELAY', 5_000)),
                          max_queue_size: Integer(ENV.fetch('OTEL_BSP_MAX_QUEUE_SIZE', 2048)),

--- a/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
@@ -65,11 +65,6 @@ module OpenTelemetry
 
         # Adds a new SpanProcessor to this {Tracer}.
         #
-        # Any registered processor causes overhead, consider to use an
-        # async/batch processor especially for span exporting, and export to
-        # multiple backends using the
-        # {io.opentelemetry.sdk.trace.export.MultiSpanExporter}.
-        #
         # @param span_processor the new SpanProcessor to be added.
         def add_span_processor(span_processor)
           @mutex.synchronize do

--- a/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
@@ -78,7 +78,11 @@ module OpenTelemetry
               return
             end
             @registered_span_processors << span_processor
-            @active_span_processor = MultiSpanProcessor.new(@registered_span_processors.dup)
+            @active_span_processor = if @registered_span_processors.size == 1
+                                       span_processor
+                                     else
+                                       MultiSpanProcessor.new(@registered_span_processors.dup)
+                                     end
           end
         end
       end

--- a/sdk/test/integration/global_tracer_configurations_test.rb
+++ b/sdk/test/integration/global_tracer_configurations_test.rb
@@ -43,7 +43,7 @@ describe OpenTelemetry::SDK, 'global_tracer_configurations' do
   end
 
   describe 'using batch span processor' do
-    let(:span_processor) { sdk::Trace::Export::BatchSpanProcessor.new(exporter: exporter) }
+    let(:span_processor) { sdk::Trace::Export::BatchSpanProcessor.new(exporter) }
 
     it "doesn't crash" do
       finished_spans

--- a/sdk/test/opentelemetry/sdk/configurator_test.rb
+++ b/sdk/test/opentelemetry/sdk/configurator_test.rb
@@ -179,10 +179,7 @@ describe OpenTelemetry::SDK::Configurator do
       it 'defaults to SimpleSpanProcessor w/ ConsoleSpanExporter' do
         configurator.configure
 
-        processors = active_span_processors
-
-        _(processors.size).must_equal(1)
-        _(processors.first).must_be_instance_of(
+        _(OpenTelemetry.tracer_provider.active_span_processor).must_be_instance_of(
           OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor
         )
       end
@@ -190,15 +187,13 @@ describe OpenTelemetry::SDK::Configurator do
       it 'reflects configured value' do
         configurator.add_span_processor(
           OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
-            exporter: OpenTelemetry::SDK::Trace::Export::ConsoleSpanExporter.new
+            OpenTelemetry::SDK::Trace::Export::ConsoleSpanExporter.new
           )
         )
 
         configurator.configure
-        processors = active_span_processors
 
-        _(processors.size).must_equal(1)
-        _(processors.first).must_be_instance_of(
+        _(OpenTelemetry.tracer_provider.active_span_processor).must_be_instance_of(
           OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor
         )
       end
@@ -239,10 +234,6 @@ describe OpenTelemetry::SDK::Configurator do
         _(instrumentation.config).must_equal(opt: true)
       end
     end
-  end
-
-  def active_span_processors
-    OpenTelemetry.tracer_provider.active_span_processor.instance_variable_get(:@span_processors)
   end
 
   def extractors_for(propagator)

--- a/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
@@ -59,14 +59,14 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
   describe 'initialization' do
     it 'if max batch size is gt max queue size raise' do
       assert_raises ArgumentError do
-        BatchSpanProcessor.new(exporter: TestExporter.new, max_queue_size: 6, max_export_batch_size: 999)
+        BatchSpanProcessor.new(TestExporter.new, max_queue_size: 6, max_export_batch_size: 999)
       end
     end
 
     it 'raises if OTEL_BSP_EXPORT_TIMEOUT env var is not numeric' do
       assert_raises ArgumentError do
         with_env('OTEL_BSP_EXPORT_TIMEOUT' => 'foo') do
-          BatchSpanProcessor.new(exporter: TestExporter.new)
+          BatchSpanProcessor.new(TestExporter.new)
         end
       end
     end
@@ -76,7 +76,7 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
                      'OTEL_BSP_SCHEDULE_DELAY' => '3',
                      'OTEL_BSP_MAX_QUEUE_SIZE' => '2',
                      'OTEL_BSP_MAX_EXPORT_BATCH_SIZE' => '1') do
-        BatchSpanProcessor.new(exporter: TestExporter.new)
+        BatchSpanProcessor.new(TestExporter.new)
       end
       _(bsp.instance_variable_get(:@exporter_timeout_seconds)).must_equal 0.004
       _(bsp.instance_variable_get(:@delay_seconds)).must_equal 0.003
@@ -89,7 +89,7 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
                      'OTEL_BSP_SCHEDULE_DELAY' => '3',
                      'OTEL_BSP_MAX_QUEUE_SIZE' => '2',
                      'OTEL_BSP_MAX_EXPORT_BATCH_SIZE' => '1') do
-        BatchSpanProcessor.new(exporter: TestExporter.new,
+        BatchSpanProcessor.new(TestExporter.new,
                                exporter_timeout: 10,
                                schedule_delay: 9,
                                max_queue_size: 8,
@@ -102,7 +102,7 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
     end
 
     it 'sets defaults for parameters not in the environment' do
-      bsp = BatchSpanProcessor.new(exporter: TestExporter.new)
+      bsp = BatchSpanProcessor.new(TestExporter.new)
       _(bsp.instance_variable_get(:@exporter_timeout_seconds)).must_equal 30.0
       _(bsp.instance_variable_get(:@delay_seconds)).must_equal 5.0
       _(bsp.instance_variable_get(:@max_queue_size)).must_equal 2048
@@ -114,7 +114,7 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
       mock.expect(:call, nil)
 
       Thread.stub(:new, mock) do
-        BatchSpanProcessor.new(exporter: TestExporter.new)
+        BatchSpanProcessor.new(TestExporter.new)
       end
 
       mock.verify
@@ -126,7 +126,7 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
 
       Thread.stub(:new, mock) do
         with_env('OTEL_RUBY_BSP_START_THREAD_ON_BOOT' => 'true') do
-          BatchSpanProcessor.new(exporter: TestExporter.new)
+          BatchSpanProcessor.new(TestExporter.new)
         end
       end
 
@@ -139,7 +139,7 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
 
       Thread.stub(:new, mock) do
         with_env('OTEL_RUBY_BSP_START_THREAD_ON_BOOT' => 'false') do
-          BatchSpanProcessor.new(exporter: TestExporter.new)
+          BatchSpanProcessor.new(TestExporter.new)
         end
       end
     end
@@ -150,7 +150,7 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
 
       Thread.stub(:new, mock) do
         with_env('OTEL_RUBY_BSP_START_THREAD_ON_BOOT' => 'true') do
-          BatchSpanProcessor.new(exporter: TestExporter.new,
+          BatchSpanProcessor.new(TestExporter.new,
                                  start_thread_on_boot: false)
         end
       end
@@ -160,7 +160,7 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
   describe '#force_flush' do
     it 'reenqueues excess spans on timeout' do
       test_exporter = TestExporter.new
-      bsp = BatchSpanProcessor.new(exporter: test_exporter)
+      bsp = BatchSpanProcessor.new(test_exporter)
       bsp.on_finish(TestSpan.new)
       result = bsp.force_flush(timeout: 0)
 
@@ -176,7 +176,7 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
   describe '#shutdown' do
     it 'respects the timeout' do
       test_exporter = TestExporter.new
-      bsp = BatchSpanProcessor.new(exporter: test_exporter)
+      bsp = BatchSpanProcessor.new(test_exporter)
       bsp.on_finish(TestSpan.new)
       bsp.shutdown(timeout: 0)
 
@@ -187,20 +187,20 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
     end
 
     it 'works if the thread is not running' do
-      bsp = BatchSpanProcessor.new(exporter: TestExporter.new, start_thread_on_boot: false)
+      bsp = BatchSpanProcessor.new(TestExporter.new, start_thread_on_boot: false)
       bsp.shutdown(timeout: 0)
     end
   end
 
   describe 'lifecycle' do
     it 'should stop and start correctly' do
-      bsp = BatchSpanProcessor.new(exporter: TestExporter.new)
+      bsp = BatchSpanProcessor.new(TestExporter.new)
       bsp.shutdown
     end
 
     it 'should flush everything on shutdown' do
       te = TestExporter.new
-      bsp = BatchSpanProcessor.new(exporter: te)
+      bsp = BatchSpanProcessor.new(te)
       ts = TestSpan.new
       bsp.on_finish(ts)
 
@@ -214,7 +214,7 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
     it 'should batch up to but not over the max_batch' do
       te = TestExporter.new
 
-      bsp = BatchSpanProcessor.new(exporter: te, max_queue_size: 6, max_export_batch_size: 3)
+      bsp = BatchSpanProcessor.new(te, max_queue_size: 6, max_export_batch_size: 3)
 
       tss = [TestSpan.new, TestSpan.new, TestSpan.new, TestSpan.new]
       tss.each { |ts| bsp.on_finish(ts) }
@@ -227,7 +227,7 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
     it 'should batch only recording samples' do
       te = TestExporter.new
 
-      bsp = BatchSpanProcessor.new(exporter: te, max_queue_size: 6, max_export_batch_size: 3)
+      bsp = BatchSpanProcessor.new(te, max_queue_size: 6, max_export_batch_size: 3)
 
       tss = [TestSpan.new, TestSpan.new(nil, false)]
       tss.each { |ts| bsp.on_finish(ts) }
@@ -241,8 +241,8 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
     it 'should not retry on FAILURE exports' do
       te = TestExporter.new(status_codes: [FAILURE, SUCCESS])
 
-      bsp = BatchSpanProcessor.new(schedule_delay: 999,
-                                   exporter: te,
+      bsp = BatchSpanProcessor.new(te,
+                                   schedule_delay: 999,
                                    max_queue_size: 6,
                                    max_export_batch_size: 3)
 
@@ -265,7 +265,7 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
     it 'shouldnt blow up with a lot of things' do
       te = TestExporter.new
 
-      bsp = BatchSpanProcessor.new(exporter: te)
+      bsp = BatchSpanProcessor.new(te)
       producers = 10.times.map do |i|
         Thread.new do
           x = i * 10
@@ -289,7 +289,7 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
   describe 'fork safety test' do
     let(:exporter) { TestExporter.new }
     let(:bsp) do
-      BatchSpanProcessor.new(exporter: exporter,
+      BatchSpanProcessor.new(exporter,
                              max_queue_size: 10,
                              max_export_batch_size: 3)
     end


### PR DESCRIPTION
This streamlines the SpanProcessor pipeline in the common case (a single non-noop processor), removing the (double) indirection through MultiSpanProcessor when only a single span processor is registered.

It also replaces the required `exporter:` keyword parameter to the BatchSpanProcessor initializer with a positional parameter. This aligns it with the SimpleSpanProcessor initializer and avoids a (probably common) mistake when switching between the BatchSpanProcessor and SimpleSpanProcessor. (e.g. #595).