### PR TITLE
fix: HTTP example uses the console exporter.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,6 +113,8 @@ services:
 
   ex-http:
     <<: *base
+    environment:
+      - OTEL_TRACES_EXPORTER=console
     command: ./start_server.sh
     working_dir: /app/examples/http
 

--- a/examples/http/Gemfile.lock
+++ b/examples/http/Gemfile.lock
@@ -1,20 +1,20 @@
 PATH
   remote: ../../api
   specs:
-    opentelemetry-api (0.15.0)
+    opentelemetry-api (0.16.0)
 
 PATH
   remote: ../../common
   specs:
-    opentelemetry-common (0.15.0)
-      opentelemetry-api (~> 0.15.0)
+    opentelemetry-common (0.16.0)
+      opentelemetry-api (~> 0.16.0)
 
 PATH
   remote: ../../sdk
   specs:
-    opentelemetry-sdk (0.15.0)
-      opentelemetry-api (~> 0.15.0)
-      opentelemetry-common (~> 0.15.0)
+    opentelemetry-sdk (0.16.0)
+      opentelemetry-api (~> 0.16.0)
+      opentelemetry-common (~> 0.16.0)
 
 GEM
   remote: https://rubygems.org/
@@ -44,4 +44,4 @@ DEPENDENCIES
   sinatra (~> 2.0)
 
 BUNDLED WITH
-   2.2.14
+   2.2.15


### PR DESCRIPTION
Leaving OTEL_TRACES_EXPORTER unspecified was making the sample
application look for the default OTLP exporter instead of the console exporter.