### PR TITLE
fix: Support Case Insensitive Trace and Span IDs

### DIFF
--- a/propagator/ottrace/lib/opentelemetry/propagator/ottrace/text_map_propagator.rb
+++ b/propagator/ottrace/lib/opentelemetry/propagator/ottrace/text_map_propagator.rb
@@ -18,8 +18,8 @@ module OpenTelemetry
       # Propagates context using OTTrace header format
       class TextMapPropagator
         PADDING = '0' * 16
-        VALID_TRACE_ID_REGEX = /^[0-9a-f]{32}$/.freeze
-        VALID_SPAN_ID_REGEX = /^[0-9a-f]{16}$/.freeze
+        VALID_TRACE_ID_REGEX = /^[0-9a-f]{32}$/i.freeze
+        VALID_SPAN_ID_REGEX = /^[0-9a-f]{16}$/i.freeze
         TRACE_ID_64_BIT_WIDTH = 64 / 4
         TRACE_ID_HEADER = 'ot-tracer-traceid'
         SPAN_ID_HEADER = 'ot-tracer-spanid'

--- a/propagator/ottrace/test/opentelemetry/propagator/ottrace/text_map_propagator_test.rb
+++ b/propagator/ottrace/test/opentelemetry/propagator/ottrace/text_map_propagator_test.rb
@@ -117,6 +117,26 @@ describe OpenTelemetry::Propagator::OTTrace::TextMapPropagator do
       end
     end
 
+    describe 'given a minimal context with uppercase fields' do
+      let(:carrier) do
+        {
+          'ot-tracer-traceid' => trace_id_header.upcase,
+          'ot-tracer-spanid' => span_id_header.upcase,
+          'ot-tracer-sampled' => sampled_header
+        }
+      end
+
+      it 'extracts parent context' do
+        context = propagator.extract(carrier, context: parent_context)
+        extracted_context = OpenTelemetry::Trace.current_span(context).context
+
+        _(extracted_context.hex_trace_id).must_equal('80f198ee56343ba864fe8b2a57d3eff7')
+        _(extracted_context.hex_span_id).must_equal('e457b5a2e4d86bd1')
+        _(extracted_context.trace_flags).must_equal(OpenTelemetry::Trace::TraceFlags::SAMPLED)
+        _(extracted_context).must_be(:remote?)
+      end
+    end
+
     describe 'given a context with sampling disabled' do
       let(:sampled_header) do
         'false'


### PR DESCRIPTION
This change allows systems that generate uppercase hexadecimal values to properly propagate OTTrace context.

