### PR TITLE
Improve registry rake task.

### DIFF
--- a/instrumentation/rails/opentelemetry-instrumentation-rails.gemspec
+++ b/instrumentation/rails/opentelemetry-instrumentation-rails.gemspec
@@ -40,4 +40,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+
+  spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/main/instrumentation/rails' if spec.respond_to?(:metadata)
 end

--- a/rakelib/update_registry_instrumentation.rake
+++ b/rakelib/update_registry_instrumentation.rake
@@ -44,6 +44,7 @@ TEMPLATE
         raise "Could not infer Title from gem spec summary #{gem_specification.summary}"
       end
       repo = gem_specification.metadata['source_code_uri']
+      raise "Could not find repo for #{gem_specification.name}" unless repo
       gem_specification.description =~ /^.* instrumentation/
       description = $& + " for Ruby."
 


### PR DESCRIPTION
I burned a few cycles because our Rails instrumentation gemspec was missing a repo link, which meant that my PR to opentelemetry.io had some fairly opaque error messages. This PR tightens the feedback loop on this by having the Rake task raise a clear error if that happens in the future.