### PR TITLE
HTTP instrumenter should check for gem presence

### DIFF
--- a/instrumentation/http/lib/opentelemetry/instrumentation/http/instrumentation.rb
+++ b/instrumentation/http/lib/opentelemetry/instrumentation/http/instrumentation.rb
@@ -17,7 +17,7 @@ module OpenTelemetry
         end
 
         present do
-          defined?(::HTTP) && Gem.loaded_specs['http']
+          !(defined?(::HTTP) && Gem.loaded_specs['http']).nil?
         end
 
         def patch

--- a/instrumentation/http/lib/opentelemetry/instrumentation/http/instrumentation.rb
+++ b/instrumentation/http/lib/opentelemetry/instrumentation/http/instrumentation.rb
@@ -17,7 +17,7 @@ module OpenTelemetry
         end
 
         present do
-          defined?(::HTTP)
+          defined?(::HTTP) && Gem.loaded_specs['http']
         end
 
         def patch

--- a/instrumentation/http/opentelemetry-instrumentation-http.gemspec
+++ b/instrumentation/http/opentelemetry-instrumentation-http.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 0.0'
   spec.add_development_dependency 'rake', '~> 12.3.3'
+  spec.add_development_dependency 'rspec-mocks'
   spec.add_development_dependency 'rubocop', '~> 0.73.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'

--- a/instrumentation/http/test/instrumentation/http/instrumentation_test.rb
+++ b/instrumentation/http/test/instrumentation/http/instrumentation_test.rb
@@ -20,6 +20,22 @@ describe OpenTelemetry::Instrumentation::HTTP do
     _(instrumentation.version).wont_be_empty
   end
 
+  describe 'present' do
+    it 'when http gem installed' do
+      _(instrumentation.present?).must_equal(true)
+    end
+
+    it 'when HTTP constant not present' do
+      hide_const('HTTP')
+      _(instrumentation.present?).must_equal(false)
+    end
+
+    it 'when http gem not installed' do
+      allow(Gem).to receive(:loaded_specs).and_return({})
+      _(instrumentation.present?).must_equal(false)
+    end
+  end
+
   describe '#install' do
     it 'accepts argument' do
       _(instrumentation.install({})).must_equal(true)

--- a/instrumentation/http/test/test_helper.rb
+++ b/instrumentation/http/test/test_helper.rb
@@ -8,6 +8,7 @@ require 'http'
 require 'opentelemetry/sdk'
 
 require 'minitest/autorun'
+require 'rspec/mocks/minitest_integration'
 require 'webmock/minitest'
 require 'pry'
 


### PR DESCRIPTION
My app apparently defines `::HTTP` without using the HTTP gem, so I see this error:

```
OpenTelemetry error: Instrumentation: OpenTelemetry::Instrumentation::HTTP unhandled exception during install:
...
uninitialized constant HTTP::Client
```