### PR TITLE
chore: Ensure the merge commit, the previous commit, and the release commit are fetched

### DIFF
--- a/.toys/release/retry.rb
+++ b/.toys/release/retry.rb
@@ -116,9 +116,11 @@ end
 
 def setup_git
   @original_branch = @utils.current_branch
-  merge_sha = sha || @pr_info["merge_commit_sha"]
+  merge_sha = @pr_info["merge_commit_sha"]
+  release_sha = sha || merge_sha
   exec(["git", "fetch", "--depth=2", "origin", merge_sha])
-  exec(["git", "checkout", merge_sha])
+  exec(["git", "fetch", "--depth=2", "origin", release_sha])
+  exec(["git", "checkout", release_sha])
 end
 
 def cleanup_git


### PR DESCRIPTION
Hating git today.

If releasing from a different SHA than the merge commit for the release PR, we still need to make sure that two commits are fetched from the merge commit (because we need the diff). So we actually have to fetch twice: the merge SHA and the release SHA.
