### PR TITLE
fix: missing instrumentation classes during configuration

### DIFF
--- a/instrumentation/base/lib/opentelemetry/instrumentation/registry.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/registry.rb
@@ -47,9 +47,9 @@ module OpenTelemetry
             instrumentation = find_instrumentation(instrumentation_name)
             if instrumentation.nil?
               OpenTelemetry.logger.warn "Could not install #{instrumentation_name} because it was not found"
-              next
+            else
+              install_instrumentation(instrumentation, instrumentation_config_map[instrumentation.name])
             end
-            install_instrumentation(instrumentation, instrumentation_config_map[instrumentation.name])
           end
         end
       end

--- a/instrumentation/base/lib/opentelemetry/instrumentation/registry.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/registry.rb
@@ -45,8 +45,10 @@ module OpenTelemetry
         @lock.synchronize do
           instrumentation_names.each do |instrumentation_name|
             instrumentation = find_instrumentation(instrumentation_name)
-            OpenTelemetry.logger.warn "Could not install #{instrumentation_name} because it was not found" unless instrumentation
-
+            if instrumentation.nil?
+              OpenTelemetry.logger.warn "Could not install #{instrumentation_name} because it was not found"
+              next
+            end
             install_instrumentation(instrumentation, instrumentation_config_map[instrumentation.name])
           end
         end


### PR DESCRIPTION
When auto-instrumention classes are declared but cannot be loaded, the registry will report an error to logger
and then proceed with the installation.

Before:

```
Could not install OpenTelemetry::Instrumentation::Faraday because it was not found

OpenTelemetry error: unexpected configuration error due to undefined method `name' for nil:NilClass - OpenTelemetry::SDK::ConfigurationError
```

After:
```
Could not install OpenTelemetry::Instrumentation::Faraday because it was not found
```