### PR TITLE
Updated rack middleware position to zero

### DIFF
--- a/instrumentation/rails/lib/opentelemetry/instrumentation/rails/railtie.rb
+++ b/instrumentation/rails/lib/opentelemetry/instrumentation/rails/railtie.rb
@@ -14,7 +14,7 @@ module OpenTelemetry
         config.before_initialize do |app|
           OpenTelemetry::Instrumentation::Rack::Instrumentation.instance.install({})
 
-          app.middleware.insert_after(
+          app.middleware.insert_before(
             0,
             OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware
           )


### PR DESCRIPTION
PR #699 was opened to place the rack middleware at the very first position. However, it is using `app.middleware.insert_after(0` which has the effect of inserting at the second spot in the chain instead of the first. This updates it to `app.middleware.insert_before(0` to have the originally intended effect