### PR TITLE
fix: rescue socket err in otlp exporter to prevent failures when unable to connect

### DIFF
--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -177,6 +177,9 @@ module OpenTelemetry
           rescue Net::OpenTimeout, Net::ReadTimeout
             retry if backoff?(retry_count: retry_count += 1, reason: 'timeout')
             return FAILURE
+          rescue SocketError
+            retry if backoff?(retry_count: retry_count += 1, reason: 'socket_error')
+            return FAILURE
           end
         ensure
           # Reset timeouts to defaults for the next call.


### PR DESCRIPTION
We saw errors when the OTel endpoint was invalid or unreachable causing our deployments to fail. This PR simply adds the rescuing of SocketError.