### PR TITLE
chore: Attempt to fix bundler integration in releases, and allow retries from arbitrary SHAs

### DIFF
--- a/.toys/release/.lib/release_utils.rb
+++ b/.toys/release/.lib/release_utils.rb
@@ -268,7 +268,7 @@ class ReleaseUtils
     if cur_repo == repo_path
       logger.info("Git repo is correct.")
     else
-      error("Remmote repo is #{cur_repo}, expected #{repo_path}")
+      error("Remote repo is #{cur_repo}, expected #{repo_path}")
     end
     cur_repo
   end

--- a/.toys/release/retry.rb
+++ b/.toys/release/retry.rb
@@ -26,6 +26,13 @@ flag_group desc: "Flags" do
       "The name of the git remote pointing at the canonical repository." \
       " Defaults to 'origin'."
   end
+  flag :sha, "--sha=VAL" do
+    desc "Override the SHA for the release"
+    long_desc \
+      "The SHA to release from. This can be used if additional commits" \
+      " needed to be done to fix the release. If not given, the merge SHA" \
+      " of the pull request is used."
+  end
   flag :rubygems_api_key, "--rubygems-api-key=VAL" do
     desc "Set the Rubygems API key"
     long_desc \
@@ -109,7 +116,7 @@ end
 
 def setup_git
   @original_branch = @utils.current_branch
-  merge_sha = @pr_info["merge_commit_sha"]
+  merge_sha = sha || @pr_info["merge_commit_sha"]
   exec(["git", "fetch", "--depth=2", "origin", merge_sha])
   exec(["git", "checkout", merge_sha])
 end

--- a/.toys/yardoc.rb
+++ b/.toys/yardoc.rb
@@ -9,6 +9,7 @@ def run
   raise "No yardopts in the current directory" unless File.file?(".yardopts")
   rm_rf(".yardoc")
   rm_rf("doc")
+  exec(["bundle", "update"])
   exec_tool(["yardoc", "_build"])
 end
 


### PR DESCRIPTION
This is an attempt to fix release #662.

The theory is that something changed in recent bundler 2.2 releases that is breaking the Toys-Bundler integration. We'll try to work around that by invoking Bundler directly. And we'll also need a way to retry a release from a specific SHA, since currently `toys release retry` works from the original release PR's merge point.