### PR TITLE
fix: update instrumentation gen for base extraction

### DIFF
--- a/.instrumentation_generator/instrumentation_generator.rb
+++ b/.instrumentation_generator/instrumentation_generator.rb
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require_relative '../api/lib/opentelemetry/version'
+require_relative '../instrumentation/base/lib/opentelemetry/instrumentation/version'
 require 'thor'
 
 class InstrumentationGenerator < Thor::Group
@@ -36,7 +37,7 @@ class InstrumentationGenerator < Thor::Group
   def test_files
     template('templates/test/.rubocop.yml', "#{instrumentation_path}/test/.rubocop.yml")
     template('templates/test/test_helper.rb', "#{instrumentation_path}/test/test_helper.rb")
-    template('templates/test/instrumentation.rb', "#{instrumentation_path}/test/#{instrumentation_path}/instrumentation_test.rb")
+    template('templates/test/instrumentation.rb', "#{instrumentation_path}/test/opentelemetry/#{instrumentation_path}/instrumentation_test.rb")
   end
 
   def add_to_releases
@@ -65,6 +66,10 @@ class InstrumentationGenerator < Thor::Group
 
   def opentelemetry_version
     OpenTelemetry::VERSION
+  end
+
+  def instrumentation_base_version
+    OpenTelemetry::Instrumentation::VERSION
   end
 
   def instrumentation_path

--- a/.instrumentation_generator/templates/gemspec.tt
+++ b/.instrumentation_generator/templates/gemspec.tt
@@ -26,11 +26,12 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_dependency 'opentelemetry-api', '~> <%= opentelemetry_version %>'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> <%= instrumentation_base_version %>'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'minitest', '~> 5.0'
-  spec.add_development_dependency 'opentelemetry-sdk', '~> 0.0'
+  spec.add_development_dependency 'opentelemetry-sdk'
   spec.add_development_dependency 'rake', '~> 12.3.3'
   spec.add_development_dependency 'rubocop', '~> 0.73.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'

--- a/.instrumentation_generator/templates/lib/instrumentation/instrumentation_name.rb.tt
+++ b/.instrumentation_generator/templates/lib/instrumentation/instrumentation_name.rb.tt
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require 'opentelemetry'
+require 'opentelemetry-instrumentation-base'
 
 module OpenTelemetry
   module Instrumentation

--- a/.instrumentation_generator/templates/lib/instrumentation/instrumentation_name/instrumentation.rb.tt
+++ b/.instrumentation_generator/templates/lib/instrumentation/instrumentation_name/instrumentation.rb.tt
@@ -4,8 +4,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'opentelemetry'
-
 module OpenTelemetry
   module Instrumentation
     module <%= pascal_cased_instrumentation_name %>

--- a/.instrumentation_generator/templates/rubocop.yml.tt
+++ b/.instrumentation_generator/templates/rubocop.yml.tt
@@ -1,27 +1,5 @@
-AllCops:
-  TargetRubyVersion: "2.5.0"
+inherit_from: ../.rubocop-examples.yml
 
-Bundler/OrderedGems:
-  Exclude:
-    - gemfiles/**/*
-Lint/UnusedMethodArgument:
-  Enabled: false
-Metrics/AbcSize:
-  Max: 18
-Metrics/LineLength:
-  Enabled: false
-Metrics/MethodLength:
-  Max: 20
-Metrics/ParameterLists:
-  Enabled: false
 Naming/FileName:
   Exclude:
     - "lib/opentelemetry-instrumentation-<%= instrumentation_name %>.rb"
-Style/FrozenStringLiteralComment:
-  Exclude:
-    - gemfiles/**/*
-Style/ModuleFunction:
-  Enabled: false
-Style/StringLiterals:
-  Exclude:
-    - gemfiles/**/*

--- a/.instrumentation_generator/templates/test/instrumentation.rb.tt
+++ b/.instrumentation_generator/templates/test/instrumentation.rb.tt
@@ -6,7 +6,7 @@
 
 require 'test_helper'
 
-require_relative '../../../lib/opentelemetry/instrumentation/<%= instrumentation_name %>'
+require_relative '../../../../lib/opentelemetry/instrumentation/<%= instrumentation_name %>'
 
 describe OpenTelemetry::Instrumentation::<%= pascal_cased_instrumentation_name %> do
   let(:instrumentation) { OpenTelemetry::Instrumentation::<%= pascal_cased_instrumentation_name %>::Instrumentation.instance }


### PR DESCRIPTION
The instrumentation generator was getting a little out of date, so this just a few small updates.