### PR TITLE
feat: option to obfuscate redis arguments

### DIFF
--- a/instrumentation/redis/README.md
+++ b/instrumentation/redis/README.md
@@ -47,8 +47,8 @@ end
 OpenTelemetry::SDK.configure do |c|
   c.use 'OpenTelemetry::Instrumentation::Redis', {
     # The obfuscation of arguments in the db.statement attribute is disabled by default.
-    # To enable, set enable_arg_obfuscation to true.
-    enable_arg_obfuscation: false,
+    # To enable, set enable_statement_obfuscation to true.
+    enable_statement_obfuscation: false,
   }
 end
 ```

--- a/instrumentation/redis/README.md
+++ b/instrumentation/redis/README.md
@@ -41,6 +41,18 @@ OpenTelemetry::Instrumentation::Redis.with_attributes('peer.service' => 'cache')
 end
 ```
 
+### Configuration options
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::Redis', {
+    # The obfuscation of arguments in the db.statement attribute is disabled by default.
+    # To enable, set enable_arg_obfuscation to true.
+    enable_arg_obfuscation: false,
+  }
+end
+```
+
 ## Example
 
 An example of usage can be seen in [`example/redis.rb`](https://github.com/open-telemetry/opentelemetry-ruby/blob/main/instrumentation/redis/example/redis.rb).

--- a/instrumentation/redis/README.md
+++ b/instrumentation/redis/README.md
@@ -46,9 +46,9 @@ end
 ```ruby
 OpenTelemetry::SDK.configure do |c|
   c.use 'OpenTelemetry::Instrumentation::Redis', {
-    # The obfuscation of arguments in the db.statement attribute is disabled by default.
-    # To enable, set enable_statement_obfuscation to true.
-    enable_statement_obfuscation: false,
+    # The obfuscation of arguments in the db.statement attribute is enabled by default.
+    # To disable, set enable_statement_obfuscation to false.
+    enable_statement_obfuscation: true,
   }
 end
 ```

--- a/instrumentation/redis/lib/opentelemetry/instrumentation/redis/instrumentation.rb
+++ b/instrumentation/redis/lib/opentelemetry/instrumentation/redis/instrumentation.rb
@@ -20,7 +20,7 @@ module OpenTelemetry
         end
 
         option :peer_service, default: nil, validate: :string
-        option :enable_arg_obfuscation, default: false, validate: :boolean
+        option :enable_statement_obfuscation, default: false, validate: :boolean
 
         private
 

--- a/instrumentation/redis/lib/opentelemetry/instrumentation/redis/instrumentation.rb
+++ b/instrumentation/redis/lib/opentelemetry/instrumentation/redis/instrumentation.rb
@@ -20,6 +20,7 @@ module OpenTelemetry
         end
 
         option :peer_service, default: nil, validate: :string
+        option :enable_arg_obfuscation, default: false, validate: :boolean
 
         private
 

--- a/instrumentation/redis/lib/opentelemetry/instrumentation/redis/instrumentation.rb
+++ b/instrumentation/redis/lib/opentelemetry/instrumentation/redis/instrumentation.rb
@@ -20,7 +20,7 @@ module OpenTelemetry
         end
 
         option :peer_service, default: nil, validate: :string
-        option :enable_statement_obfuscation, default: false, validate: :boolean
+        option :enable_statement_obfuscation, default: true, validate: :boolean
 
         private
 

--- a/instrumentation/redis/lib/opentelemetry/instrumentation/redis/utils.rb
+++ b/instrumentation/redis/lib/opentelemetry/instrumentation/redis/utils.rb
@@ -50,7 +50,7 @@ module OpenTelemetry
         private
 
         def obfuscate_arg(arg)
-          return PLACEHOLDER if config[:enable_arg_obfuscation]
+          return PLACEHOLDER if config[:enable_statement_obfuscation]
 
           arg
         end

--- a/instrumentation/redis/test/opentelemetry/instrumentation/redis/instrumentation_test.rb
+++ b/instrumentation/redis/test/opentelemetry/instrumentation/redis/instrumentation_test.rb
@@ -208,18 +208,26 @@ describe OpenTelemetry::Instrumentation::Redis::Instrumentation do
       it 'obfuscates arguments in db.statement' do
         instrumentation.instance_variable_set(:@installed, false)
         instrumentation.install(enable_arg_obfuscation: true)
-        redis = ::Redis.new
+        redis = redis_with_auth
         _(redis.set('K', 'xyz')).must_equal 'OK'
         _(redis.get('K')).must_equal 'xyz'
-        _(exporter.finished_spans.size).must_equal 2
+        _(exporter.finished_spans.size).must_equal 3
 
-        set_span = exporter.finished_spans.first
+        set_span = exporter.finished_spans[0]
+        _(set_span.name).must_equal 'AUTH'
+        _(set_span.attributes['db.system']).must_equal 'redis'
+        _(set_span.attributes['db.statement']).must_equal(
+          'AUTH ?'
+        )
+
+        set_span = exporter.finished_spans[1]
         _(set_span.name).must_equal 'SET'
         _(set_span.attributes['db.system']).must_equal 'redis'
         _(set_span.attributes['db.statement']).must_equal(
           'SET ? ?'
         )
-        set_span = exporter.finished_spans.last
+
+        set_span = exporter.finished_spans[2]
         _(set_span.name).must_equal 'GET'
         _(set_span.attributes['db.system']).must_equal 'redis'
         _(set_span.attributes['db.statement']).must_equal(

--- a/instrumentation/redis/test/opentelemetry/instrumentation/redis/instrumentation_test.rb
+++ b/instrumentation/redis/test/opentelemetry/instrumentation/redis/instrumentation_test.rb
@@ -19,6 +19,12 @@ describe OpenTelemetry::Instrumentation::Redis::Instrumentation do
 
   before do
     exporter.reset
+
+    # Force re-install of instrumentation as it may have been set by another test suite
+    instrumentation.instance_variable_set(:@installed, false)
+    # ensure obfuscation is off if it was previously set in a different test
+    options = { enable_statement_obfuscation: false }
+    instrumentation.install(options)
   end
 
   after do
@@ -27,12 +33,6 @@ describe OpenTelemetry::Instrumentation::Redis::Instrumentation do
   end
 
   describe 'tracing' do
-    before do
-      # ensure obfuscation is off if it was previously set in a different test
-      options = { enable_statement_obfuscation: false }
-      instrumentation.install(options)
-    end
-
     # Instantiate the Redis client with the correct password. Note that this
     # will generate one extra span on connect because the Redis client will
     # send an AUTH command before doing anything else.

--- a/instrumentation/redis/test/opentelemetry/instrumentation/redis/instrumentation_test.rb
+++ b/instrumentation/redis/test/opentelemetry/instrumentation/redis/instrumentation_test.rb
@@ -28,7 +28,9 @@ describe OpenTelemetry::Instrumentation::Redis::Instrumentation do
 
   describe 'tracing' do
     before do
-      instrumentation.install
+      # ensure obfuscation is off if it was previously set in a different test
+      options = { enable_arg_obfuscation: false }
+      instrumentation.install(options)
     end
 
     # Instantiate the Redis client with the correct password. Note that this

--- a/instrumentation/redis/test/opentelemetry/instrumentation/redis/instrumentation_test.rb
+++ b/instrumentation/redis/test/opentelemetry/instrumentation/redis/instrumentation_test.rb
@@ -29,7 +29,7 @@ describe OpenTelemetry::Instrumentation::Redis::Instrumentation do
   describe 'tracing' do
     before do
       # ensure obfuscation is off if it was previously set in a different test
-      options = { enable_arg_obfuscation: false }
+      options = { enable_statement_obfuscation: false }
       instrumentation.install(options)
     end
 
@@ -206,10 +206,10 @@ describe OpenTelemetry::Instrumentation::Redis::Instrumentation do
       _(last_span.attributes['net.peer.port']).must_equal redis_port
     end
 
-    describe 'when enable_arg_obfuscation is enabled' do
+    describe 'when enable_statement_obfuscation is enabled' do
       it 'obfuscates arguments in db.statement' do
         instrumentation.instance_variable_set(:@installed, false)
-        instrumentation.install(enable_arg_obfuscation: true)
+        instrumentation.install(enable_statement_obfuscation: true)
         redis = redis_with_auth
         _(redis.set('K', 'xyz')).must_equal 'OK'
         _(redis.get('K')).must_equal 'xyz'

--- a/instrumentation/redis/test/opentelemetry/instrumentation/redis/utils_test.rb
+++ b/instrumentation/redis/test/opentelemetry/instrumentation/redis/utils_test.rb
@@ -14,7 +14,7 @@ describe OpenTelemetry::Instrumentation::Redis::Utils do
   let(:instrumentation) { OpenTelemetry::Instrumentation::Redis::Instrumentation.instance }
   before do
     instrumentation.instance_variable_set(:@installed, false)
-    instrumentation.install(enable_arg_obfuscation: false)
+    instrumentation.install(enable_statement_obfuscation: false)
   end
 
   describe '#format_arg' do
@@ -54,7 +54,7 @@ describe OpenTelemetry::Instrumentation::Redis::Utils do
       describe 'with arg obfuscation' do
         before do
           instrumentation.instance_variable_set(:@installed, false)
-          instrumentation.install(enable_arg_obfuscation: true)
+          instrumentation.install(enable_statement_obfuscation: true)
         end
         let(:arg) { 'XYZ' }
         it { _(subject).must_equal('?') }
@@ -104,7 +104,7 @@ describe OpenTelemetry::Instrumentation::Redis::Utils do
     describe 'with arg obfuscation' do
       before do
         instrumentation.instance_variable_set(:@installed, false)
-        instrumentation.install(enable_arg_obfuscation: true)
+        instrumentation.install(enable_statement_obfuscation: true)
       end
       let(:args) { [:set, 'KEY', 'VALUE'] }
       it { _(subject).must_equal('SET ? ?') }

--- a/instrumentation/redis/test/opentelemetry/instrumentation/redis/utils_test.rb
+++ b/instrumentation/redis/test/opentelemetry/instrumentation/redis/utils_test.rb
@@ -7,9 +7,15 @@
 require 'test_helper'
 
 require_relative '../../../../lib/opentelemetry/instrumentation/redis/utils'
+require_relative '../../../../lib/opentelemetry/instrumentation/redis/instrumentation'
 
 describe OpenTelemetry::Instrumentation::Redis::Utils do
   let(:utils) { OpenTelemetry::Instrumentation::Redis::Utils }
+  let(:instrumentation) { OpenTelemetry::Instrumentation::Redis::Instrumentation.instance }
+  before do
+    instrumentation.instance_variable_set(:@installed, false)
+    instrumentation.install(enable_arg_obfuscation: false)
+  end
 
   describe '#format_arg' do
     subject { utils.format_arg(arg) }
@@ -43,6 +49,15 @@ describe OpenTelemetry::Instrumentation::Redis::Utils do
       describe 'a string over the limit by a lot' do
         let(:arg) { 'C' * 1000 }
         it { _(subject).must_equal('C' * 47 + '...') }
+      end
+
+      describe 'with arg obfuscation' do
+        before do
+          instrumentation.instance_variable_set(:@installed, false)
+          instrumentation.install(enable_arg_obfuscation: true)
+        end
+        let(:arg) { 'XYZ' }
+        it { _(subject).must_equal('?') }
       end
 
       describe 'an object that can\'t be converted to a string' do
@@ -84,6 +99,15 @@ describe OpenTelemetry::Instrumentation::Redis::Utils do
     describe 'given a nested array' do
       let(:args) { [[:set, 'KEY', 'VALUE']] }
       it { _(subject).must_equal('SET KEY VALUE') }
+    end
+
+    describe 'with arg obfuscation' do
+      before do
+        instrumentation.instance_variable_set(:@installed, false)
+        instrumentation.install(enable_arg_obfuscation: true)
+      end
+      let(:args) { [:set, 'KEY', 'VALUE'] }
+      it { _(subject).must_equal('SET ? ?') }
     end
   end
 end


### PR DESCRIPTION
This change introduces an option for the Redis instrumentation that will obfuscate all arguments in the db.statement attribute.

The purpose of this change is to give clients the option to hide potentially sensitive information such as personally identifiable
information. This is similar to changes that have already been made to the mysql and pg instrumentation.