### PR TITLE
fix: Fix Mongo instrumentation example.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,12 +44,6 @@ services:
     <<: *base
     working_dir: /app/instrumentation/faraday/example
 
-  ex-instrumentation-mongo:
-    <<: *base
-    depends_on:
-      - mongo
-    working_dir: /app/instrumentation/mongo/example
-
   ex-instrumentation-mysql2:
     <<: *base
     environment:

--- a/instrumentation/mongo/README.md
+++ b/instrumentation/mongo/README.md
@@ -30,9 +30,19 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
-## Examples
+## Example
 
-Example usage of mongo can be seen in the `./example/mongo.rb` file [here](https://github.com/open-telemetry/opentelemetry-ruby/blob/main/instrumentation/mongo/example/mongo.rb)
+To run the example:
+
+1. Start MongoDB using docker-compose
+	* `docker-compose up mongo`
+2. In a separate terminal window, `cd` to the examples directory and install gems
+	* `cd example`
+	* `bundle install`
+3. Run the sample client script
+	* `./mongo.rb`
+
+This will run a few MongoDB commands, printing OpenTelemetry traces to the console as it goes.
 
 ## How can I get involved?
 
@@ -51,3 +61,4 @@ Apache 2.0 license. See [LICENSE][license-github] for more information.
 [ruby-sig]: https://github.com/open-telemetry/community#ruby-sig
 [community-meetings]: https://github.com/open-telemetry/community#community-meetings
 [discussions-url]: https://github.com/open-telemetry/opentelemetry-ruby/discussions
+

--- a/instrumentation/mongo/example/Gemfile
+++ b/instrumentation/mongo/example/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'mongo-ruby-driver'
+gem 'mongo'
 gem 'opentelemetry-api', path: '../../../api'
 gem 'opentelemetry-instrumentation-mongo', path: '../../../instrumentation/mongo'
 gem 'opentelemetry-sdk', path: '../../../sdk'

--- a/instrumentation/mongo/example/mongo.rb
+++ b/instrumentation/mongo/example/mongo.rb
@@ -9,6 +9,9 @@ require 'bundler/setup'
 
 Bundler.require
 
+# Export traces to console by default
+ENV['OTEL_TRACES_EXPORTER'] ||= 'console'
+
 OpenTelemetry::SDK.configure do |c|
   c.use 'OpenTelemetry::Instrumentation::Mongo'
 end


### PR DESCRIPTION
Fixed a bad gem name, and removed the docker-compose container for the
example, which was adding little value.