### PR TITLE
chore: CI infrastructure updates

### DIFF
--- a/.github/workflows/ci-without-services.yml
+++ b/.github/workflows/ci-without-services.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby' }}
+    strategy:
+      matrix:
+        include:
+          - name: Test MacOS / Ruby 3.0
+            os: macos-latest
+            ruby: "3.0"
+            # mysql2 omitted because it depends on the mysql C library which is not present
+            # redis omitted because it depends on redis-server which is not present
+            flags: >-
+              --include-simple --include-appraisal --omit-services
+              --exclude opentelemetry-instrumentation-mysql2
+              --exclude opentelemetry-instrumentation-redis
+          - name: Test Windows / Ruby 3.0
+            os: windows-latest
+            ruby: "3.0"
+            # ethon omitted because it depends on libcurl which is not present
+            # mysql2 omitted because it depends on the mysql C library which is not present
+            # pg omitted because it depends on the postgres C library which is not present
+            # rails omitted because it depends on tzinfo which is not present
+            # redis omitted because it depends on redis-server which is not present
+            # sidekiq omitted because it depends on redis-server which is not present
+            flags: >-
+              --include-simple --include-appraisal --omit-services
+              --exclude opentelemetry-instrumentation-ethon
+              --exclude opentelemetry-instrumentation-mysql2
+              --exclude opentelemetry-instrumentation-pg
+              --exclude opentelemetry-instrumentation-rails
+              --exclude opentelemetry-instrumentation-redis
+              --exclude opentelemetry-instrumentation-sidekiq
+          - name: Rubocop and build
+            os: ubuntu-latest
+            ruby: "2.7"
+            flags: --include-simple --include-appraisal --no-check-tests --check-rubocop --check-yard --check-build
+      fail-fast: false
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "${{ matrix.ruby }}"
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install tools
+        run: gem install --no-document bundler:2.1.4 toys:0.11.5
+      - name: Run tests
+        run: toys ci ${{ matrix.flags }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,25 +14,30 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: Ruby 2.5
-            container: circleci/ruby:2.5-buster
+          - name: Test Linux / Ruby 2.5
+            os: ubuntu-latest
+            ruby: "2.5"
             flags: --include-simple --include-appraisal
-          - name: Ruby 2.6
-            container: circleci/ruby:2.6-buster
+          - name: Test Linux / Ruby 2.6
+            os: ubuntu-latest
+            ruby: "2.6"
             flags: --include-simple --include-appraisal
-          - name: Ruby 2.7
-            container: circleci/ruby:2.7-buster
-            flags: --include-simple --include-appraisal --check-rubocop --check-yard
-          - name: Ruby 3.0
-            container: circleci/ruby:3.0-buster
-            flags: --include-simple --include-appraisal --exclude opentelemetry-exporter-otlp
-          - name: JRuby
-            container: circleci/jruby:latest
-            flags: --include-simple --exclude opentelemetry-resource_detectors --exclude opentelemetry-exporter-otlp
+          - name: Test Linux / Ruby 2.7
+            os: ubuntu-latest
+            ruby: "2.7"
+            flags: --include-simple --include-appraisal
+          - name: Test Linux / Ruby 3.0
+            os: ubuntu-latest
+            ruby: "3.0"
+            flags: --include-simple --include-appraisal
+          - name: Test Linux / JRuby
+            os: ubuntu-latest
+            ruby: jruby
+            # otlp omitted because it depends on protobuf which does not work on JRuby
+            flags: --include-simple --exclude opentelemetry-exporter-otlp
       fail-fast: false
-    name: Test ${{ matrix.name }} (${{ matrix.flags }})
-    runs-on: ubuntu-latest
-    container: ${{ matrix.container }}
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
     env:
       JRUBY_OPTS: --debug
     services:
@@ -47,10 +52,11 @@ jobs:
         image: confluentinc/cp-kafka:latest
         ports:
           - 9092:9092
+          - 29092:29092
         env:
           KAFKA_BROKER_ID: 1
           KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-          KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+          KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:29092,PLAINTEXT_HOST://localhost:9092
           KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
           KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
           KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
@@ -76,9 +82,6 @@ jobs:
       mysql:
         image: mysql:5.6
         env:
-          TEST_MYSQL_USER: root
-          TEST_MYSQL_ROOT_PASSWORD: root
-          TEST_MYSQ_DB: mysql
           MYSQL_DATABASE: mysql
           MYSQL_ROOT_PASSWORD: root
           MYSQL_PASSWORD: mysql
@@ -98,28 +101,34 @@ jobs:
           - 5432:5432
         options: --health-cmd="pg_isready" --health-interval=5s --health-timeout=2s --health-retries=3
     steps:
-      - name: Setup file system permissions
-        run: sudo chmod -R 777 $GITHUB_WORKSPACE /github /__w/_temp
+      - name: Install Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "${{ matrix.ruby }}"
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install tools
-        run: gem install --no-document bundler:2.1.4 toys:0.11.4
+        run: gem install --no-document bundler:2.1.4 toys:0.11.5
       - name: Run tests
         env:
-          TEST_KAFKA_HOST: kafka
+          TEST_KAFKA_HOST: "127.0.0.1"
           TEST_KAFKA_PORT: 29092
-          TEST_MYSQL_HOST: mysql
+          TEST_MYSQL_HOST: "127.0.0.1"
           TEST_MYSQL_PORT: 3306
+          TEST_MYSQL_USER: mysql
+          TEST_MYSQL_PASSWORD: mysql
           TEST_POSTGRES_PASSWORD: postgres
           TEST_POSTGRES_USER: postgres
-          TEST_POSTGRES_HOST: postgres
+          TEST_POSTGRES_HOST: localhost
           TEST_POSTGRES_PORT: 5432
           TEST_POSTGRES_DB: postgres
-          TEST_MEMCACHED_HOST: memcached
-          TEST_MEMCACHED_PORT: ${{ job.services.memcached.ports['11211'] }}
-          TEST_MONGODB_HOST: mongodb
-          TEST_MONGODB_PORT: ${{ job.services.mongodb.ports['27017'] }}
-          TEST_RABBITMQ_URL: amqp://guest:guest@rabbitmq:${{ job.services.rabbitmq.ports['5672'] }}
-          TEST_REDIS_HOST: redis
-          TEST_REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
+          TEST_MEMCACHED_HOST: localhost
+          TEST_MEMCACHED_PORT: 11211
+          TEST_MONGODB_HOST: localhost
+          TEST_MONGODB_PORT: 27017
+          TEST_RABBITMQ_HOST: localhost
+          TEST_RABBITMQ_PORT: 5672
+          TEST_RABBITMQ_URL: amqp://guest:guest@localhost:5672
+          TEST_REDIS_HOST: localhost
+          TEST_REDIS_PORT: 6379
         run: toys ci ${{ matrix.flags }}

--- a/.toys/ci.rb
+++ b/.toys/ci.rb
@@ -6,6 +6,12 @@ end
 flag :check_yard do
   desc "Include yard checks with tests"
 end
+flag :check_build do
+  desc "Include build checks with tests"
+end
+flag :no_check_tests do
+  desc "Don't run unit tests"
+end
 flag :include_appraisal do
   desc "Run tests on gems that have an appraisal config"
 end
@@ -22,11 +28,15 @@ flag :exclude_gems, "-X NAME", "--exclude NAME" do
   handler :push
   desc "Do not run tests on the given named gem. Can be used multiple times."
 end
+flag :omit_services do
+  desc "Exclude integration tests that require services"
+end
 
-include :exec, e: true
+include :exec
 include :terminal, styled: true
 
 def run
+  @errors = []
   Dir.chdir(context_directory)
   Dir.glob("**/opentelemetry-*.gemspec").sort.each do |gemspec|
     gem_name = File.basename(gemspec, ".gemspec")
@@ -36,6 +46,7 @@ def run
       handle_gem(gem_name, has_appraisal) if test?(gem_name, has_appraisal)
     end
   end
+  final_result
 end
 
 def test?(gem_name, has_appraisal)
@@ -50,22 +61,47 @@ def test?(gem_name, has_appraisal)
       include_simple
     end
   if result
-    puts "Testing #{gem_name} ...", :cyan, :bold
+    puts("Testing #{gem_name} ...", :cyan, :bold)
   else
-    puts "Skipping #{gem_name} ...", :yellow, :bold
+    puts("Skipping #{gem_name} ...", :yellow, :bold)
   end
   result
 end
 
 def handle_gem(gem_name, has_appraisal)
-  exec(["bundle", "install", "--jobs=3", "--retry=3"])
-  if has_appraisal
-    exec(["bundle", "exec", "appraisal", "install"])
-    exec(["bundle", "exec", "appraisal", "rake", "test"])
-  else
-    exec(["bundle", "exec", "rake", "test"])
+  individual_test("#{gem_name}: bundle",
+                  ["bundle", "install", "--jobs=3", "--retry=3"])
+  unless no_check_tests
+    if has_appraisal
+      individual_test("#{gem_name}: appraisal",
+                      ["bundle", "exec", "appraisal", "install"])
+      individual_test("#{gem_name}: test",
+                      ["bundle", "exec", "appraisal", "rake", "test"])
+    else
+      individual_test("#{gem_name}: test", ["bundle", "exec", "rake", "test"])
+    end
   end
-  exec(["bundle", "exec", "rake", "rubocop"]) if check_rubocop
-  exec(["bundle", "exec", "rake", "yard"]) if check_yard
-  exec(["gem", "build", "#{gem_name}.gemspec"])
+  individual_test("#{gem_name}: rubocop",
+                  ["bundle", "exec", "rake", "rubocop"]) if check_rubocop
+  individual_test("#{gem_name}: yard",
+                  ["bundle", "exec", "rake", "yard"]) if check_yard
+  individual_test("#{gem_name}: build",
+                  ["gem", "build", "#{gem_name}.gemspec"]) if check_build
+end
+
+def individual_test(test_name, cmd)
+  puts(test_name, :cyan, :bold)
+  env = {}
+  env["OMIT_SERVICES"] = "1" if omit_services
+  unless exec(cmd, env: env).success?
+    @errors << test_name
+    puts("FAILURE", :red, :bold)
+  end
+end
+
+def final_result
+  exit(0) if @errors.empty?
+  puts("CI Failures:", :red, :bold)
+  @errors.each { |test_name| puts(test_name, :yellow) }
+  exit(1)
 end

--- a/api/test/test_helper.rb
+++ b/api/test/test_helper.rb
@@ -11,4 +11,4 @@ SimpleCov.minimum_coverage 85
 require 'opentelemetry'
 require 'minitest/autorun'
 
-OpenTelemetry.logger = Logger.new('/dev/null')
+OpenTelemetry.logger = Logger.new(File::NULL)

--- a/exporter/otlp/test/test_helper.rb
+++ b/exporter/otlp/test/test_helper.rb
@@ -12,4 +12,4 @@ require 'opentelemetry/exporter/otlp'
 require 'minitest/autorun'
 require 'webmock/minitest'
 
-OpenTelemetry.logger = Logger.new('/dev/null')
+OpenTelemetry.logger = Logger.new(File::NULL)

--- a/instrumentation/base/test/test_helper.rb
+++ b/instrumentation/base/test/test_helper.rb
@@ -11,4 +11,4 @@ SimpleCov.minimum_coverage 85
 require 'opentelemetry/instrumentation'
 require 'minitest/autorun'
 
-OpenTelemetry.logger = Logger.new('/dev/null')
+OpenTelemetry.logger = Logger.new(File::NULL)

--- a/instrumentation/bunny/test/.rubocop.yml
+++ b/instrumentation/bunny/test/.rubocop.yml
@@ -2,3 +2,5 @@ inherit_from: ../.rubocop.yml
 
 Metrics/BlockLength:
   Enabled: false
+Style/MultilineIfModifier:
+  Enabled: false

--- a/instrumentation/bunny/test/opentelemetry/instrumentation/bunny/patches/consumer_test.rb
+++ b/instrumentation/bunny/test/opentelemetry/instrumentation/bunny/patches/consumer_test.rb
@@ -14,7 +14,9 @@ describe OpenTelemetry::Instrumentation::Bunny::Patches::Consumer do
   let(:instrumentation) { OpenTelemetry::Instrumentation::Bunny::Instrumentation.instance }
   let(:exporter) { EXPORTER }
   let(:spans) { exporter.finished_spans }
-  let(:url) { ENV.fetch(' RABBITMQ_URL') { 'amqp://guest:guest@rabbitmq:5672' } }
+  let(:host) { ENV.fetch('TEST_RABBITMQ_HOST') { 'localhost' } }
+  let(:port) { ENV.fetch('TEST_RABBITMQ_PORT') { '5672' } }
+  let(:url) { ENV.fetch('TEST_RABBITMQ_URL') { "amqp://guest:guest@#{host}:#{port}" } }
   let(:bunny) { Bunny.new(url) }
   let(:topic) { "topic-#{SecureRandom.uuid}" }
   let(:channel) { bunny.create_channel }
@@ -69,4 +71,4 @@ describe OpenTelemetry::Instrumentation::Bunny::Patches::Consumer do
     _(linked_span_context.trace_id).must_equal(send_span.trace_id)
     _(linked_span_context.span_id).must_equal(send_span.span_id)
   end
-end
+end unless ENV['OMIT_SERVICES']

--- a/instrumentation/bunny/test/opentelemetry/instrumentation/bunny/patches/queue_test.rb
+++ b/instrumentation/bunny/test/opentelemetry/instrumentation/bunny/patches/queue_test.rb
@@ -15,7 +15,9 @@ describe OpenTelemetry::Instrumentation::Bunny::Patches::Queue do
   let(:exporter) { EXPORTER }
   let(:spans) { exporter.finished_spans }
 
-  let(:url) { ENV.fetch(' RABBITMQ_URL') { 'amqp://guest:guest@rabbitmq:5672' } }
+  let(:host) { ENV.fetch('TEST_RABBITMQ_HOST') { 'localhost' } }
+  let(:port) { ENV.fetch('TEST_RABBITMQ_PORT') { '5672' } }
+  let(:url) { ENV.fetch('TEST_RABBITMQ_URL') { "amqp://guest:guest@#{host}:#{port}" } }
   let(:bunny) { Bunny.new(url) }
   let(:topic) { "topic-#{SecureRandom.uuid}" }
   let(:channel) { bunny.create_channel }
@@ -71,4 +73,4 @@ describe OpenTelemetry::Instrumentation::Bunny::Patches::Queue do
       _(process_span).must_be_nil
     end
   end
-end
+end unless ENV['OMIT_SERVICES']

--- a/instrumentation/dalli/test/.rubocop.yml
+++ b/instrumentation/dalli/test/.rubocop.yml
@@ -2,3 +2,5 @@ inherit_from: ../.rubocop.yml
 
 Metrics/BlockLength:
   Enabled: false
+Style/MultilineIfModifier:
+  Enabled: false

--- a/instrumentation/dalli/test/opentelemetry/instrumentation/dalli/instrumentation_test.rb
+++ b/instrumentation/dalli/test/opentelemetry/instrumentation/dalli/instrumentation_test.rb
@@ -97,4 +97,4 @@ describe OpenTelemetry::Instrumentation::Dalli::Instrumentation do
       _(span_event.attributes['exception.message']).must_equal 'Dalli::NetworkError'
     end
   end
-end
+end unless ENV['OMIT_SERVICES']

--- a/instrumentation/mongo/test/.rubocop.yml
+++ b/instrumentation/mongo/test/.rubocop.yml
@@ -2,3 +2,5 @@ inherit_from: ../.rubocop.yml
 
 Metrics/BlockLength:
   Enabled: false
+Style/MultilineIfModifier:
+  Enabled: false

--- a/instrumentation/mongo/test/opentelemetry/instrumentation/mongo/subscriber_test.rb
+++ b/instrumentation/mongo/test/opentelemetry/instrumentation/mongo/subscriber_test.rb
@@ -363,4 +363,4 @@ describe OpenTelemetry::Instrumentation::Mongo::Subscriber do
       end
     end
   end
-end
+end unless ENV['OMIT_SERVICES']

--- a/instrumentation/mongo/test/opentelemetry/instrumentation/mongo_test.rb
+++ b/instrumentation/mongo/test/opentelemetry/instrumentation/mongo_test.rb
@@ -71,5 +71,5 @@ describe OpenTelemetry::Instrumentation::Mongo do
       client['people'].find(name: 'Steve').first
       _(exporter.finished_spans.size).must_equal 2
     end
-  end
+  end unless ENV['OMIT_SERVICES']
 end

--- a/instrumentation/mysql2/test/.rubocop.yml
+++ b/instrumentation/mysql2/test/.rubocop.yml
@@ -2,3 +2,5 @@ inherit_from: ../.rubocop.yml
 
 Metrics/BlockLength:
   Enabled: false
+Style/MultilineIfModifier:
+  Enabled: false

--- a/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
+++ b/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
@@ -39,7 +39,7 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
         host: host,
         port: port,
         database: database,
-        username: 'root',
+        username: username,
         password: password
       )
     end
@@ -151,5 +151,5 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
         _(span.attributes['net.peer.port']).must_equal port.to_s
       end
     end
-  end
+  end unless ENV['OMIT_SERVICES']
 end

--- a/instrumentation/pg/test/.rubocop.yml
+++ b/instrumentation/pg/test/.rubocop.yml
@@ -2,3 +2,5 @@ inherit_from: ../.rubocop.yml
 
 Metrics/BlockLength:
   Enabled: false
+Style/MultilineIfModifier:
+  Enabled: false

--- a/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
+++ b/instrumentation/pg/test/opentelemetry/instrumentation/pg/instrumentation_test.rb
@@ -239,5 +239,5 @@ describe OpenTelemetry::Instrumentation::PG::Instrumentation do
         _(span.attributes['db.statement']).must_be_nil
       end
     end
-  end
+  end unless ENV['OMIT_SERVICES']
 end

--- a/instrumentation/rails/test/test_helpers/app_config.rb
+++ b/instrumentation/rails/test/test_helpers/app_config.rb
@@ -21,7 +21,7 @@ module AppConfig
     new_app.config.eager_load = false
 
     # Prevent tests from creating log/*.log
-    new_app.config.logger = Logger.new('/dev/null')
+    new_app.config.logger = Logger.new(File::NULL)
 
     case Rails.version
     when /^6\.0/

--- a/instrumentation/redis/test/.rubocop.yml
+++ b/instrumentation/redis/test/.rubocop.yml
@@ -2,3 +2,5 @@ inherit_from: ../.rubocop.yml
 
 Metrics/BlockLength:
   Enabled: false
+Style/MultilineIfModifier:
+  Enabled: false

--- a/instrumentation/redis/test/opentelemetry/instrumentation/redis/patches/client_test.rb
+++ b/instrumentation/redis/test/opentelemetry/instrumentation/redis/patches/client_test.rb
@@ -295,4 +295,4 @@ describe OpenTelemetry::Instrumentation::Redis::Patches::Client do
       end
     end
   end
-end
+end unless ENV['OMIT_SERVICES']

--- a/instrumentation/ruby_kafka/test/.rubocop.yml
+++ b/instrumentation/ruby_kafka/test/.rubocop.yml
@@ -2,3 +2,5 @@ inherit_from: ../.rubocop.yml
 
 Metrics/BlockLength:
   Enabled: false
+Style/MultilineIfModifier:
+  Enabled: false

--- a/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/patches/client_test.rb
+++ b/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/patches/client_test.rb
@@ -46,4 +46,4 @@ describe OpenTelemetry::Instrumentation::RubyKafka::Patches::Client do
     _(spans[1].name).must_equal("#{topic} process")
     _(spans[1].kind).must_equal(:consumer)
   end
-end
+end unless ENV['OMIT_SERVICES']

--- a/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/patches/consumer_test.rb
+++ b/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/patches/consumer_test.rb
@@ -130,4 +130,4 @@ describe OpenTelemetry::Instrumentation::RubyKafka::Patches::Consumer do
       _(spans.size).must_equal(3)
     end
   end
-end
+end unless ENV['OMIT_SERVICES']

--- a/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/patches/producer_test.rb
+++ b/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/patches/producer_test.rb
@@ -72,4 +72,4 @@ describe OpenTelemetry::Instrumentation::RubyKafka::Patches::Producer do
       _(spans.first.attributes['messaging.destination']).must_equal(async_topic)
     end
   end
-end
+end unless ENV['OMIT_SERVICES']

--- a/instrumentation/sidekiq/test/.rubocop.yml
+++ b/instrumentation/sidekiq/test/.rubocop.yml
@@ -2,3 +2,5 @@ inherit_from: ../.rubocop.yml
 
 Metrics/BlockLength:
   Enabled: false
+Style/MultilineIfModifier:
+  Enabled: false

--- a/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/patches/poller_test.rb
+++ b/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/patches/poller_test.rb
@@ -58,7 +58,7 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Patches::Poller do
         end
       end
     end
-  end
+  end unless ENV['OMIT_SERVICES']
 
   describe '#wait' do
     it 'does not trace' do

--- a/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/patches/processor_test.rb
+++ b/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/patches/processor_test.rb
@@ -59,5 +59,5 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Patches::Processor do
         end
       end
     end
-  end
+  end unless ENV['OMIT_SERVICES']
 end

--- a/propagator/ottrace/test/test_helper.rb
+++ b/propagator/ottrace/test/test_helper.rb
@@ -15,4 +15,4 @@ require 'minitest/autorun'
 require 'opentelemetry/sdk'
 require 'opentelemetry-propagator-ottrace'
 
-OpenTelemetry.logger = Logger.new('/dev/null')
+OpenTelemetry.logger = Logger.new(File::NULL)

--- a/resource_detectors/Gemfile
+++ b/resource_detectors/Gemfile
@@ -14,6 +14,6 @@ gem 'opentelemetry-instrumentation-base', path: '../instrumentation/base'
 gem 'opentelemetry-sdk', path: '../sdk'
 
 group :development, :test do
-  gem 'byebug'
+  gem 'byebug' unless RUBY_PLATFORM == 'java'
   gem 'pry'
 end

--- a/sdk/lib/opentelemetry/sdk.rb
+++ b/sdk/lib/opentelemetry/sdk.rb
@@ -55,7 +55,7 @@ module OpenTelemetry
     #   Configure everything
     #
     #     OpenTelemetry::SDK.configure do |c|
-    #       c.logger = Logger.new('/dev/null')
+    #       c.logger = Logger.new(File::NULL)
     #       c.add_span_processor SpanProcessor.new(SomeExporter.new)
     #       c.use_all
     #     end

--- a/sdk/test/opentelemetry/sdk/configurator_test.rb
+++ b/sdk/test/opentelemetry/sdk/configurator_test.rb
@@ -28,7 +28,7 @@ describe OpenTelemetry::SDK::Configurator do
       _(configurator.logger).must_be_instance_of(Logger)
     end
     it 'assigns the logger to OpenTelemetry.logger' do
-      custom_logger = Logger.new('/dev/null', level: 'ERROR')
+      custom_logger = Logger.new(File::NULL, level: 'ERROR')
       _(OpenTelemetry.logger).wont_equal custom_logger
       OpenTelemetry::SDK.configure { |c| c.logger = custom_logger }
       _(OpenTelemetry.logger).must_equal custom_logger

--- a/sdk/test/opentelemetry/sdk_test.rb
+++ b/sdk/test/opentelemetry/sdk_test.rb
@@ -10,7 +10,7 @@ describe OpenTelemetry::SDK do
   describe '#configure' do
     after do
       # Ensure we don't leak custom loggers and error handlers to other tests
-      OpenTelemetry.logger = Logger.new('/dev/null')
+      OpenTelemetry.logger = Logger.new(File::NULL)
       OpenTelemetry.error_handler = nil
     end
 

--- a/sdk/test/test_helper.rb
+++ b/sdk/test/test_helper.rb
@@ -12,4 +12,4 @@ require 'opentelemetry/common/test_helpers'
 require 'opentelemetry/sdk'
 require 'minitest/autorun'
 
-OpenTelemetry.logger = Logger.new('/dev/null')
+OpenTelemetry.logger = Logger.new(File::NULL)


### PR DESCRIPTION
The primary goal here is to add MacOS and Windows to CI. This turned out not to be as easy as one might expect. Here are the details:

* A bunch of tests need to run against a running service (e.g. a mongo server, a rabbitmq server, etc.). These services are spun up in docker containers, but docker is not available in the Windows or MacOS VMs provided by GitHub Actions. Therefore:
    * We split the CI job into two parts: the normal linux tests that spin up and run against services, and macos/windows tests that do not attempt to spin up services.
    * CI jobs that have no services will set the `OMIT_SERVICES` environment variable. All tests that depend on external services are gated on that environment variable.
    * Some gems could not be tested at all under Windows and/or Mac, mostly due to unavailable dependencies (e.g. redis-server is not available on the Windows and Mac VMs). Those are disabled in the CI config, and called out explicitly in comments with notes on why they are disabled.
* Previously, test jobs themselves were run in docker containers. (We were using circleci images, an artifact of the earlier migration from CircleCI to GitHub Actions). I thought we should remove our dependency on those images. Thus:
    * Test VMs now use the GitHub Actions provided VMs directly rather than circleci images.
    * As a result, the protocol for connecting to service containers changed: all endpoint hosts are now localhost, and all ports had to be mapped explicitly. This PR makes the necessary config changes, and also cleans up some small errors in the configuration. For example, mysql tests now log in as the normal mysql user rather than the root user.
* Additional changes and fixes:
    * A few tests referenced `/dev/null` which doesn't exist on Windows. Changed to `File::NULL`.
    * Separated the Rubocop and build test job from the Ruby 2.7 unit tests to make it easier to see when a failure is due to rubocop. Additionally, because rubocop tests do not require services, that test job was moved under the same CI config as the Mac and Windows jobs, which omits service setup configuration, even though we actually run rubocop on Linux.
    * Updated the CI script to print a summary of the failing gems/sections at the bottom, to make it easier to identify failures in the log.
    * The otlp gem has been re-added to the Ruby 3.0 test job because protobuf is now working on Ruby 3.
    * CI job names have been shortened and made more readable.

Closes #541 