### PR TITLE
feat: export to jaeger collectors w/ self-signed certs

### DIFF
--- a/exporter/jaeger/README.md
+++ b/exporter/jaeger/README.md
@@ -75,11 +75,14 @@ The agent exporter can be configured explicitly in code, as shown above, or via 
 
 The collector exporter can be configured explicitly in code, as shown above, or via environment variables. The configuration parameters, environment variables, and defaults are shown below.
 
-| Parameter   | Environment variable            | Default                    |
-| ----------- | ------------------------------- | -------------------------- |
-| `endpoint:` | `OTEL_EXPORTER_JAEGER_ENDPOINT` | `"http://localhost:14268"` |
-| `username:` | `OTEL_EXPORTER_JAEGER_USER`     | `nil`                      |
-| `password:` | `OTEL_EXPORTER_JAEGER_PASSWORD` | `nil`                      |
+| Parameter          | Environment variable                   | Default                    |
+| ------------------ | -------------------------------------- | -------------------------- |
+| `endpoint:`        | `OTEL_EXPORTER_JAEGER_ENDPOINT`        | `"http://localhost:14268"` |
+| `username:`        | `OTEL_EXPORTER_JAEGER_USER`            | `nil`                      |
+| `password:`        | `OTEL_EXPORTER_JAEGER_PASSWORD`        | `nil`                      |
+| `ssl_verify_mode:` | `OTEL_EXPORTER_JAEGER_SSL_VERIFY_MODE` | `OpenSSL::SSL:VERIFY_PEER` |
+
+`ssl_verify_mode:` parameter values should be flags for server certificate verification: `OpenSSL::SSL:VERIFY_PEER` and `OpenSSL::SSL:VERIFY_NONE` are acceptable. These values can also be supplied, as an environment variable, in an integer value format: `1` for `OpenSSL::SSL:VERIFY_PEER` and `0` for `OpenSSL::SSL:VERIFY_NONE`.  Please see [the Net::HTTP docs](https://ruby-doc.org/stdlib-2.5.1/libdoc/net/http/rdoc/Net/HTTP.html#verify_mode) for more information.
 
 ## How can I get involved?
 

--- a/exporter/jaeger/README.md
+++ b/exporter/jaeger/README.md
@@ -75,14 +75,15 @@ The agent exporter can be configured explicitly in code, as shown above, or via 
 
 The collector exporter can be configured explicitly in code, as shown above, or via environment variables. The configuration parameters, environment variables, and defaults are shown below.
 
-| Parameter          | Environment variable                   | Default                    |
-| ------------------ | -------------------------------------- | -------------------------- |
-| `endpoint:`        | `OTEL_EXPORTER_JAEGER_ENDPOINT`        | `"http://localhost:14268"` |
-| `username:`        | `OTEL_EXPORTER_JAEGER_USER`            | `nil`                      |
-| `password:`        | `OTEL_EXPORTER_JAEGER_PASSWORD`        | `nil`                      |
-| `ssl_verify_mode:` | `OTEL_RUBY_EXPORTER_JAEGER_SSL_VERIFY_MODE` | `OpenSSL::SSL:VERIFY_PEER` |
+| Parameter          | Environment variable                           | Default                    |
+| ------------------ | ---------------------------------------------- | -------------------------- |
+| `endpoint:`        | `OTEL_EXPORTER_JAEGER_ENDPOINT`                | `"http://localhost:14268"` |
+| `username:`        | `OTEL_EXPORTER_JAEGER_USER`                    | `nil`                      |
+| `password:`        | `OTEL_EXPORTER_JAEGER_PASSWORD`                | `nil`                      |
+| `ssl_verify_mode:` | `OTEL_RUBY_EXPORTER_JAEGER_SSL_VERIFY_PEER` or | `OpenSSL::SSL:VERIFY_PEER` |
+|                    | `OTEL_RUBY_EXPORTER_JAEGER_SSL_VERIFY_NONE`    |                            |
 
-`ssl_verify_mode:` parameter values should be flags for server certificate verification: `OpenSSL::SSL:VERIFY_PEER` and `OpenSSL::SSL:VERIFY_NONE` are acceptable. These values can also be supplied, as an environment variable, in an integer value format: `1` for `OpenSSL::SSL:VERIFY_PEER` and `0` for `OpenSSL::SSL:VERIFY_NONE`.  Please see [the Net::HTTP docs](https://ruby-doc.org/stdlib-2.5.1/libdoc/net/http/rdoc/Net/HTTP.html#verify_mode) for more information.
+`ssl_verify_mode:` parameter values should be flags for server certificate verification: `OpenSSL::SSL:VERIFY_PEER` and `OpenSSL::SSL:VERIFY_NONE` are acceptable. These values can also be set using the appropriately named environment variables as shown where `VERIFY_PEER` will take precedence over `VERIFY_NONE`.  Please see [the Net::HTTP docs](https://ruby-doc.org/stdlib-2.5.1/libdoc/net/http/rdoc/Net/HTTP.html#verify_mode) for more information about these flags.
 
 ## How can I get involved?
 

--- a/exporter/jaeger/README.md
+++ b/exporter/jaeger/README.md
@@ -80,7 +80,7 @@ The collector exporter can be configured explicitly in code, as shown above, or 
 | `endpoint:`        | `OTEL_EXPORTER_JAEGER_ENDPOINT`        | `"http://localhost:14268"` |
 | `username:`        | `OTEL_EXPORTER_JAEGER_USER`            | `nil`                      |
 | `password:`        | `OTEL_EXPORTER_JAEGER_PASSWORD`        | `nil`                      |
-| `ssl_verify_mode:` | `OTEL_EXPORTER_JAEGER_SSL_VERIFY_MODE` | `OpenSSL::SSL:VERIFY_PEER` |
+| `ssl_verify_mode:` | `OTEL_RUBY_EXPORTER_JAEGER_SSL_VERIFY_MODE` | `OpenSSL::SSL:VERIFY_PEER` |
 
 `ssl_verify_mode:` parameter values should be flags for server certificate verification: `OpenSSL::SSL:VERIFY_PEER` and `OpenSSL::SSL:VERIFY_NONE` are acceptable. These values can also be supplied, as an environment variable, in an integer value format: `1` for `OpenSSL::SSL:VERIFY_PEER` and `0` for `OpenSSL::SSL:VERIFY_NONE`.  Please see [the Net::HTTP docs](https://ruby-doc.org/stdlib-2.5.1/libdoc/net/http/rdoc/Net/HTTP.html#verify_mode) for more information.
 

--- a/exporter/jaeger/lib/opentelemetry/exporter/jaeger/collector_exporter.rb
+++ b/exporter/jaeger/lib/opentelemetry/exporter/jaeger/collector_exporter.rb
@@ -18,7 +18,7 @@ module OpenTelemetry
         def initialize(endpoint: ENV.fetch('OTEL_EXPORTER_JAEGER_ENDPOINT', 'http://localhost:14268/api/traces'),
                        username: ENV['OTEL_EXPORTER_JAEGER_USER'],
                        password: ENV['OTEL_EXPORTER_JAEGER_PASSWORD'],
-                       ssl_verify_mode: ENV.fetch('OTEL_EXPORTER_JAEGER_SSL_VERIFY_MODE', OpenSSL::SSL::VERIFY_PEER))
+                       ssl_verify_mode: ENV.fetch('OTEL_RUBY_EXPORTER_JAEGER_SSL_VERIFY_MODE', OpenSSL::SSL::VERIFY_PEER))
           raise ArgumentError, "invalid url for Jaeger::CollectorExporter #{endpoint}" if invalid_url?(endpoint)
           raise ArgumentError, 'username and password should either both be nil or both be set' if username.nil? != password.nil?
 

--- a/exporter/jaeger/lib/opentelemetry/exporter/jaeger/collector_exporter.rb
+++ b/exporter/jaeger/lib/opentelemetry/exporter/jaeger/collector_exporter.rb
@@ -15,10 +15,20 @@ module OpenTelemetry
         FAILURE = OpenTelemetry::SDK::Trace::Export::FAILURE
         private_constant(:SUCCESS, :FAILURE)
 
+        def self.ssl_verify_mode
+          if ENV.key?('OTEL_RUBY_EXPORTER_JAEGER_SSL_VERIFY_PEER')
+            OpenSSL::SSL::VERIFY_PEER
+          elsif ENV.key?('OTEL_RUBY_EXPORTER_JAEGER_SSL_VERIFY_NONE')
+            OpenSSL::SSL::VERIFY_NONE
+          else
+            OpenSSL::SSL::VERIFY_PEER
+          end
+        end
+
         def initialize(endpoint: ENV.fetch('OTEL_EXPORTER_JAEGER_ENDPOINT', 'http://localhost:14268/api/traces'),
                        username: ENV['OTEL_EXPORTER_JAEGER_USER'],
                        password: ENV['OTEL_EXPORTER_JAEGER_PASSWORD'],
-                       ssl_verify_mode: ENV.fetch('OTEL_RUBY_EXPORTER_JAEGER_SSL_VERIFY_MODE', OpenSSL::SSL::VERIFY_PEER))
+                       ssl_verify_mode: CollectorExporter.ssl_verify_mode)
           raise ArgumentError, "invalid url for Jaeger::CollectorExporter #{endpoint}" if invalid_url?(endpoint)
           raise ArgumentError, 'username and password should either both be nil or both be set' if username.nil? != password.nil?
 

--- a/exporter/jaeger/lib/opentelemetry/exporter/jaeger/collector_exporter.rb
+++ b/exporter/jaeger/lib/opentelemetry/exporter/jaeger/collector_exporter.rb
@@ -17,11 +17,13 @@ module OpenTelemetry
 
         def initialize(endpoint: ENV.fetch('OTEL_EXPORTER_JAEGER_ENDPOINT', 'http://localhost:14268/api/traces'),
                        username: ENV['OTEL_EXPORTER_JAEGER_USER'],
-                       password: ENV['OTEL_EXPORTER_JAEGER_PASSWORD'])
+                       password: ENV['OTEL_EXPORTER_JAEGER_PASSWORD'],
+                       ssl_verify_mode: ENV.fetch('OTEL_EXPORTER_JAEGER_SSL_VERIFY_MODE', OpenSSL::SSL::VERIFY_PEER))
           raise ArgumentError, "invalid url for Jaeger::CollectorExporter #{endpoint}" if invalid_url?(endpoint)
           raise ArgumentError, 'username and password should either both be nil or both be set' if username.nil? != password.nil?
 
-          @transport = ::Thrift::HTTPClientTransport.new(endpoint)
+          transport_opts = { ssl_verify_mode: Integer(ssl_verify_mode) }
+          @transport = ::Thrift::HTTPClientTransport.new(endpoint, transport_opts)
           unless username.nil? || password.nil?
             authorization = Base64.strict_encode64("#{username}:#{password}")
             auth_header = { 'Authorization': "Basic #{authorization}" }

--- a/exporter/jaeger/test/opentelemetry/exporters/jaeger/collector_exporter_test.rb
+++ b/exporter/jaeger/test/opentelemetry/exporters/jaeger/collector_exporter_test.rb
@@ -19,6 +19,7 @@ describe OpenTelemetry::Exporter::Jaeger::CollectorExporter do
       _(headers).wont_include 'Authorization'
       _(url.host).must_equal 'localhost'
       _(url.port).must_equal 14_268
+      _(transport.instance_variable_get(:@ssl_verify_mode)).must_equal OpenSSL::SSL::VERIFY_PEER
     end
 
     it 'refuses an invalid endpoint' do
@@ -46,10 +47,20 @@ describe OpenTelemetry::Exporter::Jaeger::CollectorExporter do
       _(headers[:Authorization]).must_equal "Basic #{Base64.strict_encode64('foo:bar')}"
     end
 
+    it 'refuses an ssl_verify_mode that cannot be converted to an integer' do
+      assert_raises ArgumentError do
+        OpenTelemetry::Exporter::Jaeger::CollectorExporter.new(ssl_verify_mode: 'foo')
+      end
+      assert_raises TypeError do
+        OpenTelemetry::Exporter::Jaeger::CollectorExporter.new(ssl_verify_mode: nil)
+      end
+    end
+
     it 'sets parameters from the environment' do
       exp = with_env('OTEL_EXPORTER_JAEGER_ENDPOINT' => 'http://127.0.0.1:1234',
                      'OTEL_EXPORTER_JAEGER_USER' => 'foo',
-                     'OTEL_EXPORTER_JAEGER_PASSWORD' => 'bar') do
+                     'OTEL_EXPORTER_JAEGER_PASSWORD' => 'bar',
+                     'OTEL_EXPORTER_JAEGER_SSL_VERIFY_MODE' => '0') do
         OpenTelemetry::Exporter::Jaeger::CollectorExporter.new
       end
       transport = exp.instance_variable_get(:@transport)
@@ -59,15 +70,18 @@ describe OpenTelemetry::Exporter::Jaeger::CollectorExporter do
       _(headers[:Authorization]).must_equal "Basic #{Base64.strict_encode64('foo:bar')}"
       _(url.host).must_equal '127.0.0.1'
       _(url.port).must_equal 1_234
+      _(transport.instance_variable_get(:@ssl_verify_mode)).must_equal OpenSSL::SSL::VERIFY_NONE
     end
 
     it 'prefers explicit parameters rather than the environment' do
       exp = with_env('OTEL_EXPORTER_JAEGER_ENDPOINT' => 'http://127.0.0.1:1234',
                      'OTEL_EXPORTER_JAEGER_USER' => 'foo',
-                     'OTEL_EXPORTER_JAEGER_PASSWORD' => 'bar') do
+                     'OTEL_EXPORTER_JAEGER_PASSWORD' => 'bar',
+                     'OTEL_EXPORTER_JAEGER_SSL_VERIFY_MODE' => '1') do
         OpenTelemetry::Exporter::Jaeger::CollectorExporter.new(endpoint: 'http://192.168.0.1:4321',
                                                                username: 'bar',
-                                                               password: 'baz')
+                                                               password: 'baz',
+                                                               ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE)
       end
       transport = exp.instance_variable_get(:@transport)
       headers = transport.instance_variable_get(:@headers)
@@ -76,6 +90,7 @@ describe OpenTelemetry::Exporter::Jaeger::CollectorExporter do
       _(headers[:Authorization]).must_equal "Basic #{Base64.strict_encode64('bar:baz')}"
       _(url.host).must_equal '192.168.0.1'
       _(url.port).must_equal 4_321
+      _(transport.instance_variable_get(:@ssl_verify_mode)).must_equal OpenSSL::SSL::VERIFY_NONE
     end
   end
 

--- a/exporter/jaeger/test/opentelemetry/exporters/jaeger/collector_exporter_test.rb
+++ b/exporter/jaeger/test/opentelemetry/exporters/jaeger/collector_exporter_test.rb
@@ -60,7 +60,7 @@ describe OpenTelemetry::Exporter::Jaeger::CollectorExporter do
       exp = with_env('OTEL_EXPORTER_JAEGER_ENDPOINT' => 'http://127.0.0.1:1234',
                      'OTEL_EXPORTER_JAEGER_USER' => 'foo',
                      'OTEL_EXPORTER_JAEGER_PASSWORD' => 'bar',
-                     'OTEL_EXPORTER_JAEGER_SSL_VERIFY_MODE' => '0') do
+                     'OTEL_RUBY_EXPORTER_JAEGER_SSL_VERIFY_MODE' => '0') do
         OpenTelemetry::Exporter::Jaeger::CollectorExporter.new
       end
       transport = exp.instance_variable_get(:@transport)
@@ -77,7 +77,7 @@ describe OpenTelemetry::Exporter::Jaeger::CollectorExporter do
       exp = with_env('OTEL_EXPORTER_JAEGER_ENDPOINT' => 'http://127.0.0.1:1234',
                      'OTEL_EXPORTER_JAEGER_USER' => 'foo',
                      'OTEL_EXPORTER_JAEGER_PASSWORD' => 'bar',
-                     'OTEL_EXPORTER_JAEGER_SSL_VERIFY_MODE' => '1') do
+                     'OTEL_RUBY_EXPORTER_JAEGER_SSL_VERIFY_MODE' => '1') do
         OpenTelemetry::Exporter::Jaeger::CollectorExporter.new(endpoint: 'http://192.168.0.1:4321',
                                                                username: 'bar',
                                                                password: 'baz',


### PR DESCRIPTION
This change covers adding configuration to the Jaeger `CollectorExporter` to support exporting to Collectors that use self-signed certificates or any certificate chain that can't be verified by Ruby's openssl implementation.

It works by passing the configuration parameter onto the `Jaeger::HTTPClientTransport` class.

A similar implementation could be added for the other HTTP based exporters.

I'm a bit unsure about passing the verify mode in as an envvar in its current form, so I'm keen for feedback on this. I believe this is the most correct approach as the flag are meant to be combined together using union operations (e.g. `VERIFY_PEER | VERIFY_FAIL_IF_NO_PEER_CERT`). However, this might not be obvious and I've not been able to find a reliable reference for this.