### PR TITLE
fix: updated rack middleware position to zero

### DIFF
--- a/instrumentation/rails/lib/opentelemetry/instrumentation/rails/railtie.rb
+++ b/instrumentation/rails/lib/opentelemetry/instrumentation/rails/railtie.rb
@@ -15,7 +15,7 @@ module OpenTelemetry
           OpenTelemetry::Instrumentation::Rack::Instrumentation.instance.install({})
 
           app.middleware.insert_after(
-            ActionDispatch::RequestId,
+            0,
             OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware
           )
         end


### PR DESCRIPTION
# Description 
## TL;DR;
The current insertion point is after some important middlewares
 like the ActionDispatch::Static.
That is making us missing some traces,
so I changed the insert to the first position

## Deep down

We are starting to test the OTel in production to remove Datadog. After the deployment, we saw a big difference in requests:
Datadog version:
![Screenshot from 2021-04-01 15-12-47](https://user-images.githubusercontent.com/1574240/113336422-c6d20a80-92fc-11eb-8cae-f59083e7c853.png)
OTel version:
![Screenshot from 2021-04-01 15-13-21](https://user-images.githubusercontent.com/1574240/113336456-d2253600-92fc-11eb-97d7-3b2f9ade18b5.png)

After some research, I found the problem in the current position of the ` TracerMiddleware`. The stack looks like that:
```
[0] = {Class} Datadog::Contrib::Rack::TraceMiddleware
[1] = {Class} Rack::Cors
[2] = {Class} SecureHeaders::Middleware
[3] = {Class} Rack::Sendfile
[4] = {Class} ActionDispatch::Static
[5] = {Class} ActionDispatch::Executor
[6] = {ActiveSupport::Cache::Strategy::LocalCache::Middleware} #<ActiveSupport::Cache::Strategy::LocalCache::Middleware:0x0000564147e12f60>
[7] = {Class} Rack::Runtime
[8] = {Class} Rack::MethodOverride
[9] = {Class} ActionDispatch::RequestId
[10] = {Class} OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware
[11] = {Class} RequestStore::Middleware
[12] = {Class} ActionDispatch::RemoteIp
[13] = {Class} Sprockets::Rails::QuietAssets
[14] = {Class} Rails::Rack::Logger
[15] = {Class} ActionDispatch::ShowExceptions
[16] = {Class} Datadog::Contrib::Rails::ExceptionMiddleware
[17] = {Class} ActionDispatch::DebugExceptions
[18] = {Class} Rollbar::Middleware::Rails::RollbarMiddleware
[19] = {Class} ActionDispatch::Reloader
[20] = {Class} ActionDispatch::Callbacks
[21] = {Class} ActionDispatch::Cookies
[22] = {Class} RedisSessionStore
[23] = {Class} ActionDispatch::Flash
[24] = {Class} ActionDispatch::ContentSecurityPolicy::Middleware
[25] = {Class} Rack::Head
[26] = {Class} Rack::ConditionalGet
[27] = {Class} Rack::ETag
[28] = {Class} Rack::TempfileReaper
[29] = {Class} OmniAuth::Builder
```
The `ActionDispatch::Static`[position 4] comes before the TracerMiddleware [position 10], so every time a static resource is required, we lost the tracing for that.
That is the same approach used in [ddtrace library](https://github.com/DataDog/dd-trace-rb/blob/079f18f410f590252030578aa240576f3fc4c6e5/lib/ddtrace/contrib/rails/patcher.rb#L43) and based on [that comment](https://github.com/open-telemetry/opentelemetry-ruby/pull/454#discussion_r513594995) believe to change the order is not a big problem and could bring more benefits

