### PR TITLE
feat: Allow disabling of redis root spans

### DIFF
--- a/instrumentation/redis/CHANGELOG.md
+++ b/instrumentation/redis/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History: opentelemetry-instrumentation-redis
 
+### Unreleased
+
+* ADDED: Configuration option to enable or disable redis root spans [#777](https://github.com/open-telemetry/opentelemetry-ruby/pull/777)
+
 ### v0.18.0 / 2021-05-21
 
 * ADDED: Updated API depedency for 1.0.0.rc1

--- a/instrumentation/redis/lib/opentelemetry/instrumentation/redis/instrumentation.rb
+++ b/instrumentation/redis/lib/opentelemetry/instrumentation/redis/instrumentation.rb
@@ -19,8 +19,9 @@ module OpenTelemetry
           defined?(::Redis)
         end
 
-        option :peer_service, default: nil, validate: :string
-        option :enable_statement_obfuscation, default: true, validate: :boolean
+        option :peer_service,                 default: nil,   validate: :string
+        option :trace_root_spans,             default: true,  validate: :boolean
+        option :enable_statement_obfuscation, default: true,  validate: :boolean
 
         private
 

--- a/instrumentation/redis/lib/opentelemetry/instrumentation/redis/patches/client.rb
+++ b/instrumentation/redis/lib/opentelemetry/instrumentation/redis/patches/client.rb
@@ -13,7 +13,9 @@ module OpenTelemetry
           MAX_STATEMENT_LENGTH = 500
           private_constant :MAX_STATEMENT_LENGTH
 
-          def process(commands) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+          def process(commands) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
+            return super unless config[:trace_root_spans] || OpenTelemetry::Trace.current_span.context.valid?
+
             host = options[:host]
             port = options[:port]
 


### PR DESCRIPTION
Allows users to configure this instrumentation library to not trace root redis spans.  

We have observed quite a few applications with various background processes generating large volumes of single span traces for redis calls.  These traces provide no context into the work being done.  While the better goal would be to identify the sources of these spans and add context to them, this provides a less whack-a-mole style approach.