### PR TITLE
feat: consistent HTTP Request attributes with utility

### DIFF
--- a/common/lib/opentelemetry/common/http/request_attributes.rb
+++ b/common/lib/opentelemetry/common/http/request_attributes.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Common
+    module HTTP
+      # RequestAttributes contains common helpers for setting http client attributes in spans
+      module RequestAttributes
+        extend self
+
+        def from_request(request_method, uri, config = {})
+          uri = hide_query_params(uri) if config[:hide_query_params]
+
+          {
+            'http.method' => request_method,
+            'http.scheme' => uri.scheme,
+            'http.target' => uri.request_uri,
+            'http.url' => uri.to_s,
+            'peer.hostname' => uri.host,
+            'peer.port' => uri.port
+          }.compact
+        end
+
+        def hide_query_params(uri)
+          uri.query = '' if uri.query
+
+          uri
+        end
+      end
+    end
+  end
+end

--- a/common/lib/opentelemetry/common/http/request_attributes.rb
+++ b/common/lib/opentelemetry/common/http/request_attributes.rb
@@ -25,6 +25,7 @@ module OpenTelemetry
         end
 
         def hide_query_params(uri)
+          uri = uri.dup
           uri.query = '' if uri.query
 
           uri

--- a/common/test/opentelemetry/common/http/request_attributes_test.rb
+++ b/common/test/opentelemetry/common/http/request_attributes_test.rb
@@ -35,15 +35,23 @@ describe OpenTelemetry::Common::HTTP::RequestAttributes do
     )
   end
 
-  it 'hides query params if config option provided' do
-    attributes = subject.from_request('GET', URI('http://example.com/foo?bar=baz'), hide_query_params: true)
-    _(attributes).must_equal(
-      'http.method' => 'GET',
-      'http.scheme' => 'http',
-      'http.url' => 'http://example.com/foo?',
-      'http.target' => '/foo?',
-      'peer.hostname' => 'example.com',
-      'peer.port' => 80
-    )
+  describe 'if hide_query_params config option provided' do
+    it 'hides query params in attributes' do
+      attributes = subject.from_request('GET', URI('http://example.com/foo?bar=baz'), hide_query_params: true)
+      _(attributes).must_equal(
+        'http.method' => 'GET',
+        'http.scheme' => 'http',
+        'http.url' => 'http://example.com/foo?',
+        'http.target' => '/foo?',
+        'peer.hostname' => 'example.com',
+        'peer.port' => 80
+      )
+    end
+
+    it 'does not alter input uri' do
+      uri = URI('http://example.com/foo?bar=baz')
+      subject.from_request('GET', uri, hide_query_params: true)
+      _(uri.query).must_equal('bar=baz')
+    end
   end
 end

--- a/common/test/opentelemetry/common/http/request_attributes_test.rb
+++ b/common/test/opentelemetry/common/http/request_attributes_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+require 'opentelemetry/common/http/request_attributes'
+
+describe OpenTelemetry::Common::HTTP::RequestAttributes do
+  subject { OpenTelemetry::Common::HTTP::RequestAttributes }
+
+  it 'returns http attributes matching the spec given input' do
+    attributes = subject.from_request('GET', URI('http://example.com/foo?bar=baz'))
+    _(attributes).must_equal(
+      'http.method' => 'GET',
+      'http.scheme' => 'http',
+      'http.url' => 'http://example.com/foo?bar=baz',
+      'http.target' => '/foo?bar=baz',
+      'peer.hostname' => 'example.com',
+      'peer.port' => 80
+    )
+  end
+
+  it 'returns http attributes matching the spec given input' do
+    attributes = subject.from_request('GET', URI('http://example.com/foo?bar=baz'))
+    _(attributes).must_equal(
+      'http.method' => 'GET',
+      'http.scheme' => 'http',
+      'http.url' => 'http://example.com/foo?bar=baz',
+      'http.target' => '/foo?bar=baz',
+      'peer.hostname' => 'example.com',
+      'peer.port' => 80
+    )
+  end
+
+  it 'hides query params if config option provided' do
+    attributes = subject.from_request('GET', URI('http://example.com/foo?bar=baz'), hide_query_params: true)
+    _(attributes).must_equal(
+      'http.method' => 'GET',
+      'http.scheme' => 'http',
+      'http.url' => 'http://example.com/foo?',
+      'http.target' => '/foo?',
+      'peer.hostname' => 'example.com',
+      'peer.port' => 80
+    )
+  end
+end

--- a/instrumentation/faraday/README.md
+++ b/instrumentation/faraday/README.md
@@ -30,6 +30,18 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
+### Configuration options
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::Faraday', {
+    # Query parameters are hidden by default.
+    # To disable, set hide_query_params to false.
+    hide_query_params: true,
+  }
+end
+```
+
 ## Examples
 
 Example usage of faraday can be seen in the `./example/faraday.rb` file [here](https://github.com/open-telemetry/opentelemetry-ruby/blob/main/instrumentation/faraday/example/faraday.rb)

--- a/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/instrumentation.rb
+++ b/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/instrumentation.rb
@@ -21,6 +21,7 @@ module OpenTelemetry
         end
 
         option :peer_service, default: nil, validate: :string
+        option :hide_query_params, default: true, validate: :boolean
 
         private
 

--- a/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
+++ b/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
@@ -19,6 +19,7 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
     ::Faraday.new('http://username:password@example.com') do |builder|
       builder.adapter(:test) do |stub|
         stub.get('/success') { |_| [200, {}, 'OK'] }
+        stub.get('/success?foo=bar') { |_| [200, {}, 'OK'] }
         stub.get('/failure') { |_| [500, {}, 'OK'] }
         stub.get('/not_found') { |_| [404, {}, 'OK'] }
       end
@@ -40,19 +41,29 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
 
   describe 'first span' do
     before do
-      instrumentation.install
+      instrumentation.instance_variable_set(:@installed, false)
+      instrumentation.install(hide_query_params: true)
     end
 
     it 'has http 200 attributes' do
-      response = client.get('/success')
+      response = client.get('/success?foo=bar')
 
       _(span.name).must_equal 'HTTP GET'
       _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.status_code']).must_equal 200
-      _(span.attributes['http.url']).must_equal 'http://example.com/success'
+      _(span.attributes['http.url']).must_equal 'http://example.com/success?'
       _(response.env.request_headers['Traceparent']).must_equal(
         "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
       )
+    end
+
+    it 'does not hide query params when hide_query_params is false' do
+      instrumentation.instance_variable_set(:@installed, false)
+      instrumentation.install(hide_query_params: false)
+
+      client.get('/success?foo=bar')
+
+      _(span.attributes['http.url']).must_equal 'http://example.com/success?foo=bar'
     end
 
     it 'has http.status_code 404' do

--- a/instrumentation/http/README.md
+++ b/instrumentation/http/README.md
@@ -30,6 +30,18 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
+### Configuration options
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::HTTP', {
+    # Query parameters are hidden by default.
+    # To disable, set hide_query_params to false.
+    hide_query_params: true,
+  }
+end
+```
+
 ## Examples
 
 Example usage can be seen in the `./example/trace_demonstration.rb` file [here](https://github.com/open-telemetry/opentelemetry-ruby/blob/main/instrumentation/http/example/trace_demonstration.rb)

--- a/instrumentation/http/lib/opentelemetry/instrumentation/http/instrumentation.rb
+++ b/instrumentation/http/lib/opentelemetry/instrumentation/http/instrumentation.rb
@@ -18,6 +18,8 @@ module OpenTelemetry
           !(defined?(::HTTP) && Gem.loaded_specs['http']).nil?
         end
 
+        option :hide_query_params, default: true, validate: :boolean
+
         def patch
           ::HTTP::Client.prepend(Patches::Client)
           ::HTTP::Connection.prepend(Patches::Connection)

--- a/instrumentation/net_http/README.md
+++ b/instrumentation/net_http/README.md
@@ -30,6 +30,18 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
+### Configuration options
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::Net::HTTP', {
+    # Query parameters are hidden by default.
+    # To disable, set hide_query_params to false.
+    hide_query_params: true,
+  }
+end
+```
+
 ## Example
 
 An example of usage can be seen in [`example/net_http.rb`](https://github.com/open-telemetry/opentelemetry-ruby/blob/main/instrumentation/net_http/example/net_http.rb).

--- a/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/instrumentation.rb
+++ b/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/instrumentation.rb
@@ -20,6 +20,8 @@ module OpenTelemetry
             defined?(::Net::HTTP)
           end
 
+          option :hide_query_params, default: true, validate: :boolean
+
           private
 
           def require_dependencies

--- a/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/patches/instrumentation.rb
+++ b/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/patches/instrumentation.rb
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require 'opentelemetry/common/http/request_attributes'
+
 module OpenTelemetry
   module Instrumentation
     module Net
@@ -18,16 +20,15 @@ module OpenTelemetry
               # Do not trace recursive call for starting the connection
               return super(req, body, &block) unless started?
 
-              attributes = OpenTelemetry::Common::HTTP::ClientContext.attributes
+              uri = uri_from_req(req)
+              method = req.method
+
+              attributes = OpenTelemetry::Common::HTTP::ClientContext.attributes.merge(
+                OpenTelemetry::Common::HTTP::RequestAttributes.from_request(method, uri, config)
+              )
               tracer.in_span(
-                HTTP_METHODS_TO_SPAN_NAMES[req.method],
-                attributes: attributes.merge(
-                  'http.method' => req.method,
-                  'http.scheme' => USE_SSL_TO_SCHEME[use_ssl?],
-                  'http.target' => req.path,
-                  'peer.hostname' => @address,
-                  'peer.port' => @port
-                ),
+                HTTP_METHODS_TO_SPAN_NAMES[method],
+                attributes: attributes,
                 kind: :client
               ) do |span|
                 OpenTelemetry.propagation.inject(req)
@@ -71,6 +72,14 @@ module OpenTelemetry
 
             def tracer
               Net::HTTP::Instrumentation.instance.tracer
+            end
+
+            def config
+              Net::HTTP::Instrumentation.instance.config
+            end
+
+            def uri_from_req(req)
+              req.uri || URI.join("#{USE_SSL_TO_SCHEME[use_ssl?]}://#{@address}:#{@port}", req.path)
             end
           end
         end

--- a/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/instrumentation_test.rb
+++ b/instrumentation/net_http/test/opentelemetry/instrumentation/net/http/instrumentation_test.rb
@@ -24,7 +24,7 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
     @orig_propagation = OpenTelemetry.propagation
     propagator = OpenTelemetry::Trace::Propagation::TraceContext.text_map_propagator
     OpenTelemetry.propagation = propagator
-    instrumentation.install
+    instrumentation.install({})
   end
 
   after do
@@ -40,21 +40,85 @@ describe OpenTelemetry::Instrumentation::Net::HTTP::Instrumentation do
     end
 
     it 'after request with success code' do
-      ::Net::HTTP.get('example.com', '/success')
+      stub_request(:get, 'http://example.com/success?foo=bar').to_return(status: 200)
+      ::Net::HTTP.get('example.com', '/success?foo=bar')
 
       _(exporter.finished_spans.size).must_equal 1
       _(span.name).must_equal 'HTTP GET'
       _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.scheme']).must_equal 'http'
       _(span.attributes['http.status_code']).must_equal 200
-      _(span.attributes['http.target']).must_equal '/success'
+      _(span.attributes['http.target']).must_equal '/success?'
       _(span.attributes['peer.hostname']).must_equal 'example.com'
       _(span.attributes['peer.port']).must_equal 80
       assert_requested(
         :get,
-        'http://example.com/success',
+        'http://example.com/success?foo=bar',
         headers: { 'Traceparent' => "00-#{span.hex_trace_id}-#{span.hex_span_id}-01" }
       )
+    end
+
+    it 'after URI request with success code' do
+      stub_request(:get, 'http://example.com/success?foo=bar').to_return(status: 200)
+      ::Net::HTTP.get(URI('http://example.com/success?foo=bar'))
+
+      _(exporter.finished_spans.size).must_equal 1
+      _(span.name).must_equal 'HTTP GET'
+      _(span.attributes['http.method']).must_equal 'GET'
+      _(span.attributes['http.scheme']).must_equal 'http'
+      _(span.attributes['http.status_code']).must_equal 200
+      _(span.attributes['http.target']).must_equal '/success?'
+      _(span.attributes['peer.hostname']).must_equal 'example.com'
+      _(span.attributes['peer.port']).must_equal 80
+      assert_requested(
+        :get,
+        'http://example.com/success?foo=bar',
+        headers: { 'Traceparent' => "00-#{span.hex_trace_id}-#{span.hex_span_id}-01" }
+      )
+    end
+
+    describe 'with hide_query_params disabled' do
+      before do
+        # Force re-install of instrumentation
+        instrumentation.instance_variable_set(:@installed, false)
+        instrumentation.install(hide_query_params: false)
+      end
+      it 'includes the query params in the target attribute' do
+        stub_request(:get, 'http://example.com/success?foo=bar').to_return(status: 200)
+        ::Net::HTTP.get('example.com', '/success?foo=bar')
+
+        _(exporter.finished_spans.size).must_equal 1
+        _(span.name).must_equal 'HTTP GET'
+        _(span.attributes['http.method']).must_equal 'GET'
+        _(span.attributes['http.scheme']).must_equal 'http'
+        _(span.attributes['http.status_code']).must_equal 200
+        _(span.attributes['http.target']).must_equal '/success?foo=bar'
+        _(span.attributes['peer.hostname']).must_equal 'example.com'
+        _(span.attributes['peer.port']).must_equal 80
+        assert_requested(
+          :get,
+          'http://example.com/success?foo=bar',
+          headers: { 'Traceparent' => "00-#{span.hex_trace_id}-#{span.hex_span_id}-01" }
+        )
+      end
+      it 'includes the query params in the target attribute after URI request' do
+        stub_request(:get, 'http://example.com/success?foo=bar').to_return(status: 200)
+        ::Net::HTTP.get(URI('http://example.com/success?foo=bar'))
+
+        _(exporter.finished_spans.size).must_equal 1
+        _(span.name).must_equal 'HTTP GET'
+        _(span.attributes['http.method']).must_equal 'GET'
+        _(span.attributes['http.scheme']).must_equal 'http'
+        _(span.attributes['http.status_code']).must_equal 200
+        _(span.attributes['http.target']).must_equal '/success?foo=bar'
+        _(span.attributes['peer.hostname']).must_equal 'example.com'
+        _(span.attributes['peer.port']).must_equal 80
+        assert_requested(
+          :get,
+          'http://example.com/success?foo=bar',
+          headers: { 'Traceparent' => "00-#{span.hex_trace_id}-#{span.hex_span_id}-01" }
+        )
+      end
     end
 
     it 'after request with failure code' do


### PR DESCRIPTION
This change introduces a utility that can be used by instrumentation to add consistent attributes for HTTP requests. Currently, HTTP attributes are set inconsistently across clients, which can be a bit of a headache if the services you're tracing have multiple HTTP client dependencies.

The utility also has an option to hide query parameters so that they don't show up in these attributes. Query parameters often hold sensitive information, which some (hopefully all 😅 ) teams may not want to log. I've made this on by default to align other recent changes to handling sensitive information.

I've applied this utility to the `net/http`, `faraday`, and `http` instrumentation, but I'd also want to apply this to all the other http clients in the repository.