### PR TITLE
fix: Mongodb test asserting error message

### DIFF
--- a/instrumentation/mongo/CHANGELOG.md
+++ b/instrumentation/mongo/CHANGELOG.md
@@ -1,15 +1,19 @@
 # Release History: opentelemetry-instrumentation-mongo
 
+### Unreleased
+
+* FIXED: Mongodb test failing on error message assertion
+
 ### v0.17.0 / 2021-04-22
 
-* ADDED: Mongo instrumentation accepts peer service config attribute. 
-* FIXED: Fix Mongo instrumentation example. 
-* FIXED: Refactor propagators to add #fields 
+* ADDED: Mongo instrumentation accepts peer service config attribute.
+* FIXED: Fix Mongo instrumentation example.
+* FIXED: Refactor propagators to add #fields
 
 ### v0.16.0 / 2021-03-17
 
-* FIXED: Example scripts now reference local common lib 
-* DOCS: Replace Gitter with GitHub Discussions 
+* FIXED: Example scripts now reference local common lib
+* DOCS: Replace Gitter with GitHub Discussions
 
 ### v0.15.0 / 2021-02-18
 
@@ -17,13 +21,13 @@
 
 ### v0.14.0 / 2021-02-03
 
-* BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators 
+* BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
 
-* ADDED: Replace getter and setter callables and remove rack specific propagators 
+* ADDED: Replace getter and setter callables and remove rack specific propagators
 
 ### v0.13.0 / 2021-01-29
 
-* FIXED: Mongo Instrumenter: Do not send nil attributes 
+* FIXED: Mongo Instrumenter: Do not send nil attributes
 
 ### v0.12.0 / 2020-12-24
 
@@ -31,7 +35,7 @@
 
 ### v0.11.0 / 2020-12-11
 
-* FIXED: Copyright comments to not reference year 
+* FIXED: Copyright comments to not reference year
 
 ### v0.10.0 / 2020-12-03
 

--- a/instrumentation/mongo/test/opentelemetry/instrumentation/mongo/subscriber_test.rb
+++ b/instrumentation/mongo/test/opentelemetry/instrumentation/mongo/subscriber_test.rb
@@ -336,10 +336,12 @@ describe OpenTelemetry::Instrumentation::Mongo::Subscriber do
   describe 'with LDAP/SASL authentication' do
     let(:client) { Mongo::Client.new(["#{TestHelper.host}:#{TestHelper.port}"], client_options) }
     let(:client_options) do
-      { database: TestHelper.database,
+      {
+        database: TestHelper.database,
         auth_mech: :plain,
         user: 'plain_user',
-        password: 'plain_pass' }
+        password: 'plain_pass'
+      }
     end
 
     describe 'which fails' do
@@ -357,7 +359,7 @@ describe OpenTelemetry::Instrumentation::Mongo::Subscriber do
         _(span.events[0].name).must_equal 'exception'
         _(span.events[0].timestamp).must_be_kind_of Integer
         _(span.events[0].attributes['exception.type']).must_equal 'CommandFailed'
-        _(span.events[0].attributes['exception.message']).must_match(/mechanism.+PLAIN.+\(2\)/)
+        _(span.events[0].attributes['exception.message']).must_match(/mechanism.+PLAIN./)
       end
     end
   end


### PR DESCRIPTION

>  1) Failure:
OpenTelemetry::Instrumentation::Mongo::Subscriber::with LDAP/SASL authentication::which fails#test_0001_produces spans for command and authentication [/__w/opentelemetry-ruby/opentelemetry-ruby/instrumentation/mongo/test/opentelemetry/instrumentation/mongo/subscriber_test.rb:360]:
Expected /mechanism.+PLAIN.+\(2\)/ to match "Received authentication for mechanism PLAIN which is unknown or not enabled (334)".
>
>37 runs, 136 assertions, 1 failures, 0 errors, 0 skips
W, [2021-05-11T02:20:55.694142 #3731]  WARN -- : MONGODB | Failed to authenticate to mongodb:27017: Mongo::Auth::Unauthorized: User plain_user (mechanism: plain) is not authorized to access otel_test (auth source: otel_test, used mechanism: PLAIN, used server: mongodb:27017 (STANDALONE)): Received authentication for mechanism PLAIN which is unknown or not enabled (334: MechanismUnavailable)
rake aborted!
