### PR TITLE
Fix: HTTP instrumentation missing require

### DIFF
--- a/instrumentation/http/lib/opentelemetry/instrumentation/http/instrumentation.rb
+++ b/instrumentation/http/lib/opentelemetry/instrumentation/http/instrumentation.rb
@@ -27,6 +27,7 @@ module OpenTelemetry
 
         def require_dependencies
           require_relative 'patches/client'
+          require_relative 'patches/connection'
         end
       end
     end


### PR DESCRIPTION
Unfortunate error here, the install hook makes a lot of noise as a result and will raise errors as the gem is partially patched with no tracer available.  We require the patches as part of the test setup so this one slipped by.