### PR TITLE
feat: added http.route in rails instrumentation to match the spec

### DIFF
--- a/instrumentation/rails/README.md
+++ b/instrumentation/rails/README.md
@@ -33,7 +33,7 @@ end
 
 ### Configuration options
 
-The `http.route` attribute is disabled by default because we use [.recognize](https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/journey/router.rb#L65)
+The `http.route` attribute is disabled by default because we use [.recognize](https://github.com/rails/rails/blob/v6.1.3/actionpack/lib/action_dispatch/journey/router.rb#L65)
 ```ruby
 OpenTelemetry::SDK.configure do |c|
   c.use 'OpenTelemetry::Instrumentation::Rails', {

--- a/instrumentation/rails/README.md
+++ b/instrumentation/rails/README.md
@@ -30,6 +30,18 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
+
+### Configuration options
+
+The `http.route` attribute is disabled by default because we use [.recognize](https://github.com/rails/rails/blob/main/actionpack/lib/action_dispatch/journey/router.rb#L65)
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::Rails', {
+    enable_recognize_route: true
+  }
+end
+```
+
 ## Examples
 
 Example usage can be seen in the `./example/trace_demonstration.rb` file [here](https://github.com/open-telemetry/opentelemetry-ruby/blob/main/instrumentation/rails/example/trace_request_demonstration.ru)

--- a/instrumentation/rails/lib/opentelemetry/instrumentation/rails/instrumentation.rb
+++ b/instrumentation/rails/lib/opentelemetry/instrumentation/rails/instrumentation.rb
@@ -22,6 +22,8 @@ module OpenTelemetry
           defined?(::Rails)
         end
 
+        option :enable_recognize_route, default: false, validate: :boolean
+
         private
 
         def require_dependencies

--- a/instrumentation/rails/lib/opentelemetry/instrumentation/rails/patches/action_controller/metal.rb
+++ b/instrumentation/rails/lib/opentelemetry/instrumentation/rails/patches/action_controller/metal.rb
@@ -15,10 +15,20 @@ module OpenTelemetry
               rack_span = OpenTelemetry::Instrumentation::Rack.current_span
               rack_span.name = "#{self.class.name}##{name}" if rack_span.context.valid? && !request.env['action_dispatch.exception']
 
+              add_rails_route(rack_span, request) if instrumentation_config[:enable_recognize_route]
+              super(name, request, response)
+            end
+
+            private
+
+            def add_rails_route(rack_span, request)
               ::Rails.application.routes.router.recognize(request) do |route, _params|
                 rack_span.set_attribute('http.route', route.path.spec.to_s)
               end
-              super(name, request, response)
+            end
+
+            def instrumentation_config
+              Rails::Instrumentation.instance.config
             end
           end
         end

--- a/instrumentation/rails/lib/opentelemetry/instrumentation/rails/patches/action_controller/metal.rb
+++ b/instrumentation/rails/lib/opentelemetry/instrumentation/rails/patches/action_controller/metal.rb
@@ -14,6 +14,10 @@ module OpenTelemetry
             def dispatch(name, request, response)
               rack_span = OpenTelemetry::Instrumentation::Rack.current_span
               rack_span.name = "#{self.class.name}##{name}" if rack_span.context.valid? && !request.env['action_dispatch.exception']
+
+              ::Rails.application.routes.router.recognize(request) do |route, _params|
+                rack_span.set_attribute('http.route', route.path.spec.to_s)
+              end
               super(name, request, response)
             end
           end

--- a/instrumentation/rails/test/opentelemetry/instrumentation/rails/patches/action_controller/metal_test.rb
+++ b/instrumentation/rails/test/opentelemetry/instrumentation/rails/patches/action_controller/metal_test.rb
@@ -36,7 +36,7 @@ describe OpenTelemetry::Instrumentation::Rails::Patches::ActionController::Metal
     _(span.attributes['http.target']).must_equal '/ok'
     _(span.attributes['http.status_code']).must_equal 200
     _(span.attributes['http.user_agent']).must_be_nil
-    _(span.attributes['http.route']).must_equal '/ok(.:format)'
+    _(span.attributes['http.route']).must_be_nil
   end
 
   it 'sets the span name when the controller raises an exception' do
@@ -64,6 +64,37 @@ describe OpenTelemetry::Instrumentation::Rails::Patches::ActionController::Metal
       get 'internal_server_error'
 
       _(span.name).must_equal 'ExampleController#internal_server_error'
+    end
+  end
+
+  describe 'when the application has enable_rails_route enabled' do
+    before do
+      OpenTelemetry::Instrumentation::Rails::Instrumentation.instance.config[:enable_recognize_route] = true
+    end
+
+    after do
+      OpenTelemetry::Instrumentation::Rails::Instrumentation.instance.config[:enable_recognize_route] = false
+    end
+
+    it 'sets the span name to ControllerName#action' do
+      get '/ok'
+
+      _(last_response.body).must_equal 'actually ok'
+      _(last_response.ok?).must_equal true
+      _(span.name).must_equal 'ExampleController#ok'
+      _(span.kind).must_equal :server
+      _(span.status.ok?).must_equal true
+
+      _(span.instrumentation_library.name).must_equal 'OpenTelemetry::Instrumentation::Rack'
+      _(span.instrumentation_library.version).must_equal OpenTelemetry::Instrumentation::Rack::VERSION
+
+      _(span.attributes['http.method']).must_equal 'GET'
+      _(span.attributes['http.host']).must_equal 'example.org'
+      _(span.attributes['http.scheme']).must_equal 'http'
+      _(span.attributes['http.target']).must_equal '/ok'
+      _(span.attributes['http.status_code']).must_equal 200
+      _(span.attributes['http.user_agent']).must_be_nil
+      _(span.attributes['http.route']).must_equal '/ok(.:format)'
     end
   end
 

--- a/instrumentation/rails/test/opentelemetry/instrumentation/rails/patches/action_controller/metal_test.rb
+++ b/instrumentation/rails/test/opentelemetry/instrumentation/rails/patches/action_controller/metal_test.rb
@@ -36,6 +36,7 @@ describe OpenTelemetry::Instrumentation::Rails::Patches::ActionController::Metal
     _(span.attributes['http.target']).must_equal '/ok'
     _(span.attributes['http.status_code']).must_equal 200
     _(span.attributes['http.user_agent']).must_be_nil
+    _(span.attributes['http.route']).must_equal '/ok(.:format)'
   end
 
   it 'sets the span name when the controller raises an exception' do


### PR DESCRIPTION
# Description
The [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-server-semantic-conventions) says:

> Given an inbound request for a route (e.g. "/users/:userID?") the name attribute of the span SHOULD be set to this route. If the route does not include the application root, it SHOULD be prepended to the span name.
> 
> If the route cannot be determined, the name attribute MUST be set as defined in the general semantic conventions for HTTP.

Some exporters need more information to provide useful insights to the user,
so add `http.route` could make more easily convert traces to the final destination.

My current case is using Datadog: The [exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/translate_traces.go#L440) uses the `http.route` to define how the resource will be shown, so I think makes sense to add here that information.

I created a really simple implementation, so any feedback would be useful 

The result is something like that:

![Screenshot from 2021-03-17 16-20-46](https://user-images.githubusercontent.com/1574240/111525924-dcf89c00-873c-11eb-96d4-6412bfde0c3a.png)


