### PR TITLE
fix: remove passwords from http.url

### DIFF
--- a/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/instrumentation_test.rb
+++ b/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/instrumentation_test.rb
@@ -43,7 +43,7 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
     end
 
     describe 'easy' do
-      let(:easy) { ::Ethon::Easy.new(url: 'http://example.com/test') }
+      let(:easy) { ::Ethon::Easy.new(url: 'http://username:password@example.com/test') }
 
       describe '#http_request' do
         it 'preserves HTTP request method on easy instance' do

--- a/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
+++ b/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
@@ -16,7 +16,7 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
   let(:span) { exporter.finished_spans.first }
 
   let(:client) do
-    ::Faraday.new('http://example.com') do |builder|
+    ::Faraday.new('http://username:password@example.com') do |builder|
       builder.adapter(:test) do |stub|
         stub.get('/success') { |_| [200, {}, 'OK'] }
         stub.get('/failure') { |_| [500, {}, 'OK'] }

--- a/instrumentation/http_client/test/instrumentation/http_client/patches/session_test.rb
+++ b/instrumentation/http_client/test/instrumentation/http_client/patches/session_test.rb
@@ -32,7 +32,7 @@ describe OpenTelemetry::Instrumentation::HttpClient::Patches::Session do
         assert_raises(HTTPClient::ReceiveTimeoutError) do
           http = HTTPClient.new
           http.receive_timeout = 0.01
-          http.get("http://localhost:#{port}/example")
+          http.get("http://username:password@localhost:#{port}/example")
         end
       end
 

--- a/instrumentation/restclient/test/opentelemetry/instrumentation/restclient/instrumentation_test.rb
+++ b/instrumentation/restclient/test/opentelemetry/instrumentation/restclient/instrumentation_test.rb
@@ -45,7 +45,7 @@ describe OpenTelemetry::Instrumentation::RestClient::Instrumentation do
     end
 
     it 'after request with success code' do
-      ::RestClient.get('http://example.com/success')
+      ::RestClient.get('http://username:password@example.com/success')
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP GET'
@@ -61,7 +61,7 @@ describe OpenTelemetry::Instrumentation::RestClient::Instrumentation do
 
     it 'after request with failure code' do
       expect do
-        ::RestClient.get('http://example.com/failure')
+        ::RestClient.get('http://username:password@example.com/failure')
       end.must_raise RestClient::InternalServerError
 
       _(exporter.finished_spans.size).must_equal 1


### PR DESCRIPTION
Fixes #647 

This modifies tests to ensure `http.url` does not contain the username and password. `restclient` and `ethon` instrumentation needs to be fixed. Other instrumentation is correct.