### PR TITLE
chore: Prevent release fetch from clobbering the merge fetch

### DIFF
--- a/.toys/release/retry.rb
+++ b/.toys/release/retry.rb
@@ -118,8 +118,8 @@ def setup_git
   @original_branch = @utils.current_branch
   merge_sha = @pr_info["merge_commit_sha"]
   release_sha = sha || merge_sha
+  exec(["git", "fetch", "--depth=1", "origin", release_sha])
   exec(["git", "fetch", "--depth=2", "origin", merge_sha])
-  exec(["git", "fetch", "--depth=2", "origin", release_sha])
   exec(["git", "checkout", release_sha])
 end
 


### PR DESCRIPTION
Now git is just being mean to me.

Apparently, if you git fetch with a depth, and then fetch again with depth that partially overlaps the first, you'll lose history edges between the overlap region and the non-overlap region. Since we care about history from merge_sha, make sure that fetch happens last. And since we don't care about history from release_sha, reduce its depth to 1. (And if release_sha and merge_sha are the same, then the second fetch will overwrite the first, which is fine; we just need to make sure we end up with depth=2 from merge_sha.)
