### PR TITLE
feat: Span#add_attributes

### DIFF
--- a/api/lib/opentelemetry/trace/span.rb
+++ b/api/lib/opentelemetry/trace/span.rb
@@ -61,6 +61,23 @@ module OpenTelemetry
       end
       alias []= set_attribute
 
+      # Add attributes
+      #
+      # Note that the OpenTelemetry project
+      # {https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md
+      # documents} certain "standard attributes" that have prescribed semantic
+      # meanings.
+      #
+      # @param [Hash{String => String, Numeric, Boolean, Array<String, Numeric, Boolean>}] attributes
+      #   Values must be non-nil and (array of) string, boolean or numeric type.
+      #   Array values must not contain nil elements and all elements must be of
+      #   the same basic type (string, numeric, boolean).
+      #
+      # @return [self] returns itself
+      def add_attributes(attributes)
+        self
+      end
+
       # Add an event to a {Span}.
       #
       # Example:

--- a/api/test/opentelemetry/trace/span_test.rb
+++ b/api/test/opentelemetry/trace/span_test.rb
@@ -30,6 +30,12 @@ describe OpenTelemetry::Trace::Span do
     end
   end
 
+  describe '#add_attributes' do
+    it 'returns self' do
+      _(span.add_attributes('foo' => 'bar')).must_equal(span)
+    end
+  end
+
   describe '#add_event' do
     it 'returns self' do
       _(span.add_event('event-name')).must_equal(span)

--- a/sdk/lib/opentelemetry/sdk/trace/span.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span.rb
@@ -85,6 +85,34 @@ module OpenTelemetry
         end
         alias []= set_attribute
 
+        # Add attributes
+        #
+        # Note that the OpenTelemetry project
+        # {https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md
+        # documents} certain "standard attributes" that have prescribed semantic
+        # meanings.
+        #
+        # @param [Hash{String => String, Numeric, Boolean, Array<String, Numeric, Boolean>}] attributes
+        #   Values must be non-nil and (array of) string, boolean or numeric type.
+        #   Array values must not contain nil elements and all elements must be of
+        #   the same basic type (string, numeric, boolean).
+        #
+        # @return [self] returns itself
+        def add_attributes(attributes)
+          super
+          @mutex.synchronize do
+            if @ended
+              OpenTelemetry.logger.warn('Calling add_attributes on an ended Span.')
+            else
+              @attributes ||= {}
+              @attributes.merge!(attributes)
+              trim_span_attributes(@attributes)
+              @total_recorded_attributes += attributes.size
+            end
+          end
+          self
+        end
+
         # Add an Event to a {Span}.
         #
         # Example:

--- a/sdk/test/opentelemetry/sdk/trace/span_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/span_test.rb
@@ -84,6 +84,36 @@ describe OpenTelemetry::SDK::Trace::Span do
     end
   end
 
+  describe '#add_attributes' do
+    it 'sets attributes' do
+      span.add_attributes('foo' => 'bar')
+      _(span.attributes).must_equal('foo' => 'bar')
+    end
+
+    it 'trims the oldest attributes' do
+      span.add_attributes('old' => 'oldbar')
+      span.add_attributes('foo' => 'bar', 'bar' => 'baz')
+      _(span.attributes).must_equal('bar' => 'baz')
+    end
+
+    it 'does not set an attribute if span is ended' do
+      span.finish
+      span.add_attributes('no' => 'set')
+      _(span.attributes).must_be_nil
+    end
+
+    it 'counts attributes' do
+      span.add_attributes('old' => 'oldbar')
+      span.add_attributes('foo' => 'bar', 'bar' => 'baz')
+      _(span.to_span_data.total_recorded_attributes).must_equal(3)
+    end
+
+    it 'accepts an array value' do
+      span.add_attributes('foo' => [1, 2, 3])
+      _(span.attributes).must_equal('foo' => [1, 2, 3])
+    end
+  end
+
   describe '#add_event' do
     it 'add a named event' do
       span.add_event('added')


### PR DESCRIPTION
See: https://github.com/open-telemetry/opentelemetry-specification/pull/1473

This is optional, however I think it is useful both for convenience and for performance reasons (adding multiple attributes only requires taking the lock and trimming attributes once vs N times).