### PR TITLE
fix: Add missing rubocop file to test directory

### DIFF
--- a/.instrumentation_generator/instrumentation_generator.rb
+++ b/.instrumentation_generator/instrumentation_generator.rb
@@ -34,6 +34,7 @@ class InstrumentationGenerator < Thor::Group
   end
 
   def test_files
+    template('templates/test/.rubocop.yml', "#{instrumentation_path}/test/.rubocop.yml")
     template('templates/test/test_helper.rb', "#{instrumentation_path}/test/test_helper.rb")
     template('templates/test/instrumentation.rb', "#{instrumentation_path}/test/#{instrumentation_path}/instrumentation_test.rb")
   end

--- a/.instrumentation_generator/templates/test/.rubocop.yml
+++ b/.instrumentation_generator/templates/test/.rubocop.yml
@@ -1,0 +1,4 @@
+inherit_from: ../.rubocop.yml
+
+Metrics/BlockLength:
+  Enabled: false

--- a/.instrumentation_generator/templates/test/instrumentation.rb.tt
+++ b/.instrumentation_generator/templates/test/instrumentation.rb.tt
@@ -22,7 +22,8 @@ describe OpenTelemetry::Instrumentation::<%= pascal_cased_instrumentation_name %
 
   describe '#install' do
     it 'accepts argument' do
-      instrumentation.install({})
+      _(instrumentation.install({})).must_equal(true)
+      instrumentation.instance_variable_set(:@installed, false)
     end
   end
 end


### PR DESCRIPTION
The generator was not adding a rubocop config file to the test directory.