### PR TITLE
feat: add otlp exporter hooks

### DIFF
--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -120,7 +120,7 @@ module OpenTelemetry
         # is to not trace these operations.
         #
         # An example use case would be to prepend a patch, or extend this class
-        # and override this methods behaviour to explicitly trace the. ttp request.
+        # and override this method's behaviour to explicitly trace the HTTP request.
         # This would allow you to trace your export pipeline.
         def around_request
           OpenTelemetry::Common::Utilities.untraced { yield }

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -42,10 +42,10 @@ module OpenTelemetry
           raise ArgumentError, 'headers must be comma-separated k=v pairs or a Hash' unless valid_headers?(headers)
 
           @uri = if endpoint == ENV['OTEL_EXPORTER_OTLP_ENDPOINT']
-                  URI("#{endpoint}/v1/traces")
-                else
-                  URI(endpoint)
-                end
+                   URI("#{endpoint}/v1/traces")
+                 else
+                   URI(endpoint)
+                 end
 
           @http = Net::HTTP.new(@uri.host, @uri.port)
           @http.use_ssl = @uri.scheme == 'https'

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -115,7 +115,14 @@ module OpenTelemetry
           true
         end
 
-        def trace_request
+        # The around_request is a private method that provides an extension
+        # point for the exporters network calls. The default behaviour
+        # is to not trace these operations.
+        #
+        # An example use case would be to prepend a patch, or extend this class
+        # and override this methods behaviour to explicitly trace the. ttp request.
+        # This would allow you to trace your export pipeline.
+        def around_request
           OpenTelemetry::Common::Utilities.untraced { yield }
         end
 
@@ -123,7 +130,7 @@ module OpenTelemetry
           retry_count = 0
           timeout ||= @timeout
           start_time = Time.now
-          trace_request do # rubocop:disable Metrics/BlockLength
+          around_request do # rubocop:disable Metrics/BlockLength
             request = Net::HTTP::Post.new(@path)
             request.body = if @compression == 'gzip'
                              request.add_field('Content-Encoding', 'gzip')


### PR DESCRIPTION
The intention of this method is to allow users of the exporter to either
prepend or inherit from the class so that the exporter send_bytes
method can be traced, or wrapped with any other customer methods.

Two example use cases:
- Tracing the trace pipeline itself, this would allow for the an end to end tracing of the exporter/tracing pipeline
- In some applications we have a requirement of explicitly permitting URLs that are allowed to be communicated via HTTP.  In those applications we will need this hook to wrap the `send_byes` http call with an allow method that permits the network call.