### PR TITLE
fix: add thread error handling to the BSP

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -177,8 +177,9 @@ module OpenTelemetry
             @pid = pid
             spans.clear
             @thread = restart_thread ? Thread.new { work } : nil
-          rescue ThreadError
-            @metrics_reporter.add_to_counter('otel.bsp.failure', labels: { 'reason' => 'ThreadError' })
+          rescue ThreadError => error
+            @metrics_reporter.add_to_counter('otel.bsp.error', labels: { 'reason' => 'ThreadError' })
+            OpenTelemetry.logger.error "OpenTelemetry error in BatchSpanProcessor#reset_on_fork #{error.message}"
           end
 
           def export_batch(batch, timeout: @exporter_timeout_seconds)

--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -177,9 +177,9 @@ module OpenTelemetry
             @pid = pid
             spans.clear
             @thread = restart_thread ? Thread.new { work } : nil
-          rescue ThreadError => error
+          rescue ThreadError => e
             @metrics_reporter.add_to_counter('otel.bsp.error', labels: { 'reason' => 'ThreadError' })
-            OpenTelemetry.logger.error "OpenTelemetry error in BatchSpanProcessor#reset_on_fork #{error.message}"
+            OpenTelemetry.logger.error "OpenTelemetry error in BatchSpanProcessor#reset_on_fork #{e.message}"
           end
 
           def export_batch(batch, timeout: @exporter_timeout_seconds)

--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -179,7 +179,7 @@ module OpenTelemetry
             @thread = restart_thread ? Thread.new { work } : nil
           rescue ThreadError => e
             @metrics_reporter.add_to_counter('otel.bsp.error', labels: { 'reason' => 'ThreadError' })
-            OpenTelemetry.logger.error "OpenTelemetry error in BatchSpanProcessor#reset_on_fork #{e.message}"
+            OpenTelemetry.handle_error(exception: e, message: 'unexpected error in BatchSpanProcessor#reset_on_fork')
           end
 
           def export_batch(batch, timeout: @exporter_timeout_seconds)

--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -177,6 +177,8 @@ module OpenTelemetry
             @pid = pid
             spans.clear
             @thread = restart_thread ? Thread.new { work } : nil
+          rescue ThreadError
+            @metrics_reporter.add_to_counter('otel.bsp.failure', labels: { 'reason' => 'ThreadError' })
           end
 
           def export_batch(batch, timeout: @exporter_timeout_seconds)


### PR DESCRIPTION
This adds graceful handling for when creating a new thread raises.  We observed this scenario with an application that was improperly terminating sidekiq which resulted in a `ThreadError`.

mperham/sidekiq#4029
mperham/sidekiq#4738