### PR TITLE
feat: add Net::HTTP#connect tracing

### DIFF
--- a/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/patches/instrumentation.rb
+++ b/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/patches/instrumentation.rb
@@ -40,6 +40,24 @@ module OpenTelemetry
 
             private
 
+            def connect
+              if proxy?
+                conn_address = proxy_address
+                conn_port    = proxy_port
+              else
+                conn_address = address
+                conn_port    = port
+              end
+
+              attributes = OpenTelemetry::Common::HTTP::ClientContext.attributes
+              tracer.in_span('HTTP CONNECT', attributes: attributes.merge(
+                'peer.hostname' => conn_address,
+                'peer.port' => conn_port
+              )) do
+                super
+              end
+            end
+
             def annotate_span_with_response!(span, response)
               return unless response&.code
 

--- a/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
+++ b/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0.1'
   spec.add_development_dependency 'rubocop', '~> 0.73.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'webmock', '~> 3.7.6'
+  spec.add_development_dependency 'webmock', '~> 3.11.0'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 

--- a/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/instrumentation_test.rb
+++ b/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/instrumentation_test.rb
@@ -27,6 +27,7 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
       OpenTelemetry::Trace::Propagation::TraceContext.text_map_extractor
     )
     OpenTelemetry.propagation = propagator
+    instrumentation.install
   end
 
   after do
@@ -36,11 +37,7 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
     OpenTelemetry.propagation = @orig_propagation
   end
 
-  describe 'tracing' do
-    before do
-      instrumentation.install
-    end
-
+  describe '#request' do
     it 'before request' do
       _(exporter.finished_spans.size).must_equal 0
     end
@@ -126,6 +123,48 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
         'http://example.com/success',
         headers: { 'Traceparent' => "00-#{span.hex_trace_id}-#{span.hex_span_id}-01" }
       )
+    end
+  end
+
+  describe '#connect' do
+    it 'emits span on connect' do
+      WebMock.allow_net_connect!
+      TCPServer.open('localhost', 0) do |server|
+        Thread.start { server.accept }
+        port = server.addr[1]
+
+        uri  = URI.parse("http://localhost:#{port}/example")
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.read_timeout = 0
+        _(-> { http.request(Net::HTTP::Get.new(uri.request_uri)) }).must_raise(Net::ReadTimeout)
+      end
+
+      _(exporter.finished_spans.size).must_equal(2)
+      _(span.name).must_equal 'HTTP CONNECT'
+      _(span.attributes['peer.hostname']).must_equal('localhost')
+      _(span.attributes['peer.port']).wont_be_nil
+    ensure
+      WebMock.disable_net_connect!
+    end
+
+    it 'captures errors' do
+      WebMock.allow_net_connect!
+
+      uri  = URI.parse('http://localhost:99999999/example')
+      http = Net::HTTP.new(uri.host, uri.port)
+      _(-> { http.request(Net::HTTP::Get.new(uri.request_uri)) }).must_raise(SocketError)
+
+      _(exporter.finished_spans.size).must_equal(1)
+      _(span.name).must_equal 'HTTP CONNECT'
+      _(span.attributes['peer.hostname']).must_equal('localhost')
+      _(span.attributes['peer.port']).must_equal(99_999_999)
+
+      span_event = span.events.first
+      _(span_event.name).must_equal 'exception'
+      _(span_event.attributes['exception.type']).must_equal 'SocketError'
+      _(span_event.attributes['exception.message']).must_equal 'Failed to open TCP connection to localhost:99999999 (getaddrinfo: nodename nor servname provided, or not known)'
+    ensure
+      WebMock.disable_net_connect!
     end
   end
 end

--- a/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/instrumentation_test.rb
+++ b/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/instrumentation_test.rb
@@ -150,19 +150,19 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
     it 'captures errors' do
       WebMock.allow_net_connect!
 
-      uri  = URI.parse('http://localhost:99999999/example')
+      uri  = URI.parse('http://localhost:99999/example')
       http = Net::HTTP.new(uri.host, uri.port)
-      _(-> { http.request(Net::HTTP::Get.new(uri.request_uri)) }).must_raise(SocketError)
+      _(-> { http.request(Net::HTTP::Get.new(uri.request_uri)) }).must_raise
 
       _(exporter.finished_spans.size).must_equal(1)
       _(span.name).must_equal 'HTTP CONNECT'
       _(span.attributes['peer.hostname']).must_equal('localhost')
-      _(span.attributes['peer.port']).must_equal(99_999_999)
+      _(span.attributes['peer.port']).must_equal(99_999)
 
       span_event = span.events.first
       _(span_event.name).must_equal 'exception'
-      _(span_event.attributes['exception.type']).must_equal 'SocketError'
-      _(span_event.attributes['exception.message']).must_equal 'Failed to open TCP connection to localhost:99999999 (getaddrinfo: nodename nor servname provided, or not known)'
+      _(span_event.attributes['exception.type']).wont_be_nil
+      _(span_event.attributes['exception.message']).must_match(/Failed to open TCP connection to localhost:99999/)
     ensure
       WebMock.disable_net_connect!
     end


### PR DESCRIPTION
Followup to a discussion regarding connect spans https://github.com/open-telemetry/opentelemetry-ruby/pull/508#issuecomment-777152748