### PR TITLE
fix: http release yml entry

### DIFF
--- a/.toys/.data/releases.yml
+++ b/.toys/.data/releases.yml
@@ -33,7 +33,7 @@ commit_lint:
 gems:
   - name: opentelemetry-instrumentation-http
     directory: instrumentation/http
-    version_constant: [OpenTelemetry, Instrumentation, Http, VERSION]
+    version_constant: [OpenTelemetry, Instrumentation, HTTP, VERSION]
 
   - name: opentelemetry-instrumentation-graphql
     directory: instrumentation/graphql


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-ruby/runs/1931000292

```
Error: Version file /home/runner/work/opentelemetry-ruby/opentelemetry-ruby/instrumentation/http/lib/opentelemetry/instrumentation/http/version.rb for gem opentelemetry-instrumentation-http didn't define OpenTelemetry::Instrumentation::Http::VERSION
```