### PR TITLE
Fix: Nil value for db.name attribute

### DIFF
--- a/instrumentation/mysql2/CHANGELOG.md
+++ b/instrumentation/mysql2/CHANGELOG.md
@@ -1,18 +1,22 @@
 # Release History: opentelemetry-instrumentation-mysql2
 
+### Unreleased
+
+* Fix: Nil value for db.name attribute #744
+
 ### v0.17.0 / 2021-04-22
 
 * (No significant changes)
 
 ### v0.16.0 / 2021-03-17
 
-* FIXED: Update DB semantic conventions 
-* FIXED: Example scripts now reference local common lib 
+* FIXED: Update DB semantic conventions
+* FIXED: Example scripts now reference local common lib
 * ADDED: Configurable obfuscation of sql in mysql2 instrumentation to avoid logging sensitive data
 
 ### v0.15.0 / 2021-02-18
 
-* ADDED: Add instrumentation config validation 
+* ADDED: Add instrumentation config validation
 
 ### v0.14.0 / 2021-02-03
 
@@ -28,12 +32,12 @@
 
 ### v0.11.0 / 2020-12-11
 
-* ADDED: Add peer service config to mysql 
-* FIXED: Copyright comments to not reference year 
+* ADDED: Add peer service config to mysql
+* FIXED: Copyright comments to not reference year
 
 ### v0.10.1 / 2020-12-09
 
-* FIXED: Semantic conventions db.type -> db.system 
+* FIXED: Semantic conventions db.type -> db.system
 
 ### v0.10.0 / 2020-12-03
 
@@ -41,19 +45,19 @@
 
 ### v0.9.0 / 2020-11-27
 
-* BREAKING CHANGE: Add timeout for force_flush and shutdown 
+* BREAKING CHANGE: Add timeout for force_flush and shutdown
 
-* ADDED: Add timeout for force_flush and shutdown 
+* ADDED: Add timeout for force_flush and shutdown
 
 ### v0.8.0 / 2020-10-27
 
-* BREAKING CHANGE: Remove 'canonical' from status codes 
+* BREAKING CHANGE: Remove 'canonical' from status codes
 
-* FIXED: Remove 'canonical' from status codes 
+* FIXED: Remove 'canonical' from status codes
 
 ### v0.7.0 / 2020-10-07
 
-* DOCS: Standardize toplevel docs structure and readme 
+* DOCS: Standardize toplevel docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 

--- a/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
+++ b/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
@@ -119,10 +119,10 @@ module OpenTelemetry
 
             attributes = {
               'db.system' => 'mysql',
-              'db.name' => database_name,
               'net.peer.name' => host,
               'net.peer.port' => port
             }
+            attributes['db.name'] = database_name if database_name
             attributes['peer.service'] = config[:peer_service] if config[:peer_service]
             attributes
           end


### PR DESCRIPTION
One of our users reported some log spam during migrations on their application.

It looks like we're expecting a `db.name` to be present when there might not be one available.

```
E, [2021-05-05T15:02:17.437321 #55630] ERROR -- : OpenTelemetry error: invalid span attribute value type NilClass for key 'db.name' on span 'set names'
E, [2021-05-05T15:02:17.440246 #55630] ERROR -- : OpenTelemetry error: invalid span attribute value type NilClass for key 'db.name' on span 'create database'
```