### PR TITLE
fix: do not disorder randomization used by seed when creating spans

### DIFF
--- a/api/lib/opentelemetry/trace.rb
+++ b/api/lib/opentelemetry/trace.rb
@@ -21,7 +21,7 @@ module OpenTelemetry
     # the class `Random`.
     #
     # @return [#bytes]
-    RANDOM = Random.respond_to?(:bytes) ? Random : Random::DEFAULT
+    RANDOM = Random.respond_to?(:bytes) ? Random.new : Random::DEFAULT
 
     private_constant :CURRENT_SPAN_KEY, :RANDOM
 


### PR DESCRIPTION
We noticed that when using `seed` for randomization, the sequence was getting disordered because OTel traces and span IDs are generated using `Random`. This change prevents the disordering.