### PR TITLE
feat: default noop tracer for instrumentation

### DIFF
--- a/api/lib/opentelemetry/instrumentation/base.rb
+++ b/api/lib/opentelemetry/instrumentation/base.rb
@@ -194,6 +194,7 @@ module OpenTelemetry
         @config = {}
         @installed = false
         @options = options
+        @tracer = OpenTelemetry::Trace::Tracer.new
       end
 
       # Install instrumentation with the given config. The present? and compatible?
@@ -207,7 +208,7 @@ module OpenTelemetry
 
         @config = config_options(config)
         instance_exec(@config, &@install_blk)
-        @tracer ||= OpenTelemetry.tracer_provider.tracer(name, version)
+        @tracer = OpenTelemetry.tracer_provider.tracer(name, version)
         @installed = true
       end
 

--- a/api/test/opentelemetry/instrumentation/base_test.rb
+++ b/api/test/opentelemetry/instrumentation/base_test.rb
@@ -298,8 +298,8 @@ describe OpenTelemetry::Instrumentation::Base do
   end
 
   describe '#tracer' do
-    it 'returns nil if not installed' do
-      _(instrumentation_with_callbacks.instance.tracer).must_be_nil
+    it 'returns a noop api tracer if not installed' do
+      _(instrumentation_with_callbacks.instance.tracer).must_be_instance_of(OpenTelemetry::Trace::Tracer)
     end
 
     it 'returns named tracer if installed' do


### PR DESCRIPTION
To improve the ergonomics of adding first party instrumentation we should
return a noop tracer when the instrumentation has not been installed.

This PR has come up now that I've started adding first party instrumentation directly into gems.  As discussed at a prior SIG there is value that comes with using the base instrumentation class to gain access to a named tracer, as well as add the instrumented library to the registry.

In the case where the instrumentation is never installed you would having to conditionally check for the presence of a tracer.  This change allows those who are instrumenting their library to simply add the trace points using the `Instrumention.instance.tracer` handle indifferently.