### PR TITLE
Remove the OTLP receiver legacy gRPC port(55680) references

### DIFF
--- a/exporter/otlp/README.md
+++ b/exporter/otlp/README.md
@@ -40,7 +40,7 @@ OpenTelemetry::SDK.configure do |c|
   c.add_span_processor(
     OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
       OpenTelemetry::Exporter::OTLP::Exporter.new(
-        endpoint: 'http://localhost:55680'
+        compression: 'gzip'
       )
     )
   )


### PR DESCRIPTION
**Description:**
The legacy gRPC port(55680) in OTLP Receiver will be disabled in OTel Collector before the collector GA.

This CR replaced all gRPC port occurrences from `55680` to `4317` in this repo.

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector/issues/2565