### PR TITLE
fix: handle rack env getter edge cases

### DIFF
--- a/api/lib/opentelemetry/context/propagation/rack_env_getter.rb
+++ b/api/lib/opentelemetry/context/propagation/rack_env_getter.rb
@@ -16,7 +16,7 @@ module OpenTelemetry
         # Converts key into a rack-normalized key and reads it from the carrier.
         # Useful for extract operations.
         def get(carrier, key)
-          carrier[to_rack_key(key)]
+          carrier[to_rack_key(key)] || carrier[key]
         end
 
         # Reads all keys from a carrier and converts them from the rack-normalized
@@ -32,6 +32,7 @@ module OpenTelemetry
           ret = 'HTTP_' + key
           ret.tr!('-', '_')
           ret.upcase!
+          ret
         end
 
         def from_rack_key(key)
@@ -39,6 +40,7 @@ module OpenTelemetry
           ret = key[start..-1]
           ret.tr!('_', '-')
           ret.downcase!
+          ret
         end
       end
     end

--- a/api/test/opentelemetry/context/propagation/rack_env_getter_test.rb
+++ b/api/test/opentelemetry/context/propagation/rack_env_getter_test.rb
@@ -11,13 +11,21 @@ describe OpenTelemetry::Context::Propagation::RackEnvGetter do
     OpenTelemetry::Context::Propagation::RackEnvGetter.new
   end
 
-  let(:carrier) { { 'HTTP_TRACEPARENT' => 'tp', 'HTTP_TRACESTATE' => 'ts', 'HTTP_X_SOURCE_ID' => '123' } }
+  let(:carrier) do
+    {
+      'HTTP_TRACEPARENT' => 'tp',
+      'HTTP_TRACESTATE' => 'ts',
+      'HTTP_X_SOURCE_ID' => '123',
+      'rack.hijack?' => true
+    }
+  end
 
   describe '#get' do
     it 'reads key from carrier' do
       _(getter.get(carrier, 'traceparent')).must_equal('tp')
       _(getter.get(carrier, 'tracestate')).must_equal('ts')
       _(getter.get(carrier, 'x-source-id')).must_equal('123')
+      _(getter.get(carrier, 'rack.hijack?')).must_equal(true)
     end
 
     it 'returns nil for non-existent key' do
@@ -27,7 +35,7 @@ describe OpenTelemetry::Context::Propagation::RackEnvGetter do
 
   describe '#keys' do
     it 'returns carrier keys' do
-      _(getter.keys(carrier)).must_equal(%w[traceparent tracestate x-source-id])
+      _(getter.keys(carrier)).must_equal(%w[traceparent tracestate x-source-id rack.hijack?])
     end
 
     it 'returns empty array for empty carrier' do


### PR DESCRIPTION
While looking over #564 I found an issue with the RackEnvGetter where the `keys` method was returning a handful of nil entries, which caused breakage while processing baggage. This is because `String#downcase!` and `String#upcase!` only return a value if the string was modified. This PR fixes that issue. It also updates the `get` method to look for the original key if it wasn't transformed. This wasn't a bug that I ran into, but as I was writing tests it occurred to me that it is a fallback that we'd want.