### PR TITLE
fix: rescue missed otlp exporter network errors

### DIFF
--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -190,6 +190,12 @@ module OpenTelemetry
           rescue SocketError
             retry if backoff?(retry_count: retry_count += 1, reason: 'socket_error')
             return FAILURE
+          rescue SystemCallError
+            retry if backoff?(retry_count: retry_count += 1, reason: 'system_call_error')
+            return FAILURE
+          rescue EOFError
+            retry if backoff?(retry_count: retry_count += 1, reason: 'eof_error')
+            return FAILURE
           end
         ensure
           # Reset timeouts to defaults for the next call.

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -190,8 +190,8 @@ module OpenTelemetry
           rescue SocketError
             retry if backoff?(retry_count: retry_count += 1, reason: 'socket_error')
             return FAILURE
-          rescue SystemCallError
-            retry if backoff?(retry_count: retry_count += 1, reason: 'system_call_error')
+          rescue SystemCallError => e
+            retry if backoff?(retry_count: retry_count += 1, reason: e.class.name)
             return FAILURE
           rescue EOFError
             retry if backoff?(retry_count: retry_count += 1, reason: 'eof_error')


### PR DESCRIPTION
The Net::HTTP client has a few more errors that need to be caught by the OTLP exporter or it will crash if the upstream agent/collector is temporarily unavailable.

You can simulate one of the SystemCallErrors, Errno::ECONNREFUSED by restarting a local OpenTelemetry collector while an app is trying to export spans to it. Without this change the exporter will crash, but with this change the exporter should recover when the collector becomes available again.