### PR TITLE
feat: add a SSL verify mode option for the OTLP exporter

### DIFF
--- a/exporter/otlp/README.md
+++ b/exporter/otlp/README.md
@@ -65,6 +65,22 @@ end
 
 For additional examples, see the [examples on github][examples-github].
 
+## How can I configure the Jaeger exporter?
+
+The collector exporter can be configured explicitly in code, as shown above, or via environment variables. The configuration parameters, environment variables, and defaults are shown below.
+
+| Parameter           | Environment variable                         | Default                             |
+| ------------------- | -------------------------------------------- | ----------------------------------- |
+| `endpoint:`         | `OTEL_EXPORTER_OTLP_ENDPOINT`                | `"http://localhost:4317/v1/traces"` |
+| `certificate_file: `| `OTEL_EXPORTER_OTLP_CERTIFICATE`             |                                     |
+| `headers:`          | `OTEL_EXPORTER_OTLP_HEADERS`                 |                                     |
+| `compression:`      | `OTEL_EXPORTER_OTLP_COMPRESSION`             |                                     |
+| `timeout:`          | `OTEL_EXPORTER_OTLP_TIMEOUT`                 | `10`                                |
+| `ssl_verify_mode:`  | `OTEL_RUBY_EXPORTER_OTLP_SSL_VERIFY_PEER` or | `OpenSSL::SSL:VERIFY_PEER`          |
+|                     | `OTEL_RUBY_EXPORTER_OTLP_SSL_VERIFY_NONE`    |                                     |
+
+`ssl_verify_mode:` parameter values should be flags for server certificate verification: `OpenSSL::SSL:VERIFY_PEER` and `OpenSSL::SSL:VERIFY_NONE` are acceptable. These values can also be set using the appropriately named environment variables as shown where `VERIFY_PEER` will take precedence over `VERIFY_NONE`.  Please see [the Net::HTTP docs](https://ruby-doc.org/stdlib-2.5.1/libdoc/net/http/rdoc/Net/HTTP.html#verify_mode) for more information about these flags.
+
 ## How can I get involved?
 
 The `opentelemetry-exporter-otlp` gem source is [on github][repo-github], along with related gems including `opentelemetry-sdk`.

--- a/exporter/otlp/README.md
+++ b/exporter/otlp/README.md
@@ -65,7 +65,7 @@ end
 
 For additional examples, see the [examples on github][examples-github].
 
-## How can I configure the Jaeger exporter?
+## How can I configure the OTLP exporter?
 
 The collector exporter can be configured explicitly in code, as shown above, or via environment variables. The configuration parameters, environment variables, and defaults are shown below.
 


### PR DESCRIPTION
This change covers adding configuration to the OTLP Exporter
to support exporting to Collectors that have certificates that can't be
 verified by OpenSSL.

This approach is copied from the similar change for the Jaeger
CollectorExporter:
https://github.com/open-telemetry/opentelemetry-ruby/pull/743