### PR TITLE
refactor: simplify redis attribute assignment

### DIFF
--- a/instrumentation/redis/CHANGELOG.md
+++ b/instrumentation/redis/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+refactor: simplify redis attribute assignment [#758](https://github.com/open-telemetry/opentelemetry-ruby/pull/758)
 test: split redis instrumentation test [#754](https://github.com/open-telemetry/opentelemetry-ruby/pull/754)
 
 ### v0.17.0 / 2021-04-22

--- a/instrumentation/redis/lib/opentelemetry/instrumentation/redis/patches/client.rb
+++ b/instrumentation/redis/lib/opentelemetry/instrumentation/redis/patches/client.rb
@@ -10,30 +10,7 @@ module OpenTelemetry
       module Patches
         # Module to prepend to Redis::Client for instrumentation
         module Client
-          def process(commands)
-            reply = nil
-            attributes = client_attributes
-            attributes['db.statement'] = Utils.format_statements(commands)
-            tracer.in_span(
-              Utils.format_span_name(commands),
-              attributes: attributes,
-              kind: :client
-            ) do |s|
-              reply = super(commands)
-              if reply.is_a?(::Redis::CommandError)
-                s.record_exception(reply)
-                s.status = Trace::Status.new(
-                  Trace::Status::ERROR,
-                  description: reply.message
-                )
-              end
-            end
-            reply
-          end
-
-          private
-
-          def client_attributes
+          def process(commands) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
             host = options[:host]
             port = options[:port]
 
@@ -42,10 +19,26 @@ module OpenTelemetry
               'net.peer.name' => host,
               'net.peer.port' => port
             }
+
             attributes['db.redis.database_index'] = options[:db] unless options[:db].zero?
             attributes['peer.service'] = config[:peer_service] if config[:peer_service]
-            attributes.merge(OpenTelemetry::Instrumentation::Redis.attributes)
+            attributes.merge!(OpenTelemetry::Instrumentation::Redis.attributes)
+            attributes['db.statement'] = Utils.format_statements(commands)
+
+            tracer.in_span(Utils.format_span_name(commands), attributes: attributes, kind: :client) do |s|
+              super(commands).tap do |reply|
+                if reply.is_a?(::Redis::CommandError)
+                  s.record_exception(reply)
+                  s.status = Trace::Status.new(
+                    Trace::Status::ERROR,
+                    description: reply.message
+                  )
+                end
+              end
+            end
           end
+
+          private
 
           def tracer
             Redis::Instrumentation.instance.tracer


### PR DESCRIPTION
Splitting out a small cleanup PR prior to pushing up a refactor of the utils code for redis.