### PR TITLE
feat: add rack instrumentation config option to accept callable to filter requests to trace

### DIFF
--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/instrumentation.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/instrumentation.rb
@@ -29,7 +29,7 @@ module OpenTelemetry
         option :retain_middleware_names,  default: false, validate: :boolean
         option :untraced_endpoints,       default: [],    validate: :array
         option :url_quantization,         default: nil,   validate: :callable
-        option :filtered_requests,        default: nil,   validate: :callable
+        option :untraced_requests,        default: nil,   validate: :callable
 
         private
 

--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/instrumentation.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/instrumentation.rb
@@ -29,6 +29,7 @@ module OpenTelemetry
         option :retain_middleware_names,  default: false, validate: :boolean
         option :untraced_endpoints,       default: [],    validate: :array
         option :url_quantization,         default: nil,   validate: :callable
+        option :filtered_requests,        default: nil,   validate: :callable
 
         private
 

--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
@@ -53,7 +53,7 @@ module OpenTelemetry
           end
 
           def call(env) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-            if untraced_request?(env)
+            if untraced_request?(env) || filtered_request?(env)
               OpenTelemetry::Common::Utilities.untraced do
                 return @app.call(env)
               end
@@ -87,6 +87,11 @@ module OpenTelemetry
 
           def untraced_request?(env)
             @untraced_endpoints.include?(env['PATH_INFO'])
+          end
+
+          def filtered_request?(env)
+            filter = config[:filtered_requests]
+            filter ? filter.call(env) : false
           end
 
           # return Context with the frontend span as the current span

--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
@@ -53,7 +53,7 @@ module OpenTelemetry
           end
 
           def call(env) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-            if untraced_request?(env) || filtered_request?(env)
+            if untraced_request?(env)
               OpenTelemetry::Common::Utilities.untraced do
                 return @app.call(env)
               end
@@ -86,12 +86,10 @@ module OpenTelemetry
           private
 
           def untraced_request?(env)
-            @untraced_endpoints.include?(env['PATH_INFO'])
-          end
+            return true if @untraced_endpoints.include?(env['PATH_INFO'])
+            return true if config[:untraced_requests]&.call(env)
 
-          def filtered_request?(env)
-            filter = config[:filtered_requests]
-            filter ? filter.call(env) : false
+            false
           end
 
           # return Context with the frontend span as the current span

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/tracer_middleware_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/tracer_middleware_test.rb
@@ -116,12 +116,12 @@ describe OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware do
       end
     end
 
-    describe 'config[:filtered_requests]' do
+    describe 'config[:untraced_requests]' do
       describe 'when a callable is passed in' do
-        let(:filter_example) do
+        let(:untraced_callable) do
           ->(env) { env['PATH_INFO'] =~ %r{^\/assets} }
         end
-        let(:config) { default_config.merge(filtered_requests: filter_example) }
+        let(:config) { default_config.merge(untraced_requests: untraced_callable) }
 
         it 'does not trace requests in which the callable returns true' do
           Rack::MockRequest.new(rack_builder).get('/assets', env)
@@ -135,7 +135,7 @@ describe OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware do
       end
 
       describe 'when nil is passed in' do
-        let(:config) { { filtered_requests: nil } }
+        let(:config) { { untraced_requests: nil } }
 
         it 'traces everything' do
           Rack::MockRequest.new(rack_builder).get('/assets', env)


### PR DESCRIPTION
This PR adds a configuration option to Rack instrumentation that allows you to configure with a callable that accepts `env` and does not trace any requests in which the callable returns true.  This allows more flexibility in filtering out requests to be untraced than the existing config option of `untraced_endpoints`.

