### PR TITLE
Add opentelemetry.io docs

### DIFF
--- a/website_docs/_index.md
+++ b/website_docs/_index.md
@@ -1,0 +1,32 @@
+---
+title: "Ruby"
+weight: 24
+description: >
+  <img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Ruby_SDK.svg"></img>
+  A language-specific implementation of OpenTelemetry in Ruby.
+---
+
+This is the OpenTelemetry for Ruby documentation. OpenTelemetry is an
+observability framework -- an API, SDK, and tools that are designed to aid in
+the generation and collection of application telemetry data such as metrics,
+logs, and traces. This documentation is designed to help you understand how to
+get started using OpenTelemetry for Ruby.
+
+## Status and Releases
+
+The current status of the major functional components for OpenTelemetry Ruby is
+as follows:
+
+| Tracing | Metrics | Logging |
+| ------- | ------- | ------- |
+| Beta    | Alpha   | Not Yet Implemented |
+
+The current release can be found [here](https://github.com/open-telemetry/opentelemetry-ruby/releases)
+
+## Further Reading
+
+- [OpenTelemetry for Ruby on GitHub](https://github.com/open-telemetry/opentelemetry-ruby)
+- [Installation](https://github.com/open-telemetry/opentelemetry-ruby#installation)
+- [Quick Start](https://github.com/open-telemetry/opentelemetry-ruby#quick-start)
+- [API Documentation](https://open-telemetry.github.io/opentelemetry-ruby/)
+- [Examples](https://github.com/open-telemetry/opentelemetry-ruby/tree/main/examples)

--- a/website_docs/_index.md
+++ b/website_docs/_index.md
@@ -19,7 +19,7 @@ as follows:
 
 | Tracing | Metrics | Logging |
 | ------- | ------- | ------- |
-| Beta    | Alpha   | Not Yet Implemented |
+| Beta    | Not Yet Implemented | Not Yet Implemented |
 
 The current release can be found [here](https://github.com/open-telemetry/opentelemetry-ruby/releases)
 


### PR DESCRIPTION
Per open-telemetry/opentelemetry.io#472, we're mirroring the docs content on the website to each SIG. When a release occurs and these docs are updated, please make an issue or PR mirroring them to their appropriate location in the website repo (https://github.com/open-telemetry/opentelemetry.io/tree/main/content/en/docs/ruby).