### PR TITLE
Fix rails example by not using `rails` from git

### DIFF
--- a/instrumentation/rails/example/trace_request_demonstration.ru
+++ b/instrumentation/rails/example/trace_request_demonstration.ru
@@ -9,9 +9,7 @@ require 'bundler/inline'
 gemfile(true) do
   source 'https://rubygems.org'
 
-  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
-  gem 'rails', github: 'rails/rails'
+  gem 'rails'
   gem 'opentelemetry-sdk'
   gem 'opentelemetry-instrumentation-rails'
 end


### PR DESCRIPTION
The example works just fine with the version of rails released to
rubygems (currently 6.1.3.1) - there's no explicit need to use a git
dependency here. At present, this example is actually broken because the
rails repo changed their `master` branch to `main` - see #700.
