### PR TITLE
refactor: Extract duplicate truncate definitions

### DIFF
--- a/common/lib/opentelemetry/common/utilities.rb
+++ b/common/lib/opentelemetry/common/utilities.rb
@@ -46,6 +46,12 @@ module OpenTelemetry
         placeholder
       end
 
+      # Truncates a string if it exceeds the size provided.
+      #
+      # @param [String] string The string to be truncated
+      # @param [Integer] size The max size of the string
+      #
+      # @return [String]
       def truncate(string, size)
         string.size > size ? "#{string[0...size - 3]}..." : string
       end

--- a/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/utils.rb
+++ b/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/utils.rb
@@ -48,14 +48,10 @@ module OpenTelemetry
         placeholder = "#{operation} BLOB (OMITTED)"
         command = [operation, *args].join(' ').strip
         command = OpenTelemetry::Common::Utilities.utf8_encode(command, binary: true, placeholder: placeholder)
-        truncate(command, CMD_MAX_LEN)
+        OpenTelemetry::Common::Utilities.truncate(command, CMD_MAX_LEN)
       rescue StandardError => e
         OpenTelemetry.logger.debug("Error sanitizing Dalli operation: #{e}")
         placeholder
-      end
-
-      def truncate(string, size)
-        string.size > size ? "#{string[0...size - 3]}..." : string
       end
     end
   end

--- a/instrumentation/redis/lib/opentelemetry/instrumentation/redis/utils.rb
+++ b/instrumentation/redis/lib/opentelemetry/instrumentation/redis/utils.rb
@@ -30,13 +30,13 @@ module OpenTelemetry
           return 'AUTH ?' if auth_command?(command_args)
 
           cmd = command_args.map { |x| format_arg(x) }.join(' ')
-          truncate(cmd, CMD_MAX_LEN)
+          OpenTelemetry::Common::Utilities.truncate(cmd, CMD_MAX_LEN)
         end
 
         def format_arg(arg)
           str = arg.is_a?(Symbol) ? arg.to_s.upcase : arg.to_s
           str = OpenTelemetry::Common::Utilities.utf8_encode(str, binary: true)
-          truncate(str, VALUE_MAX_LEN)
+          OpenTelemetry::Common::Utilities.truncate(str, VALUE_MAX_LEN)
         rescue StandardError => e
           OpenTelemetry.logger.debug("non formattable Redis arg #{str}: #{e}")
           PLACEHOLDER
@@ -54,10 +54,6 @@ module OpenTelemetry
           return command_args.first if command_args.is_a?(Array) && command_args.first.is_a?(Array)
 
           command_args
-        end
-
-        def truncate(string, size)
-          string.size > size ? "#{string[0...size - 3]}..." : string
         end
       end
     end


### PR DESCRIPTION
Moves duplicate truncate method definitions into the common gem.