### PR TITLE
fix: Instrument Redis more thoroughly by patching Client#process.

### DIFF
--- a/instrumentation/redis/example/redis.rb
+++ b/instrumentation/redis/example/redis.rb
@@ -12,4 +12,7 @@ OpenTelemetry::SDK.configure do |c|
   c.use 'OpenTelemetry::Instrumentation::Redis'
 end
 
-Redis.new.set('mykey', 'hello world')
+port = ENV['TEST_REDIS_PORT'] || '16379'
+password = ENV['REDIS_PASSWORD'] || 'passw0rd'
+redis = Redis.new(port: port, password: password)
+redis.set('mykey', 'hello world')

--- a/instrumentation/redis/lib/opentelemetry/instrumentation/redis/patches/client.rb
+++ b/instrumentation/redis/lib/opentelemetry/instrumentation/redis/patches/client.rb
@@ -21,8 +21,8 @@ module OpenTelemetry
             ) do |s|
               reply = super(commands)
               if reply.is_a?(::Redis::CommandError)
-                s&.record_exception(reply)
-                s&.status = Trace::Status.new(
+                s.record_exception(reply)
+                s.status = Trace::Status.new(
                   Trace::Status::ERROR,
                   description: "Unhandled exception of type: #{reply.class}"
                 )

--- a/instrumentation/redis/lib/opentelemetry/instrumentation/redis/patches/client.rb
+++ b/instrumentation/redis/lib/opentelemetry/instrumentation/redis/patches/client.rb
@@ -10,36 +10,25 @@ module OpenTelemetry
       module Patches
         # Module to prepend to Redis::Client for instrumentation
         module Client
-          def call(*args, &block)
-            response = nil
-
+          def process(commands)
+            reply = nil
             attributes = client_attributes
-            attributes['db.statement'] = Utils.format_statement(args)
+            attributes['db.statement'] = Utils.format_statements(commands)
             tracer.in_span(
-              Utils.format_command(args),
+              Utils.format_span_name(commands),
               attributes: attributes,
               kind: :client
-            ) do
-              response = super(*args, &block)
+            ) do |s|
+              reply = super(commands)
+              if reply.is_a?(::Redis::CommandError)
+                s&.record_exception(reply)
+                s&.status = Trace::Status.new(
+                  Trace::Status::ERROR,
+                  description: "Unhandled exception of type: #{reply.class}"
+                )
+              end
             end
-
-            response
-          end
-
-          def call_pipeline(*args, &block)
-            response = nil
-
-            attributes = client_attributes
-            attributes['db.statement'] = Utils.format_pipeline_statement(args)
-            tracer.in_span(
-              'pipeline',
-              attributes: attributes,
-              kind: :client
-            ) do
-              response = super(*args, &block)
-            end
-
-            response
+            reply
           end
 
           private

--- a/instrumentation/redis/lib/opentelemetry/instrumentation/redis/patches/client.rb
+++ b/instrumentation/redis/lib/opentelemetry/instrumentation/redis/patches/client.rb
@@ -24,7 +24,7 @@ module OpenTelemetry
                 s.record_exception(reply)
                 s.status = Trace::Status.new(
                   Trace::Status::ERROR,
-                  description: "Unhandled exception of type: #{reply.class}"
+                  description: reply.message
                 )
               end
             end

--- a/instrumentation/redis/lib/opentelemetry/instrumentation/redis/utils.rb
+++ b/instrumentation/redis/lib/opentelemetry/instrumentation/redis/utils.rb
@@ -15,14 +15,10 @@ module OpenTelemetry
         VALUE_MAX_LEN = 50
         CMD_MAX_LEN = 500
 
-        def format_command(command_args)
-          format_arg(resolve_command_args(command_args).first)
-        end
-
-        def format_pipeline_statement(command_args)
-          command_args[0].commands.map do |args|
-            format_statement(args)
-          end.join("\n")
+        def format_span_name(commands)
+          commands.map do |command|
+            format_arg(resolve_command_args(command).first)
+          end.join(' ')
         end
 
         def format_statement(command_args)
@@ -31,6 +27,10 @@ module OpenTelemetry
 
           cmd = command_args.map { |x| format_arg(x) }.join(' ')
           OpenTelemetry::Common::Utilities.truncate(cmd, CMD_MAX_LEN)
+        end
+
+        def format_statements(commands)
+          commands.map { |command| format_statement(command) }.join("\n")
         end
 
         def format_arg(arg)

--- a/instrumentation/redis/test/opentelemetry/instrumentation/redis/instrumentation_test.rb
+++ b/instrumentation/redis/test/opentelemetry/instrumentation/redis/instrumentation_test.rb
@@ -157,7 +157,7 @@ describe OpenTelemetry::Instrumentation::Redis::Instrumentation do
         OpenTelemetry::Trace::Status::ERROR
       )
       _(last_span.status.description).must_equal(
-        'Unhandled exception of type: Redis::CommandError'
+        'ERR unknown command `THIS_IS_NOT_A_REDIS_FUNC`, with args beginning with: `THIS_IS_NOT_A_VALID_ARG`,'
       )
     end
 

--- a/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/patches/launcher_test.rb
+++ b/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/patches/launcher_test.rb
@@ -47,7 +47,7 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Patches::Launcher do
         launcher.send(:❤)
         span_names = spans.map(&:name)
         _(span_names).must_include('Sidekiq::Launcher#heartbeat')
-        _(span_names).must_include('pipeline')
+        _(span_names).must_include('MULTI SADD EXISTS HMSET EXPIRE RPOP EXEC')
       end
 
       describe 'when peer_service config is set' do


### PR DESCRIPTION
Fixes #197.

I've opted to change the span names for pipeline requests to a concatenation of the Redis commands, i.e. `GET SET INCR`. This seems like it's more inline with [what the spec recommends](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#span) than simply `pipeline`:

> The span name SHOULD be the most general string that identifies a (statistically) interesting class of Spans, rather than individual Span instances while still being human-readable.