### PR TITLE
fix: update DB semantic conventions

### DIFF
--- a/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
+++ b/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
@@ -119,8 +119,7 @@ module OpenTelemetry
 
             attributes = {
               'db.system' => 'mysql',
-              'db.instance' => database_name,
-              'db.url' => "mysql://#{host}:#{port}",
+              'db.name' => database_name,
               'net.peer.name' => host,
               'net.peer.port' => port
             }

--- a/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
+++ b/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
@@ -71,9 +71,8 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
 
       _(span.name).must_equal 'select'
       _(span.attributes['db.system']).must_equal 'mysql'
-      _(span.attributes['db.instance']).must_equal 'mysql'
+      _(span.attributes['db.name']).must_equal 'mysql'
       _(span.attributes['db.statement']).must_equal 'SELECT 1'
-      _(span.attributes['db.url']).must_equal "mysql://#{host}:#{port}"
       _(span.attributes['net.peer.name']).must_equal host.to_s
       _(span.attributes['net.peer.port']).must_equal port.to_s
     end
@@ -85,9 +84,8 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
 
       _(span.name).must_equal 'select'
       _(span.attributes['db.system']).must_equal 'mysql'
-      _(span.attributes['db.instance']).must_equal 'mysql'
+      _(span.attributes['db.name']).must_equal 'mysql'
       _(span.attributes['db.statement']).must_equal 'SELECT INVALID'
-      _(span.attributes['db.url']).must_equal "mysql://#{host}:#{port}"
       _(span.attributes['net.peer.name']).must_equal host.to_s
       _(span.attributes['net.peer.port']).must_equal port.to_s
 
@@ -108,9 +106,8 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
 
       _(span.name).must_equal 'explain'
       _(span.attributes['db.system']).must_equal 'mysql'
-      _(span.attributes['db.instance']).must_equal 'mysql'
+      _(span.attributes['db.name']).must_equal 'mysql'
       _(span.attributes['db.statement']).must_equal explain_sql
-      _(span.attributes['db.url']).must_equal "mysql://#{host}:#{port}"
       _(span.attributes['net.peer.name']).must_equal host.to_s
       _(span.attributes['net.peer.port']).must_equal port.to_s
     end
@@ -122,9 +119,8 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
 
       _(span.name).must_equal 'mysql.mysql'
       _(span.attributes['db.system']).must_equal 'mysql'
-      _(span.attributes['db.instance']).must_equal 'mysql'
+      _(span.attributes['db.name']).must_equal 'mysql'
       _(span.attributes['db.statement']).must_equal 'DESELECT 1'
-      _(span.attributes['db.url']).must_equal "mysql://#{host}:#{port}"
       _(span.attributes['net.peer.name']).must_equal host.to_s
       _(span.attributes['net.peer.port']).must_equal port.to_s
 
@@ -148,10 +144,9 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
         end.must_raise Mysql2::Error
 
         _(span.attributes['db.system']).must_equal 'mysql'
-        _(span.attributes['db.instance']).must_equal 'mysql'
+        _(span.attributes['db.name']).must_equal 'mysql'
         _(span.name).must_equal 'select'
         _(span.attributes['db.statement']).must_equal obfuscated_sql
-        _(span.attributes['db.url']).must_equal "mysql://#{host}:#{port}"
         _(span.attributes['net.peer.name']).must_equal host.to_s
         _(span.attributes['net.peer.port']).must_equal port.to_s
       end

--- a/instrumentation/redis/lib/opentelemetry/instrumentation/redis/patches/client.rb
+++ b/instrumentation/redis/lib/opentelemetry/instrumentation/redis/patches/client.rb
@@ -50,11 +50,10 @@ module OpenTelemetry
 
             attributes = {
               'db.system' => 'redis',
-              'db.instance' => options[:db].to_s,
-              'db.url' => "redis://#{host}:#{port}",
               'net.peer.name' => host,
               'net.peer.port' => port
             }
+            attributes['db.redis.database_index'] = options[:db] unless options[:db].zero?
             attributes['peer.service'] = config[:peer_service] if config[:peer_service]
             attributes.merge(OpenTelemetry::Instrumentation::Redis.attributes)
           end


### PR DESCRIPTION
The [database semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md) have evolved slightly. This PR tries to catch up. Specifically:

- `db.url` has been removed - its information was redundant anyway
- `db.instance` -> `db.name` for MySQL
- `db.instance` -> `db.redis.database_index` for Redis