### PR TITLE
feat: Add peer_service config to lmdb

### DIFF
--- a/instrumentation/lmdb/lib/opentelemetry/instrumentation/lmdb/instrumentation.rb
+++ b/instrumentation/lmdb/lib/opentelemetry/instrumentation/lmdb/instrumentation.rb
@@ -20,6 +20,8 @@ module OpenTelemetry
           defined?(::LMDB)
         end
 
+        option :peer_service, default: nil, validate: :string
+
         private
 
         def patch

--- a/instrumentation/lmdb/lib/opentelemetry/instrumentation/lmdb/patches/database.rb
+++ b/instrumentation/lmdb/lib/opentelemetry/instrumentation/lmdb/patches/database.rb
@@ -19,6 +19,7 @@ module OpenTelemetry
               'db.system' => 'lmdb',
               'db.statement' => formatted_statement('GET', "GET #{key}")
             }
+            attributes['peer.service'] = config[:peer_service] if config[:peer_service]
 
             tracer.in_span("GET #{key}", attributes: attributes, kind: :client) do
               super
@@ -30,6 +31,7 @@ module OpenTelemetry
               'db.system' => 'lmdb',
               'db.statement' => formatted_statement('DELETE', "DELETE #{key} #{value}".strip)
             }
+            attributes['peer.service'] = config[:peer_service] if config[:peer_service]
 
             tracer.in_span("DELETE #{key}", attributes: attributes, kind: :client) do
               super
@@ -41,6 +43,7 @@ module OpenTelemetry
               'db.system' => 'lmdb',
               'db.statement' => formatted_statement('PUT', "PUT #{key} #{value}")
             }
+            attributes['peer.service'] = config[:peer_service] if config[:peer_service]
 
             tracer.in_span("PUT #{key}", attributes: attributes, kind: :client) do
               super
@@ -52,6 +55,7 @@ module OpenTelemetry
               'db.system' => 'lmdb',
               'db.statement' => 'CLEAR'
             }
+            attributes['peer.service'] = config[:peer_service] if config[:peer_service]
 
             tracer.in_span('CLEAR', attributes: attributes, kind: :client) do
               super
@@ -66,6 +70,10 @@ module OpenTelemetry
           rescue StandardError => e
             OpenTelemetry.logger.debug("non formattable LMDB statement #{statement}: #{e}")
             "#{operation} BLOB (OMITTED)"
+          end
+
+          def config
+            LMDB::Instrumentation.instance.config
           end
 
           def tracer

--- a/instrumentation/lmdb/lib/opentelemetry/instrumentation/lmdb/patches/environment.rb
+++ b/instrumentation/lmdb/lib/opentelemetry/instrumentation/lmdb/patches/environment.rb
@@ -13,12 +13,19 @@ module OpenTelemetry
         # Module to prepend to LMDB::Environment for instrumentation
         module Environment
           def transaction(*args)
-            tracer.in_span('TRANSACTION', attributes: { 'db.system' => 'lmdb' }) do |_span|
+            attributes = { 'db.system' => 'lmdb' }
+            attributes['peer.service'] = config[:peer_service] if config[:peer_service]
+
+            tracer.in_span('TRANSACTION', attributes: attributes) do
               super
             end
           end
 
           private
+
+          def config
+            LMDB::Instrumentation.instance.config
+          end
 
           def tracer
             LMDB::Instrumentation.instance.tracer

--- a/instrumentation/lmdb/test/instrumentation/lmdb/instrumentation_test.rb
+++ b/instrumentation/lmdb/test/instrumentation/lmdb/instrumentation_test.rb
@@ -21,6 +21,8 @@ describe OpenTelemetry::Instrumentation::LMDB do
   end
 
   describe '#install' do
+    after { instrumentation.instance_variable_set(:@installed, false) }
+
     it 'accepts argument' do
       _(instrumentation.install({})).must_equal(true)
     end


### PR DESCRIPTION
Add a config option to set a `peer.service` attribute to LMDB in the same way we do redis, dalli, mysql, etc..