### PR TITLE
Remove http status text attribute

### DIFF
--- a/examples/http/client.rb
+++ b/examples/http/client.rb
@@ -44,5 +44,4 @@ tracer.in_span(
 
   span.set_attribute('http.url', response.env.url.to_s)
   span.set_attribute('http.status_code', response.status)
-  span.set_attribute('http.status_text', response.reason_phrase)
 end

--- a/instrumentation/excon/CHANGELOG.md
+++ b/instrumentation/excon/CHANGELOG.md
@@ -1,14 +1,18 @@
 # Release History: opentelemetry-instrumentation-excon
 
+### Unreleased
+
+* FIXED: Removed http.status_text attribute #750
+
 ### v0.17.0 / 2021-04-22
 
-* ADDED: Excon instrumentation accepts peer service config attribute. 
-* FIXED: Refactor propagators to add #fields 
+* ADDED: Excon instrumentation accepts peer service config attribute.
+* FIXED: Refactor propagators to add #fields
 
 ### v0.16.0 / 2021-03-17
 
-* FIXED: Example scripts now reference local common lib 
-* DOCS: Replace Gitter with GitHub Discussions 
+* FIXED: Example scripts now reference local common lib
+* DOCS: Replace Gitter with GitHub Discussions
 
 ### v0.15.0 / 2021-02-18
 
@@ -16,9 +20,9 @@
 
 ### v0.14.0 / 2021-02-03
 
-* BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators 
+* BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
 
-* ADDED: Replace getter and setter callables and remove rack specific propagators 
+* ADDED: Replace getter and setter callables and remove rack specific propagators
 
 ### v0.13.0 / 2021-01-29
 
@@ -30,7 +34,7 @@
 
 ### v0.11.0 / 2020-12-11
 
-* FIXED: Copyright comments to not reference year 
+* FIXED: Copyright comments to not reference year
 
 ### v0.10.0 / 2020-12-03
 
@@ -38,21 +42,21 @@
 
 ### v0.9.0 / 2020-11-27
 
-* BREAKING CHANGE: Add timeout for force_flush and shutdown 
+* BREAKING CHANGE: Add timeout for force_flush and shutdown
 
-* ADDED: Add timeout for force_flush and shutdown 
+* ADDED: Add timeout for force_flush and shutdown
 
 ### v0.8.0 / 2020-10-27
 
-* BREAKING CHANGE: Move context/span methods to Trace module 
-* BREAKING CHANGE: Remove 'canonical' from status codes 
+* BREAKING CHANGE: Move context/span methods to Trace module
+* BREAKING CHANGE: Remove 'canonical' from status codes
 
-* FIXED: Move context/span methods to Trace module 
-* FIXED: Remove 'canonical' from status codes 
+* FIXED: Move context/span methods to Trace module
+* FIXED: Remove 'canonical' from status codes
 
 ### v0.7.0 / 2020-10-07
 
-* DOCS: Standardize toplevel docs structure and readme 
+* DOCS: Standardize toplevel docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 

--- a/instrumentation/excon/lib/opentelemetry/instrumentation/excon/middlewares/tracer_middleware.rb
+++ b/instrumentation/excon/lib/opentelemetry/instrumentation/excon/middlewares/tracer_middleware.rb
@@ -79,7 +79,6 @@ module OpenTelemetry
                 if datum.key?(:response)
                   response = datum[:response]
                   span.set_attribute('http.status_code', response[:status])
-                  span.set_attribute('http.status_text', response[:reason_phrase])
                   span.status = OpenTelemetry::Trace::Status.http_to_status(
                     response[:status]
                   )

--- a/instrumentation/faraday/CHANGELOG.md
+++ b/instrumentation/faraday/CHANGELOG.md
@@ -1,25 +1,29 @@
 # Release History: opentelemetry-instrumentation-faraday
 
+### Unreleased
+
+* FIXED: Removed http.status_text attribute #750
+
 ### v0.17.0 / 2021-04-22
 
-* FIXED: Fix Faraday gem dependencies. 
-* FIXED: Refactor propagators to add #fields 
+* FIXED: Fix Faraday gem dependencies.
+* FIXED: Refactor propagators to add #fields
 
 ### v0.16.0 / 2021-03-17
 
-* FIXED: Remove passwords from http.url 
-* FIXED: Example scripts now reference local common lib 
-* DOCS: Replace Gitter with GitHub Discussions 
+* FIXED: Remove passwords from http.url
+* FIXED: Example scripts now reference local common lib
+* DOCS: Replace Gitter with GitHub Discussions
 
 ### v0.15.0 / 2021-02-18
 
-* FIXED: Include http.status_text only if reason_phrase is in the response 
+* FIXED: Include http.status_text only if reason_phrase is in the response
 
 ### v0.14.0 / 2021-02-03
 
-* BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators 
+* BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
 
-* ADDED: Replace getter and setter callables and remove rack specific propagators 
+* ADDED: Replace getter and setter callables and remove rack specific propagators
 
 ### v0.13.0 / 2021-01-29
 
@@ -31,7 +35,7 @@
 
 ### v0.11.0 / 2020-12-11
 
-* FIXED: Copyright comments to not reference year 
+* FIXED: Copyright comments to not reference year
 
 ### v0.10.0 / 2020-12-03
 
@@ -39,9 +43,9 @@
 
 ### v0.9.0 / 2020-11-27
 
-* BREAKING CHANGE: Add timeout for force_flush and shutdown 
+* BREAKING CHANGE: Add timeout for force_flush and shutdown
 
-* ADDED: Add timeout for force_flush and shutdown 
+* ADDED: Add timeout for force_flush and shutdown
 
 ### v0.8.0 / 2020-10-27
 
@@ -49,8 +53,8 @@
 
 ### v0.7.0 / 2020-10-07
 
-* DOCS: Faraday documentation 
-* DOCS: Standardize toplevel docs structure and readme 
+* DOCS: Faraday documentation
+* DOCS: Standardize toplevel docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 

--- a/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
+++ b/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
@@ -58,7 +58,6 @@ module OpenTelemetry
 
           def trace_response(span, response)
             span.set_attribute('http.status_code', response.status)
-            span.set_attribute('http.status_text', response.reason_phrase) if response.reason_phrase
             span.status = OpenTelemetry::Trace::Status.http_to_status(
               response.status
             )

--- a/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
+++ b/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
@@ -79,13 +79,6 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
       )
     end
 
-    it 'sets the reason phrase' do
-      stub_request(:any, 'example.com').to_return(status: [500, 'Internal Server Error'])
-      ::Faraday.new('http://example.com').get('/')
-
-      _(span.attributes['http.status_text']).must_equal 'Internal Server Error'
-    end
-
     it 'merges http client attributes' do
       client_context_attrs = {
         'test.attribute' => 'test.value', 'http.method' => 'OVERRIDE'

--- a/instrumentation/rack/CHANGELOG.md
+++ b/instrumentation/rack/CHANGELOG.md
@@ -1,32 +1,36 @@
 # Release History: opentelemetry-instrumentation-rack
 
+### Unreleased
+
+* FIXED: Removed http.status_text attribute #750
+
 ### v0.17.0 / 2021-04-22
 
 * (No significant changes)
 
 ### v0.16.0 / 2021-03-17
 
-* BREAKING CHANGE: Pass env to url quantization rack config to allow more flexibility 
+* BREAKING CHANGE: Pass env to url quantization rack config to allow more flexibility
 
-* ADDED: Pass env to url quantization rack config to allow more flexibility 
-* ADDED: Add rack instrumentation config option to accept callable to filter requests to trace 
-* FIXED: Example scripts now reference local common lib 
-* DOCS: Replace Gitter with GitHub Discussions 
+* ADDED: Pass env to url quantization rack config to allow more flexibility
+* ADDED: Add rack instrumentation config option to accept callable to filter requests to trace
+* FIXED: Example scripts now reference local common lib
+* DOCS: Replace Gitter with GitHub Discussions
 
 ### v0.15.0 / 2021-02-18
 
-* ADDED: Add instrumentation config validation 
+* ADDED: Add instrumentation config validation
 
 ### v0.14.0 / 2021-02-03
 
-* BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators 
+* BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
 
-* ADDED: Replace getter and setter callables and remove rack specific propagators 
-* ADDED: Add untraced endpoints config to rack middleware 
+* ADDED: Replace getter and setter callables and remove rack specific propagators
+* ADDED: Add untraced endpoints config to rack middleware
 
 ### v0.13.0 / 2021-01-29
 
-* FIXED: Only include user agent when present 
+* FIXED: Only include user agent when present
 
 ### v0.12.0 / 2020-12-24
 
@@ -34,11 +38,11 @@
 
 ### v0.11.0 / 2020-12-11
 
-* FIXED: Copyright comments to not reference year 
+* FIXED: Copyright comments to not reference year
 
 ### v0.10.1 / 2020-12-09
 
-* FIXED: Rack current_span 
+* FIXED: Rack current_span
 
 ### v0.10.0 / 2020-12-03
 
@@ -46,24 +50,24 @@
 
 ### v0.9.0 / 2020-11-27
 
-* BREAKING CHANGE: Add timeout for force_flush and shutdown 
+* BREAKING CHANGE: Add timeout for force_flush and shutdown
 
-* ADDED: Instrument rails 
-* ADDED: Add timeout for force_flush and shutdown 
+* ADDED: Instrument rails
+* ADDED: Add timeout for force_flush and shutdown
 
 ### v0.8.0 / 2020-10-27
 
-* BREAKING CHANGE: Move context/span methods to Trace module 
-* BREAKING CHANGE: Remove 'canonical' from status codes 
+* BREAKING CHANGE: Move context/span methods to Trace module
+* BREAKING CHANGE: Remove 'canonical' from status codes
 
-* FIXED: Move context/span methods to Trace module 
-* FIXED: Remove 'canonical' from status codes 
+* FIXED: Move context/span methods to Trace module
+* FIXED: Remove 'canonical' from status codes
 
 ### v0.7.0 / 2020-10-07
 
-* FIXED: Remove superfluous file from Rack gem 
-* DOCS: Added README for Rack Instrumentation 
-* DOCS: Standardize toplevel docs structure and readme 
+* FIXED: Remove superfluous file from Rack gem
+* DOCS: Added README for Rack Instrumentation
+* DOCS: Standardize toplevel docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 

--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
@@ -159,7 +159,6 @@ module OpenTelemetry
             # NOTE: if data is available, it would be good to do this:
             # set_attribute('http.route', ...
             # e.g., "/users/:userID?
-            span.set_attribute('http.status_text', ::Rack::Utils::HTTP_STATUS_CODES[status])
 
             allowed_response_headers(headers).each { |k, v| span.set_attribute(k, v) }
           end

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/tracer_middleware_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/tracer_middleware_test.rb
@@ -60,7 +60,6 @@ describe OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware do
     it 'records attributes' do
       _(first_span.attributes['http.method']).must_equal 'GET'
       _(first_span.attributes['http.status_code']).must_equal 200
-      _(first_span.attributes['http.status_text']).must_equal 'OK'
       _(first_span.attributes['http.target']).must_equal '/'
       _(first_span.status.code).must_equal OpenTelemetry::Trace::Status::OK
       _(first_span.attributes['http.url']).must_be_nil

--- a/instrumentation/restclient/CHANGELOG.md
+++ b/instrumentation/restclient/CHANGELOG.md
@@ -1,15 +1,19 @@
 # Release History: opentelemetry-instrumentation-restclient
 
+### Unreleased
+
+* FIXED: Removed http.status_text attribute #750
+
 ### v0.17.0 / 2021-04-22
 
-* ADDED: RestClient instrumentation accepts peer service config attribute. 
-* FIXED: Refactor propagators to add #fields 
+* ADDED: RestClient instrumentation accepts peer service config attribute.
+* FIXED: Refactor propagators to add #fields
 
 ### v0.16.0 / 2021-03-17
 
-* FIXED: Remove passwords from http.url 
-* FIXED: Example scripts now reference local common lib 
-* DOCS: Replace Gitter with GitHub Discussions 
+* FIXED: Remove passwords from http.url
+* FIXED: Example scripts now reference local common lib
+* DOCS: Replace Gitter with GitHub Discussions
 
 ### v0.15.0 / 2021-02-18
 
@@ -17,9 +21,9 @@
 
 ### v0.14.0 / 2021-02-03
 
-* BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators 
+* BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
 
-* ADDED: Replace getter and setter callables and remove rack specific propagators 
+* ADDED: Replace getter and setter callables and remove rack specific propagators
 
 ### v0.13.0 / 2021-01-29
 
@@ -31,7 +35,7 @@
 
 ### v0.11.0 / 2020-12-11
 
-* FIXED: Copyright comments to not reference year 
+* FIXED: Copyright comments to not reference year
 
 ### v0.10.0 / 2020-12-03
 
@@ -39,19 +43,19 @@
 
 ### v0.9.0 / 2020-11-27
 
-* BREAKING CHANGE: Add timeout for force_flush and shutdown 
+* BREAKING CHANGE: Add timeout for force_flush and shutdown
 
-* ADDED: Add timeout for force_flush and shutdown 
+* ADDED: Add timeout for force_flush and shutdown
 
 ### v0.8.0 / 2020-10-27
 
-* BREAKING CHANGE: Move context/span methods to Trace module 
+* BREAKING CHANGE: Move context/span methods to Trace module
 
-* FIXED: Move context/span methods to Trace module 
+* FIXED: Move context/span methods to Trace module
 
 ### v0.7.0 / 2020-10-07
 
-* DOCS: Standardize toplevel docs structure and readme 
+* DOCS: Standardize toplevel docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 

--- a/instrumentation/restclient/lib/opentelemetry/instrumentation/restclient/patches/request.rb
+++ b/instrumentation/restclient/lib/opentelemetry/instrumentation/restclient/patches/request.rb
@@ -43,7 +43,6 @@ module OpenTelemetry
               # If so, add additional attributes.
               if response.is_a?(::RestClient::Response)
                 span.set_attribute('http.status_code', response.code)
-                span.set_attribute('http.status_text', ::RestClient::STATUSES[response.code])
                 span.status = OpenTelemetry::Trace::Status.http_to_status(
                   response.code
                 )

--- a/instrumentation/sinatra/CHANGELOG.md
+++ b/instrumentation/sinatra/CHANGELOG.md
@@ -1,13 +1,17 @@
 # Release History: opentelemetry-instrumentation-sinatra
 
+### Unreleased
+
+* FIXED: Removed http.status_text attribute #750
+
 ### v0.17.0 / 2021-04-22
 
 * (No significant changes)
 
 ### v0.16.0 / 2021-03-17
 
-* FIXED: Example scripts now reference local common lib 
-* DOCS: Replace Gitter with GitHub Discussions 
+* FIXED: Example scripts now reference local common lib
+* DOCS: Replace Gitter with GitHub Discussions
 
 ### v0.15.0 / 2021-02-18
 
@@ -15,9 +19,9 @@
 
 ### v0.14.0 / 2021-02-03
 
-* BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators 
+* BREAKING CHANGE: Replace getter and setter callables and remove rack specific propagators
 
-* ADDED: Replace getter and setter callables and remove rack specific propagators 
+* ADDED: Replace getter and setter callables and remove rack specific propagators
 
 ### v0.13.0 / 2021-01-29
 
@@ -29,7 +33,7 @@
 
 ### v0.11.0 / 2020-12-11
 
-* FIXED: Copyright comments to not reference year 
+* FIXED: Copyright comments to not reference year
 
 ### v0.10.0 / 2020-12-03
 
@@ -37,24 +41,24 @@
 
 ### v0.9.0 / 2020-11-27
 
-* BREAKING CHANGE: Add timeout for force_flush and shutdown 
+* BREAKING CHANGE: Add timeout for force_flush and shutdown
 
-* ADDED: Add timeout for force_flush and shutdown 
+* ADDED: Add timeout for force_flush and shutdown
 
 ### v0.8.0 / 2020-10-27
 
-* BREAKING CHANGE: Remove 'canonical' from status codes 
+* BREAKING CHANGE: Remove 'canonical' from status codes
 
-* FIXED: Remove 'canonical' from status codes 
+* FIXED: Remove 'canonical' from status codes
 
 ### v0.7.1 / 2020-10-08
 
-* FIXED: Set span name to sinatra.route 
+* FIXED: Set span name to sinatra.route
 
 ### v0.7.0 / 2020-10-07
 
-* FIXED: Default to sinatra.route for span name 
-* DOCS: Standardize toplevel docs structure and readme 
+* FIXED: Default to sinatra.route for span name
+* DOCS: Standardize toplevel docs structure and readme
 
 ### v0.6.0 / 2020-09-10
 

--- a/instrumentation/sinatra/lib/opentelemetry/instrumentation/sinatra/middlewares/tracer_middleware.rb
+++ b/instrumentation/sinatra/lib/opentelemetry/instrumentation/sinatra/middlewares/tracer_middleware.rb
@@ -41,7 +41,6 @@ module OpenTelemetry
             status, _headers, _response_body = resp
 
             span.set_attribute('http.status_code', status)
-            span.set_attribute('http.status_text', ::Rack::Utils::HTTP_STATUS_CODES[status])
             span.set_attribute('http.route', env['sinatra.route'].split.last) if env['sinatra.route']
             span.name = env['sinatra.route'] if env['sinatra.route']
             span.status = OpenTelemetry::Trace::Status.http_to_status(status)

--- a/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_test.rb
+++ b/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_test.rb
@@ -90,7 +90,6 @@ describe OpenTelemetry::Instrumentation::Sinatra do
         'http.method' => 'GET',
         'http.url' => '/endpoint',
         'http.status_code' => 200,
-        'http.status_text' => 'OK',
         'http.route' => '/endpoint'
       )
     end
@@ -118,7 +117,6 @@ describe OpenTelemetry::Instrumentation::Sinatra do
         'http.method' => 'GET',
         'http.url' => '/api/v1/foo/janedoe/',
         'http.status_code' => 200,
-        'http.status_text' => 'OK',
         'http.route' => '/api/v1/foo/:myname/?'
       )
       _(exporter.finished_spans.map(&:name))
@@ -135,7 +133,6 @@ describe OpenTelemetry::Instrumentation::Sinatra do
         'http.method' => 'GET',
         'http.url' => '/missing_example/not_present',
         'http.status_code' => 404,
-        'http.status_text' => 'Not Found'
       )
     end
   end

--- a/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_test.rb
+++ b/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_test.rb
@@ -132,7 +132,7 @@ describe OpenTelemetry::Instrumentation::Sinatra do
       _(exporter.finished_spans.first.attributes).must_equal(
         'http.method' => 'GET',
         'http.url' => '/missing_example/not_present',
-        'http.status_code' => 404,
+        'http.status_code' => 404
       )
     end
   end


### PR DESCRIPTION
The `http.status_text` attribute was removed from the spec and so we should too https://github.com/open-telemetry/opentelemetry-specification/pull/972

Closes: https://github.com/open-telemetry/opentelemetry-ruby/issues/748