### PR TITLE
fix: index a link trace_id in middle rather than end

### DIFF
--- a/exporter/jaeger/lib/opentelemetry/exporter/jaeger/encoder.rb
+++ b/exporter/jaeger/lib/opentelemetry/exporter/jaeger/encoder.rb
@@ -112,8 +112,8 @@ module OpenTelemetry
           links&.map do |link|
             Thrift::SpanRef.new(
               'refType' => Thrift::SpanRefType::FOLLOWS_FROM,
-              'traceIdLow' => int64(link.span_context.trace_id[16, 16]),
-              'traceIdHigh' => int64(link.span_context.trace_id[0, 16]),
+              'traceIdLow' => int64(link.span_context.trace_id[8, 8]),
+              'traceIdHigh' => int64(link.span_context.trace_id[0, 8]),
               'spanId' => int64(link.span_context.span_id)
             )
           end

--- a/exporter/jaeger/test/opentelemetry/exporters/jaeger/encoder_test.rb
+++ b/exporter/jaeger/test/opentelemetry/exporters/jaeger/encoder_test.rb
@@ -39,6 +39,18 @@ describe OpenTelemetry::Exporter::Jaeger::Encoder do
     _(error_tag.vBool).must_equal(true)
   end
 
+  it 'encodes span.links' do
+    span_context = OpenTelemetry::Trace::SpanContext.new
+    span_data = create_span_data(links: [OpenTelemetry::Trace::Link.new(span_context)])
+    encoded_span = Encoder.encoded_span(span_data)
+
+    encoded_reference = encoded_span.references.first
+    _([encoded_reference.spanId].pack('Q>')).must_equal(span_context.span_id)
+    trace_id = [encoded_reference.traceIdHigh, encoded_reference.traceIdLow].pack('Q>Q>')
+    _(trace_id).must_equal(span_context.trace_id)
+    _(encoded_reference.refType).must_equal(OpenTelemetry::Exporter::Jaeger::Thrift::SpanRefType::FOLLOWS_FROM)
+  end
+
   it 'encodes attributes in events and the span' do
     attributes = { 'akey' => 'avalue' }
     events = [


### PR DESCRIPTION
A link's trace_id was being indexed at the end of the string rather than the
middle which was causing it to return nil and the exporter to throw an
undefined method exception when trying to convert nil into a int64:

```
undefined method '<' for nil:NilClass
```