### PR TITLE
feat: add k8s node to gcp resource detector

### DIFF
--- a/resource_detectors/lib/opentelemetry/resource/detectors/google_cloud_platform.rb
+++ b/resource_detectors/lib/opentelemetry/resource/detectors/google_cloud_platform.rb
@@ -34,6 +34,7 @@ module OpenTelemetry
             resource_attributes[resource_constants::K8S_RESOURCE[:cluster_name]] = gcp_env.instance_attribute('cluster-name')
             resource_attributes[resource_constants::K8S_RESOURCE[:namespace_name]] = gcp_env.kubernetes_engine_namespace_id
             resource_attributes[resource_constants::K8S_RESOURCE[:pod_name]] = ENV['HOSTNAME'] || safe_gethostname
+            resource_attributes[resource_constants::K8S_RESOURCE[:node_name]] = gcp_env.lookup_metadata('instance', 'hostname')
 
             resource_attributes[resource_constants::CONTAINER_RESOURCE[:name]] = ENV['CONTAINER_NAME']
           end

--- a/resource_detectors/test/opentelemetry/detectors/google_cloud_platform_test.rb
+++ b/resource_detectors/test/opentelemetry/detectors/google_cloud_platform_test.rb
@@ -29,14 +29,14 @@ describe OpenTelemetry::Resource::Detectors::GoogleCloudPlatform do
         gcp_env_mock.expect(:instance_attribute, 'us-central1', %w[cluster-location])
         gcp_env_mock.expect(:instance_zone, 'us-central1-a')
         gcp_env_mock.expect(:lookup_metadata, 'opentelemetry-test', %w[instance id])
-        gcp_env_mock.expect(:lookup_metadata, 'opentelemetry-test', %w[instance hostname])
+        gcp_env_mock.expect(:lookup_metadata, 'opentelemetry-node-1', %w[instance hostname])
         gcp_env_mock.expect(:instance_attribute, 'opentelemetry-cluster', %w[cluster-name])
         gcp_env_mock.expect(:kubernetes_engine?, true)
         gcp_env_mock.expect(:kubernetes_engine_namespace_id, 'default')
 
         Socket.stub(:gethostname, 'opentelemetry-test') do
           old_hostname = ENV['HOSTNAME']
-          ENV['HOSTNAME'] = 'opentelemetry-test'
+          ENV['HOSTNAME'] = 'opentelemetry-host-name-1'
           begin
             Google::Cloud::Env.stub(:new, gcp_env_mock) { detected_resource }
           ensure
@@ -52,10 +52,11 @@ describe OpenTelemetry::Resource::Detectors::GoogleCloudPlatform do
           'cloud.region' => 'us-central1',
           'cloud.zone' => 'us-central1-a',
           'host.id' => 'opentelemetry-test',
-          'host.name' => 'opentelemetry-test',
+          'host.name' => 'opentelemetry-host-name-1',
           'k8s.cluster.name' => 'opentelemetry-cluster',
           'k8s.namespace.name' => 'default',
-          'k8s.pod.name' => 'opentelemetry-test'
+          'k8s.pod.name' => 'opentelemetry-host-name-1',
+          'k8s.node.name' => 'opentelemetry-node-1'
         }
       end
 

--- a/sdk/lib/opentelemetry/sdk/resources/constants.rb
+++ b/sdk/lib/opentelemetry/sdk/resources/constants.rb
@@ -67,14 +67,59 @@ module OpenTelemetry
           # The name of the cluster that the pod is running in.
           cluster_name: 'k8s.cluster.name',
 
+          # The name of the Node.
+          node_name: 'k8s.node.name',
+
+          # The UID of the Node.
+          node_uid: 'k8s.node.uid',
+
           # The name of the namespace that the pod is running in.
           namespace_name: 'k8s.namespace.name',
 
           # The name of the pod.
           pod_name: 'k8s.pod.name',
 
+          # The UID of the Pod.
+          pod_uid: 'k8s.pod.uid',
+
+          #  The name of the Container in a Pod template.
+          container_name: 'k8s.container.name',
+
+          # The UID of the ReplicaSet.
+          replicaset_uid: 'k8s.replicaset.uid',
+
+          # The name of the ReplicaSet.
+          replicaset_name: 'k8s.replicaset.name',
+
+          # The UID of the Deployment.
+          deployment_uid: 'k8s.deployment.uid',
+
           # The name of the deployment.
-          deployment_name: 'k8s.deployment.name'
+          deployment_name: 'k8s.deployment.name',
+
+          # The UID of the StatefulSet.
+          statefulset_uid: 'k8s.statefulset.uid',
+
+          # The name of the StatefulSet.
+          statefulset_name: 'k8s.statefulset.name',
+
+          # The UID of the DaemonSet.
+          daemonset_uid: 'k8s.daemonset.uid',
+
+          # The name of the DaemonSet.
+          daemonset_name: 'k8s.daemonset.name',
+
+          # The UID of the Job.
+          job_uid: 'k8s.job.uid',
+
+          # The name of the Job.
+          job_name: 'k8s.job.name',
+
+          # The UID of the CronJob.
+          cronjob_uid: 'k8s.cronjob.uid',
+
+          # The name of the CronJob.
+          cronjob_name: 'k8s.cronjob.name'
         }.freeze
 
         # Attributes defining an operating system process.


### PR DESCRIPTION
We observed in production that we were no longer capturing the node name in a k8s deployment, this adds it back under the proper key.

Also updated the k8s constants to line up with the spec https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/k8s.md
