### PR TITLE
docs: Add more documentation around instrumentation libraries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ See the [API Documentation](https://open-telemetry.github.io/opentelemetry-ruby/
 detail, and the [opentelemetry examples][examples-github] for a complete example including
 context propagation.
 
+## Instrumentation Libraries
+
+This repository contains instrumentation libraries for many popular Ruby
+gems, including Rails, Rack, Sinatra, and others, so you can start
+using OpenTelemetry with minimal changes to your application. See the
+[instrumentation README](instrumentation/) for more.
+
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -1,0 +1,52 @@
+# OpenTelemetry instrumentation libraries
+ 
+[OpenTelemetry](https://opentelemetry.io/) is an open source observability framework, providing a general-purpose API, SDK, and related tools required for the instrumentation of cloud-native software, frameworks, and libraries.
+
+Instrumentation libraries provide pre-built OpenTelemetry instrumentation for popular libraries: This repository contains instrumentation for Rails, Rack, Sinatra, and others.  This way you can start using OpenTelemetry with minimal changes to your application.
+
+## How do I get started?
+
+### Individual instrumentation libraries
+
+Individual instrumentation libraries can be found in subdirectories under `/instrumentation` (with the exception of `all`, see below).
+
+To get started with a single instrumentation library, for example `opentelemetry-instrumentation-rack`:
+
+### 1. Install the gem
+
+```
+gem install opentelemetry-instrumentation-rack
+```
+
+### 2. Configure OpenTelemetry to use the instrumentation
+
+```
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::Rack'
+end
+```
+
+Instrumentation-specific documentation can be found in each subdirectory's `README.md`.
+
+### `opentelemetry-instrumentation-all`
+
+You also have the option of installing all of the instrumentation libraries by installing `opentelemetry-instrumentation-all`.  See that gem's [README](https://github.com/open-telemetry/opentelemetry-ruby/tree/main/instrumentation/all) for more.
+
+## How can I get involved?
+
+The source for all OpenTelemetry Ruby instrumentation gems is [on github](https://github.com/open-telemetry/opentelemetry-ruby/tree/main/instrumentation), along with related gems including `opentelemetry-api` and `opentelemetry-sdk`.
+
+The OpenTelemetry Ruby gems are maintained by the OpenTelemetry-Ruby special interest group (SIG). You can get involved by joining us on our [gitter channel][ruby-gitter] or attending our weekly meeting. See the [meeting calendar][community-meetings] for dates and times. For more information on this and other language SIGs, see the OpenTelemetry [community page][ruby-sig].
+
+
+## License
+
+All OpenTelemetry Ruby instrumentation gems are distributed under the Apache 2.0 license. See [LICENSE][license-github] for more information.
+
+
+[license-github]: https://github.com/open-telemetry/opentelemetry-ruby/blob/main/LICENSE
+[ruby-sig]: https://github.com/open-telemetry/community#ruby-sig
+[community-meetings]: https://github.com/open-telemetry/community#community-meetings
+[ruby-gitter]: https://gitter.im/open-telemetry/opentelemetry-ruby
+
+

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -2,13 +2,18 @@
  
 [OpenTelemetry](https://opentelemetry.io/) is an open source observability framework, providing a general-purpose API, SDK, and related tools required for the instrumentation of cloud-native software, frameworks, and libraries.
 
-Instrumentation libraries provide pre-built OpenTelemetry instrumentation for popular libraries: This repository contains instrumentation for Rails, Rack, Sinatra, and others.  This way you can start using OpenTelemetry with minimal changes to your application.
+Instrumentation libraries provide pre-built OpenTelemetry instrumentation for popular libraries: Examples include Rails, Rack, Sinatra, and others.  This way you can start using OpenTelemetry with minimal changes to your application.
+
+## Which instrumentations already exist, and which are currently in progress?
+
+Released instrumentations can be found at the [OpenTelemetry registry](https://opentelemetry.io/registry/?language=ruby&component=instrumentation#).  You can also look in this project's Github repository: Individual instrumentation libraries can be found in subdirectories under `/instrumentation`.
+
+In-progress instrumentations can be found [here](https://github.com/open-telemetry/opentelemetry-ruby/issues?q=is%3Aopen+label%3Ainstrumentation+-label%3A%22help+wanted%22+).
+
 
 ## How do I get started?
 
 ### Individual instrumentation libraries
-
-Individual instrumentation libraries can be found in subdirectories under `/instrumentation` (with the exception of `all`, see below).
 
 To get started with a single instrumentation library, for example `opentelemetry-instrumentation-rack`:
 
@@ -36,7 +41,9 @@ You also have the option of installing all of the instrumentation libraries by i
 
 The source for all OpenTelemetry Ruby instrumentation gems is [on github](https://github.com/open-telemetry/opentelemetry-ruby/tree/main/instrumentation), along with related gems including `opentelemetry-api` and `opentelemetry-sdk`.
 
-The OpenTelemetry Ruby gems are maintained by the OpenTelemetry-Ruby special interest group (SIG). You can get involved by joining us on our [gitter channel][ruby-gitter] or attending our weekly meeting. See the [meeting calendar][community-meetings] for dates and times. For more information on this and other language SIGs, see the OpenTelemetry [community page][ruby-sig].
+If you are interested in helping out with an instrumentation, you can see instrumentations that have been requested but are not currently in-progress [here](https://github.com/open-telemetry/opentelemetry-ruby/issues?q=is%3Aopen+label%3Ainstrumentation+label%3A%22help+wanted%22).
+
+The OpenTelemetry Ruby gems are maintained by the OpenTelemetry-Ruby special interest group (SIG). You can get involved by joining us in [GitHub Discussions][discussions-url] or attending our weekly meeting. See the [meeting calendar][community-meetings] for dates and times. For more information on this and other language SIGs, see the OpenTelemetry [community page][ruby-sig].
 
 
 ## License
@@ -47,6 +54,6 @@ All OpenTelemetry Ruby instrumentation gems are distributed under the Apache 2.0
 [license-github]: https://github.com/open-telemetry/opentelemetry-ruby/blob/main/LICENSE
 [ruby-sig]: https://github.com/open-telemetry/community#ruby-sig
 [community-meetings]: https://github.com/open-telemetry/community#community-meetings
-[ruby-gitter]: https://gitter.im/open-telemetry/opentelemetry-ruby
+[discussions-url]: https://github.com/open-telemetry/opentelemetry-ruby/discussions
 
 


### PR DESCRIPTION
Not sure if this is the final state of this but it seemed like a good start. After thinking about it I opted against listing all the instrumentation libraries in any READMEs: This seems brittle and I'd imagine most users should be able to navigate Github and/or the repository on their own with a quick pointer. But I'm definitely open to other thoughts if we think there are ways this documentation can be clearer.