### PR TITLE
fix: Ensure b3 injectors always return a carrier

### DIFF
--- a/propagator/b3/lib/opentelemetry/propagator/b3/multi/text_map_injector.rb
+++ b/propagator/b3/lib/opentelemetry/propagator/b3/multi/text_map_injector.rb
@@ -32,7 +32,7 @@ module OpenTelemetry
           # @return [Object] the carrier with context injected
           def inject(carrier, context, setter = nil)
             span_context = Trace.current_span(context).context
-            return unless span_context.valid?
+            return carrier unless span_context.valid?
 
             setter ||= @default_setter
             setter.set(carrier, B3_TRACE_ID_KEY, span_context.hex_trace_id)

--- a/propagator/b3/lib/opentelemetry/propagator/b3/single/text_map_injector.rb
+++ b/propagator/b3/lib/opentelemetry/propagator/b3/single/text_map_injector.rb
@@ -32,7 +32,7 @@ module OpenTelemetry
           # @return [Object] the carrier with context injected
           def inject(carrier, context, setter = nil)
             span_context = Trace.current_span(context).context
-            return unless span_context.valid?
+            return carrier unless span_context.valid?
 
             sampling_state = if B3.debug?(context)
                                'd'

--- a/propagator/b3/test/multi/text_map_injector_test.rb
+++ b/propagator/b3/test/multi/text_map_injector_test.rb
@@ -28,8 +28,9 @@ describe OpenTelemetry::Propagator::B3::Multi::TextMapInjector do
       )
 
       carrier = {}
-      injector.inject(carrier, context)
+      updated_carrier = injector.inject(carrier, context)
 
+      _(updated_carrier).must_be_same_as(updated_carrier)
       _(carrier[trace_id_key]).must_equal('80f198ee56343ba864fe8b2a57d3eff7')
       _(carrier[span_id_key]).must_equal('e457b5a2e4d86bd1')
       _(carrier[sampled_key]).must_equal('1')
@@ -45,8 +46,9 @@ describe OpenTelemetry::Propagator::B3::Multi::TextMapInjector do
       )
 
       carrier = {}
-      injector.inject(carrier, context)
+      updated_carrier = injector.inject(carrier, context)
 
+      _(updated_carrier).must_be_same_as(updated_carrier)
       _(carrier[trace_id_key]).must_equal('80f198ee56343ba864fe8b2a57d3eff7')
       _(carrier[span_id_key]).must_equal('e457b5a2e4d86bd1')
       _(carrier[sampled_key]).must_equal('0')
@@ -62,8 +64,9 @@ describe OpenTelemetry::Propagator::B3::Multi::TextMapInjector do
       )
 
       carrier = {}
-      injector.inject(carrier, context)
+      updated_carrier = injector.inject(carrier, context)
 
+      _(updated_carrier).must_be_same_as(updated_carrier)
       _(carrier[trace_id_key]).must_equal('80f198ee56343ba864fe8b2a57d3eff7')
       _(carrier[span_id_key]).must_equal('e457b5a2e4d86bd1')
       _(carrier[flags_key]).must_equal('1')
@@ -78,9 +81,11 @@ describe OpenTelemetry::Propagator::B3::Multi::TextMapInjector do
       )
 
       carrier = {}
-      injector.inject(carrier, context)
 
-      all_keys.each { |k| _(carrier.key?(k)).must_equal(false) }
+      unchanged_carrier = injector.inject(carrier, context)
+
+      _(unchanged_carrier).must_be_same_as(carrier)
+      _(unchanged_carrier).must_be(:empty?)
     end
 
     it 'no-ops if trace id invalid' do
@@ -90,9 +95,11 @@ describe OpenTelemetry::Propagator::B3::Multi::TextMapInjector do
       )
 
       carrier = {}
-      injector.inject(carrier, context)
 
-      all_keys.each { |k| _(carrier.key?(k)).must_equal(false) }
+      unchanged_carrier = injector.inject(carrier, context)
+
+      _(unchanged_carrier).must_be_same_as(carrier)
+      _(unchanged_carrier).must_be(:empty?)
     end
   end
 

--- a/propagator/b3/test/single/text_map_injector_test.rb
+++ b/propagator/b3/test/single/text_map_injector_test.rb
@@ -22,8 +22,9 @@ describe OpenTelemetry::Propagator::B3::Single::TextMapInjector do
       )
 
       carrier = {}
-      injector.inject(carrier, context)
+      updated_carrier = injector.inject(carrier, context)
 
+      _(updated_carrier).must_be_same_as(updated_carrier)
       expected_b3 = '80f198ee56343ba864fe8b2a57d3eff7-e457b5a2e4d86bd1-1'
       _(carrier['b3']).must_equal(expected_b3)
     end
@@ -36,8 +37,9 @@ describe OpenTelemetry::Propagator::B3::Single::TextMapInjector do
       )
 
       carrier = {}
-      injector.inject(carrier, context)
+      updated_carrier = injector.inject(carrier, context)
 
+      _(updated_carrier).must_be_same_as(updated_carrier)
       expected_b3 = '80f198ee56343ba864fe8b2a57d3eff7-e457b5a2e4d86bd1-0'
       _(carrier['b3']).must_equal(expected_b3)
     end
@@ -50,8 +52,9 @@ describe OpenTelemetry::Propagator::B3::Single::TextMapInjector do
       )
 
       carrier = {}
-      injector.inject(carrier, context)
+      updated_carrier = injector.inject(carrier, context)
 
+      _(updated_carrier).must_be_same_as(updated_carrier)
       expected_b3 = '80f198ee56343ba864fe8b2a57d3eff7-e457b5a2e4d86bd1-d'
       _(carrier['b3']).must_equal(expected_b3)
     end
@@ -63,8 +66,8 @@ describe OpenTelemetry::Propagator::B3::Single::TextMapInjector do
       )
 
       carrier = {}
-      injector.inject(carrier, context)
-
+      unchanged_carrier = injector.inject(carrier, context)
+      _(unchanged_carrier).must_be_same_as(carrier)
       _(carrier.key?('b3')).must_equal(false)
     end
 
@@ -75,7 +78,8 @@ describe OpenTelemetry::Propagator::B3::Single::TextMapInjector do
       )
 
       carrier = {}
-      injector.inject(carrier, context)
+      unchanged_carrier = injector.inject(carrier, context)
+      _(unchanged_carrier).must_be_same_as(carrier)
 
       _(carrier.key?('b3')).must_equal(false)
     end


### PR DESCRIPTION
This change ensures the `b3` injectors always return the supplied `carrier` per the method documentation and default API/SDK implementations.