### PR TITLE
feat: Add configurable truncation of span and event attribute values 

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/config/trace_config.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/config/trace_config.rb
@@ -16,6 +16,9 @@ module OpenTelemetry
           # The global default max number of attributes per {Span}.
           attr_reader :max_attributes_count
 
+          # The global default max length of attribute value per {Span}.
+          attr_reader :max_attributes_length
+
           # The global default max number of {OpenTelemetry::SDK::Trace::Event}s per {Span}.
           attr_reader :max_events_count
 
@@ -32,13 +35,15 @@ module OpenTelemetry
           #
           # @return [TraceConfig] with the desired values.
           # @raise [ArgumentError] if any of the max numbers are not positive.
-          def initialize(sampler: sampler_from_environment(Samplers.parent_based(root: Samplers::ALWAYS_ON)),
+          def initialize(sampler: sampler_from_environment(Samplers.parent_based(root: Samplers::ALWAYS_ON)), # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
                          max_attributes_count: Integer(ENV.fetch('OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT', 128)),
+                         max_attributes_length: ENV['OTEL_RUBY_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT'],
                          max_events_count: Integer(ENV.fetch('OTEL_SPAN_EVENT_COUNT_LIMIT', 128)),
                          max_links_count: Integer(ENV.fetch('OTEL_SPAN_LINK_COUNT_LIMIT', 128)),
                          max_attributes_per_event: max_attributes_count,
                          max_attributes_per_link: max_attributes_count)
             raise ArgumentError, 'max_attributes_count must be positive' unless max_attributes_count.positive?
+            raise ArgumentError, 'max_attributes_length must not be less than 32' unless max_attributes_length.nil? || Integer(max_attributes_length) >= 32
             raise ArgumentError, 'max_events_count must be positive' unless max_events_count.positive?
             raise ArgumentError, 'max_links_count must be positive' unless max_links_count.positive?
             raise ArgumentError, 'max_attributes_per_event must be positive' unless max_attributes_per_event.positive?
@@ -46,6 +51,7 @@ module OpenTelemetry
 
             @sampler = sampler
             @max_attributes_count = max_attributes_count
+            @max_attributes_length = max_attributes_length.nil? ? nil : Integer(max_attributes_length)
             @max_events_count = max_events_count
             @max_links_count = max_links_count
             @max_attributes_per_event = max_attributes_per_event

--- a/sdk/test/opentelemetry/sdk/trace/config/trace_config_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/config/trace_config_test.rb
@@ -25,12 +25,14 @@ describe OpenTelemetry::SDK::Trace::Config::TraceConfig do
       with_env('OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT' => '1',
                'OTEL_SPAN_EVENT_COUNT_LIMIT' => '2',
                'OTEL_SPAN_LINK_COUNT_LIMIT' => '3',
+               'OTEL_RUBY_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '32',
                'OTEL_TRACES_SAMPLER' => 'always_on') do
         config = trace_config.new
         _(config.sampler).must_equal samplers::ALWAYS_ON
         _(config.max_attributes_count).must_equal 1
         _(config.max_events_count).must_equal 2
         _(config.max_links_count).must_equal 3
+        _(config.max_attributes_length).must_equal 32
         _(config.max_attributes_per_event).must_equal 1
         _(config.max_attributes_per_link).must_equal 1
       end
@@ -40,19 +42,22 @@ describe OpenTelemetry::SDK::Trace::Config::TraceConfig do
       with_env('OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT' => '1',
                'OTEL_SPAN_EVENT_COUNT_LIMIT' => '2',
                'OTEL_SPAN_LINK_COUNT_LIMIT' => '3',
+               'OTEL_RUBY_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '4',
                'OTEL_TRACES_SAMPLER' => 'always_on') do
         config = trace_config.new(sampler: samplers::ALWAYS_OFF,
                                   max_attributes_count: 10,
                                   max_events_count: 11,
                                   max_links_count: 12,
                                   max_attributes_per_event: 13,
-                                  max_attributes_per_link: 14)
+                                  max_attributes_per_link: 14,
+                                  max_attributes_length: 32)
         _(config.sampler).must_equal samplers::ALWAYS_OFF
         _(config.max_attributes_count).must_equal 10
         _(config.max_events_count).must_equal 11
         _(config.max_links_count).must_equal 12
         _(config.max_attributes_per_event).must_equal 13
         _(config.max_attributes_per_link).must_equal 14
+        _(config.max_attributes_length).must_equal 32
       end
     end
 


### PR DESCRIPTION
We were noticing some exceptionally large spans failing to be exported due to nginx error:
`client intended to send too large body`

It turned out to be due to a case in which large event attributes were being added to spans when exceptions occured.  This PR adds support for configurable truncation of span attribute values (via `OTEL_RUBY_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT ` env variable). The default is to not truncate attribute values and the minimum is 32, following the discussion in [this open spec PR](https://github.com/open-telemetry/opentelemetry-specification/pull/1130).