### PR TITLE
feat: add console option for OTEL_TRACES_EXPORTER

### DIFF
--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -154,6 +154,7 @@ module OpenTelemetry
         when 'otlp' then fetch_exporter(exporter, 'OpenTelemetry::Exporter::OTLP::Exporter')
         when 'jaeger' then fetch_exporter(exporter, 'OpenTelemetry::Exporter::Jaeger::CollectorExporter')
         when 'zipkin' then fetch_exporter(exporter, 'OpenTelemetry::Exporter::Zipkin::Exporter')
+        when 'console' then Trace::Export::SimpleSpanProcessor.new(Trace::Export::ConsoleSpanExporter.new)
         else
           OpenTelemetry.logger.warn "The #{exporter} exporter is unknown and cannot be configured, spans will not be exported"
           nil

--- a/sdk/test/opentelemetry/sdk/configurator_test.rb
+++ b/sdk/test/opentelemetry/sdk/configurator_test.rb
@@ -263,6 +263,19 @@ describe OpenTelemetry::SDK::Configurator do
           OpenTelemetry::SDK::Trace::NoopSpanProcessor
         )
       end
+
+      it 'accepts "console" as an environment variable value' do
+        with_env('OTEL_TRACES_EXPORTER' => 'console') do
+          configurator.configure
+        end
+
+        _(OpenTelemetry.tracer_provider.active_span_processor).must_be_instance_of(
+          OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor
+        )
+        _(OpenTelemetry.tracer_provider.active_span_processor.instance_variable_get(:@span_exporter)).must_be_instance_of(
+          OpenTelemetry::SDK::Trace::Export::ConsoleSpanExporter
+        )
+      end
     end
 
     describe 'instrumentation installation' do


### PR DESCRIPTION
The console span exporter can be useful for development and quick debug sessions. This PR adds a `console` option for the `OTEL_TRACES_EXPORTER` environment variable that will wire up a `SimpleSpanProcessor` with a `ConsoleSpanExporter`.