### PR TITLE
fix: OTEL_TRACES_EXPORTER and OTEL_PROPAGATORS

### DIFF
--- a/sdk/Gemfile
+++ b/sdk/Gemfile
@@ -11,3 +11,4 @@ gemspec
 # Use the opentelemetry-api gem from source
 gem 'opentelemetry-api', path: '../api'
 gem 'opentelemetry-common', path: '../common'
+gem 'opentelemetry-exporter-jaeger', path: '../exporter/jaeger'

--- a/sdk/opentelemetry-sdk.gemspec
+++ b/sdk/opentelemetry-sdk.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'faraday', '~> 0.13'
   spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'opentelemetry-exporter-jaeger', '~> 0.14.0'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rubocop', '~> 0.73.0'
   spec.add_development_dependency 'simplecov', '~> 0.17'

--- a/sdk/test/opentelemetry/sdk/configurator_test.rb
+++ b/sdk/test/opentelemetry/sdk/configurator_test.rb
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require 'test_helper'
+require 'opentelemetry/exporter/jaeger'
 
 describe OpenTelemetry::SDK::Configurator do
   let(:configurator) { OpenTelemetry::SDK::Configurator.new }
@@ -245,8 +246,10 @@ describe OpenTelemetry::SDK::Configurator do
           configurator.configure
         end
 
-        skip 'how do we load this gem for testing?'
         _(OpenTelemetry.tracer_provider.active_span_processor).must_be_instance_of(
+          OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor
+        )
+        _(OpenTelemetry.tracer_provider.active_span_processor.instance_variable_get(:@exporter)).must_be_instance_of(
           OpenTelemetry::Exporter::Jaeger::CollectorExporter
         )
       end

--- a/sdk/test/opentelemetry/sdk/configurator_test.rb
+++ b/sdk/test/opentelemetry/sdk/configurator_test.rb
@@ -176,11 +176,11 @@ describe OpenTelemetry::SDK::Configurator do
     end
 
     describe 'span processors' do
-      it 'defaults to SimpleSpanProcessor w/ ConsoleSpanExporter' do
+      it 'defaults to NoopSpanProcessor if no valid exporter is available' do
         configurator.configure
 
         _(OpenTelemetry.tracer_provider.active_span_processor).must_be_instance_of(
-          OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor
+          OpenTelemetry::SDK::Trace::NoopSpanProcessor
         )
       end
 


### PR DESCRIPTION
Fixes #412 and #403

Many of the supported propagators and exporters are required to be implemented external to the SDK, so this requires making assumptions about the structure of the external gems.

The `OTEL_TRACES_EXPORTER` env var is not especially useful for a couple of reasons:
1. The default span processor is not specified and there is no specified environment variable to select it. We defaulted to the `SimpleSpanProcessor` previously, and I've kept that default here, but that is rarely useful with any of the defined exporters.
2. We previously defaulted to `ConsoleSpanExporter`, but the specified default is OTLP, so we instead fall back to `ConsoleSpanExporter` if either an unsupported exporter is requested or a supported but unavailable exporter is requested. In either case, we log a warning, so the out-of-the-box experience is a little noisier.

It may make more sense to wrap any supported exporter in a BSP, and otherwise default to a `ConsoleSpanExporter` wrapped in a `SimpleSpanProcessor` 🤔 - I'll try that... That'll fix 1, but 2 will still be noisy.

### TODO
- [x] tests for new functionality
- [x] change the wrapping of exporters