### PR TITLE
feat!: pass env to url quantization rack config to allow more flexibility

### DIFF
--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
@@ -67,7 +67,7 @@ module OpenTelemetry
 
             # restore extracted context in this process:
             OpenTelemetry::Context.with_current(frontend_context || extracted_context) do
-              request_span_name = create_request_span_name(env['REQUEST_URI'] || original_env['PATH_INFO'])
+              request_span_name = create_request_span_name(env['REQUEST_URI'] || original_env['PATH_INFO'], env)
               request_span_kind = frontend_context.nil? ? :server : :internal
               tracer.in_span(request_span_name,
                              attributes: request_span_attributes(env: env),
@@ -138,12 +138,12 @@ module OpenTelemetry
           # strip off query param value, keep param name)
           #
           # see http://github.com/open-telemetry/opentelemetry-specification/pull/416/files
-          def create_request_span_name(request_uri_or_path_info)
+          def create_request_span_name(request_uri_or_path_info, env)
             # NOTE: dd-trace-rb has implemented 'quantization' (which lowers url cardinality)
             #       see Datadog::Quantization::HTTP.url
 
             if (implementation = config[:url_quantization])
-              implementation.call(request_uri_or_path_info)
+              implementation.call(request_uri_or_path_info, env)
             else
               request_uri_or_path_info
             end

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/tracer_middleware_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/tracer_middleware_test.rb
@@ -208,7 +208,7 @@ describe OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware do
     describe 'with quantization' do
       let(:quantization_example) do
         # demonstrate simple shortening of URL:
-        ->(url) { url.to_s[0..5] }
+        ->(url, _env) { url.to_s[0..5] }
       end
       let(:config) { default_config.merge(url_quantization: quantization_example) }
 


### PR DESCRIPTION
This arose from needing a way to more flexibly quantize URLs that have params in the path. This change passes env to the configured `url_quantization` callable, allowing for access to things like `REQUEST_METHOD` that can be used to lower cardinality in these cases.