### PR TITLE
fix: use monotonic clock where possible

### DIFF
--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
@@ -107,9 +107,7 @@ module OpenTelemetry
 
             span = tracer.start_span('http_server.proxy',
                                      with_parent: extracted_context,
-                                     attributes: {
-                                       'start_time' => request_start_time.to_f
-                                     },
+                                     start_timestamp: request_start_time,
                                      kind: :server)
 
             OpenTelemetry::Trace.context_with_span(span, parent_context: extracted_context)

--- a/sdk/lib/opentelemetry/sdk/trace/span.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span.rb
@@ -276,7 +276,7 @@ module OpenTelemetry
         end
 
         # @api private
-        def initialize(context, parent_context, parent_span, name, kind, parent_span_id, span_limits, span_processor, attributes, links, start_timestamp, resource, instrumentation_library) # rubocop:disable Metrics/AbcSize
+        def initialize(context, parent_context, parent_span, name, kind, parent_span_id, span_limits, span_processors, attributes, links, start_timestamp, resource, instrumentation_library) # rubocop:disable Metrics/AbcSize,  Metrics/CyclomaticComplexity, Metrics/MethodLength,  Metrics/PerceivedComplexity
           super(span_context: context)
           @mutex = Mutex.new
           @name = name

--- a/sdk/lib/opentelemetry/sdk/trace/tracer.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/tracer.rb
@@ -24,19 +24,15 @@ module OpenTelemetry
         end
 
         def start_root_span(name, attributes: nil, links: nil, start_timestamp: nil, kind: nil)
-          start_span(name, with_parent: Context.empty, attributes: attributes, links: links, start_timestamp: start_timestamp, kind: kind)
+          parent_context = Context.empty
+          parent_span = Span::INVALID
+          @tracer_provider.internal_create_span(name, kind, attributes, links, start_timestamp, parent_context, parent_span, @instrumentation_library)
         end
 
         def start_span(name, with_parent: nil, attributes: nil, links: nil, start_timestamp: nil, kind: nil)
-          name ||= 'empty'
-
-          with_parent ||= Context.current
-          parent_span_context = OpenTelemetry::Trace.current_span(with_parent).context
-          if parent_span_context.valid?
-            parent_span_id = parent_span_context.span_id
-            trace_id = parent_span_context.trace_id
-          end
-          @tracer_provider.internal_create_span(name, kind, trace_id, parent_span_id, attributes, links, start_timestamp, with_parent, @instrumentation_library)
+          parent_context = with_parent || Context.current
+          parent_span = OpenTelemetry::Trace.current_span(parent_context)
+          @tracer_provider.internal_create_span(name, kind, attributes, links, start_timestamp, parent_context, parent_span, @instrumentation_library)
         end
       end
     end

--- a/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
@@ -133,7 +133,6 @@ module OpenTelemetry
             trace_id = parent_span_context.trace_id
           end
           name ||= 'empty'
-
           trace_id ||= @id_generator.generate_trace_id
           result = @sampler.should_sample?(trace_id: trace_id, parent_context: parent_context, links: links, name: name, kind: kind, attributes: attributes)
           span_id = @id_generator.generate_span_id

--- a/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
@@ -126,7 +126,7 @@ module OpenTelemetry
         end
 
         # @api private
-        def internal_create_span(name, kind, attributes, links, start_timestamp, parent_context, parent_span, instrumentation_library) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+        def internal_create_span(name, kind, trace_id, parent_span_id, attributes, links, start_timestamp, parent_context, parent_span, instrumentation_library) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
           parent_span_context = parent_span.context
           if parent_span_context.valid?
             parent_span_id = parent_span_context.span_id

--- a/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
@@ -126,7 +126,14 @@ module OpenTelemetry
         end
 
         # @api private
-        def internal_create_span(name, kind, trace_id, parent_span_id, attributes, links, start_timestamp, parent_context, instrumentation_library) # rubocop:disable Metrics/MethodLength
+        def internal_create_span(name, kind, attributes, links, start_timestamp, parent_context, parent_span, instrumentation_library) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+          parent_span_context = parent_span.context
+          if parent_span_context.valid?
+            parent_span_id = parent_span_context.span_id
+            trace_id = parent_span_context.trace_id
+          end
+          name ||= 'empty'
+
           trace_id ||= @id_generator.generate_trace_id
           result = @sampler.should_sample?(trace_id: trace_id, parent_context: parent_context, links: links, name: name, kind: kind, attributes: attributes)
           span_id = @id_generator.generate_span_id
@@ -137,6 +144,7 @@ module OpenTelemetry
             Span.new(
               context,
               parent_context,
+              parent_span,
               name,
               kind,
               parent_span_id,

--- a/sdk/test/opentelemetry/sdk/trace/span_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/span_test.rb
@@ -201,8 +201,8 @@ describe OpenTelemetry::SDK::Trace::Span do
       _(events.first.attributes).must_equal(attrs)
     end
 
-    it 'uses the provided timestamp' do
-      ts = Time.now
+    it 'honours an explicit timestamp' do
+      ts = Time.new('2021-11-23 12:00:00.000000 -0600')
       span.add_event('added', timestamp: ts)
       events = span.events
       _(events.size).must_equal(1)
@@ -210,37 +210,19 @@ describe OpenTelemetry::SDK::Trace::Span do
     end
 
     it 'sets the implicit event timestamp relative to the span start' do
-      timestamp = Time.new('2021-11-23 12:00:00.000000 -0600')
-      timestamp_in_nano = exportable_timestamp(timestamp)
-      timestamps = {
-        Process::CLOCK_MONOTONIC => 500_000_000_000_000,
-        Process::CLOCK_REALTIME => timestamp_in_nano
-      }
-
-      clock_gettime_mock = lambda do |clock_id, unit|
-        _(timestamps).must_include(clock_id)
-        _(unit).must_equal(:nanosecond)
-        timestamps[clock_id]
-      end
-
       # Create a span with deterministic time values stored on it.
-      test_span = Process.stub(:clock_gettime, clock_gettime_mock) do
-        Span.new(context, Context.empty, OpenTelemetry::Trace::Span::INVALID, 'span', SpanKind::INTERNAL, nil, span_limits, [], nil, nil, timestamp, nil, nil)
+      test_span = mock_gettime(monotonic: 100, realtime: 1_000) do
+        Span.new(context, Context.empty, OpenTelemetry::Trace::Span::INVALID, 'span', SpanKind::INTERNAL, nil, span_limits, [], nil, nil, nil, nil, nil)
       end
 
-      timestamps = {
-        Process::CLOCK_MONOTONIC => 500_000_000_000_000 + 100,
-        Process::CLOCK_REALTIME => 0
-      }
-
-      Process.stub(:clock_gettime, clock_gettime_mock) do
+      mock_gettime(monotonic: 200, realtime: 1_000_000) do
         test_span.add_event('record something with relative time')
         event = test_span.events[0]
         _(event).wont_be_nil
 
         # The expect timestamp is that of the parent offset by
         # the drift in the monotonic clock
-        _(event.timestamp).must_equal(timestamp_in_nano + 100)
+        _(event.timestamp).must_equal(1_000 + 100)
       end
     end
 
@@ -408,42 +390,23 @@ describe OpenTelemetry::SDK::Trace::Span do
       _(span.finish).must_equal(span)
     end
 
-    it 'uses the provided end timestamp' do
+    it 'honours an explicit end timestamp' do
       ts = Time.new('2021-11-23 12:00:00.000000 -0600')
       _(span.finish(end_timestamp: ts)).must_equal(span)
       _(span.end_timestamp).must_equal(exportable_timestamp(ts))
     end
 
     it 'sets the end timestamp relative to the start time' do
-      timestamp = Time.new('2021-11-23 12:00:00.000000 -0600')
-      timestamp_in_nano = exportable_timestamp(timestamp)
-
-      timestamps = {
-        Process::CLOCK_MONOTONIC => 500_000_000_000_000,
-        Process::CLOCK_REALTIME => timestamp_in_nano
-      }
-
-      clock_gettime_mock = lambda do |clock_id, unit|
-        _(timestamps).must_include(clock_id)
-        _(unit).must_equal(:nanosecond)
-        timestamps[clock_id]
-      end
-
       # Create a span with deterministic time values stored on it.
-      test_span = Process.stub(:clock_gettime, clock_gettime_mock) do
-        Span.new(context, Context.empty, OpenTelemetry::Trace::Span::INVALID, 'span', SpanKind::INTERNAL, nil, span_limits, [], nil, nil, timestamp, nil, nil)
+      test_span = mock_gettime(monotonic: 100, realtime: 1_000) do
+        Span.new(context, Context.empty, OpenTelemetry::Trace::Span::INVALID, 'span', SpanKind::INTERNAL, nil, span_limits, [], nil, nil, nil, nil, nil)
       end
 
-      timestamps = {
-        Process::CLOCK_MONOTONIC => 500_000_000_000_000 + 100,
-        Process::CLOCK_REALTIME => timestamp_in_nano
-      }
-
-      Process.stub(:clock_gettime, clock_gettime_mock) do
+      mock_gettime(monotonic: 200, realtime: 1_000_000) do
         test_span.finish
         # The expect timestamp is that of the parent offset by
         # the drift in the monotonic clock
-        _(test_span.end_timestamp).must_equal(timestamp_in_nano + 100)
+        _(test_span.end_timestamp).must_equal(1_000 + 100)
       end
     end
 
@@ -525,89 +488,54 @@ describe OpenTelemetry::SDK::Trace::Span do
       _(span.links.size).must_equal(1)
     end
 
-    it 'when a timestamp is provided it converts it into nanoseconds' do
-      # Because we are providing a timestamp we don't need to control
-      # any of the time values being set on the parent span we just
-      # want to make sure our test span has a recording parent span.
-      parent_span = Span.new(context, Context.empty, OpenTelemetry::Trace::Span::INVALID, 'parent span', SpanKind::INTERNAL, nil, span_limits, [], nil, nil, Time.now, nil, nil)
-
+    it 'honours an explicit timestamp' do
       timestamp = Time.new('2021-11-23 12:00:00.000000 -0600')
-      expected_timestamp = exportable_timestamp(timestamp)
-
-      # Again because we're explicitly passing in the timestamp
-      # we don't expect any of the calculations to be performed
-      # so we just need to assert that the value is being converted
-      # into nanoseconds.
-      test_span = Span.new(context, Context.empty, parent_span, 'child span', SpanKind::INTERNAL, nil, span_limits, [], nil, [], timestamp, nil, nil)
-      _(test_span.start_timestamp).must_equal(expected_timestamp)
+      test_span = Span.new(context, Context.empty, OpenTelemetry::Trace::Span::INVALID, 'child span', SpanKind::INTERNAL, nil, span_limits, [], nil, [], timestamp, nil, nil)
+      _(test_span.start_timestamp).must_equal(exportable_timestamp(timestamp))
     end
 
-    it 'when parent_span is recording and no start timestamp is provided it uses relative_realtime' do
-      # All this setup is so that we can generate a parent span
-      # with deterministic time values.
-      parent_time = Time.new('2021-11-23 12:00:00.000000 -0600')
-      parent_time_in_nano = exportable_timestamp(parent_time)
-
-      timestamps = {
-        Process::CLOCK_MONOTONIC => 500_000_000_000_000,
-        Process::CLOCK_REALTIME => parent_time_in_nano
-      }
-
-      clock_gettime_mock = lambda do |clock_id, unit|
-        _(timestamps).must_include(clock_id)
-        _(unit).must_equal(:nanosecond)
-        timestamps[clock_id]
-      end
-
-      parent_span = Process.stub(:clock_gettime, clock_gettime_mock) do
-        Span.new(context, Context.empty, OpenTelemetry::Trace::Span::INVALID, 'parent span', SpanKind::INTERNAL, nil, span_limits, [], nil, nil, parent_time, nil, nil)
-      end
-
-      # Add a bit of time drift to see check if the relative time is accurately offset
-      # from the parent span timestamp
-      timestamps = {
-        Process::CLOCK_MONOTONIC => 500_000_000_000_000 + 200,
-        Process::CLOCK_REALTIME => parent_time_in_nano
-      }
-      clock_gettime_mock = lambda do |clock_id, unit|
-        _(timestamps).must_include(clock_id)
-        _(unit).must_equal(:nanosecond)
-        timestamps[clock_id]
+    it 'uses the monotonic offset from the parent_span realtime start timestamp when parent_span is recording' do
+      parent_span = mock_gettime(monotonic: 100, realtime: 1_000) do
+        Span.new(context, Context.empty, OpenTelemetry::Trace::Span::INVALID, 'parent span', SpanKind::INTERNAL, nil, span_limits, [], nil, nil, nil, nil, nil)
       end
 
       _(parent_span.recording?).must_equal(true)
-      Process.stub(:clock_gettime, clock_gettime_mock) do
+      mock_gettime(monotonic: 200, realtime: 1_000_000) do
         test_span = Span.new(context, Context.empty, parent_span, 'child span', SpanKind::INTERNAL, nil, span_limits, [], nil, [], nil, nil, nil)
 
         # We expect to see the start_timestamp to be the parent span timestamp
         # with the same offset we returned with our stubbed
         # monotonic_now value we returned above
-        _(test_span.start_timestamp).must_equal(parent_time_in_nano + 200)
+        _(test_span.start_timestamp).must_equal(1_000 + 100)
       end
     end
 
-    it 'when parent_span is not recording and no start timestamp provided it uses realtime_now' do
+    it 'uses the realtime clock when the parent_span is not recording' do
       non_recording_span = OpenTelemetry::Trace.non_recording_span(span.context)
 
-      timestamps = {
-        Process::CLOCK_MONOTONIC => 500_000_000_000_000 + 200,
-        Process::CLOCK_REALTIME => 1_609_480_800_000_000_000
-      }
-
-      clock_gettime_mock = lambda do |clock_id, unit|
-        _(timestamps).must_include(clock_id)
-        _(unit).must_equal(:nanosecond)
-        timestamps[clock_id]
-      end
-
-      Process.stub(:clock_gettime, clock_gettime_mock) do
+      mock_gettime(monotonic: 100, realtime: 1_000) do
         test_span = Span.new(context, Context.empty, non_recording_span, 'name', SpanKind::INTERNAL, nil, span_limits, [], nil, [], nil, nil, nil)
 
         # We expect for the timestamp to be the value returned from
         # the call to realtime_now as we have no timestamp and no parent
         # span time to try and get a relative offset from.
-        _(test_span.start_timestamp).must_equal(timestamps[Process::CLOCK_REALTIME])
+        _(test_span.start_timestamp).must_equal(1_000)
       end
     end
+  end
+
+  def mock_gettime(monotonic:, realtime:)
+    timestamps = {
+      Process::CLOCK_MONOTONIC => monotonic,
+      Process::CLOCK_REALTIME => realtime
+    }
+
+    clock_gettime_mock = lambda do |clock_id, unit|
+      _(timestamps).must_include(clock_id)
+      _(unit).must_equal(:nanosecond)
+      timestamps[clock_id]
+    end
+
+    Process.stub(:clock_gettime, clock_gettime_mock) { yield }
   end
 end

--- a/sdk/test/opentelemetry/sdk/trace/span_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/span_test.rb
@@ -27,7 +27,7 @@ describe OpenTelemetry::SDK::Trace::Span do
   end
   let(:span) do
     Span.new(context, Context.empty, OpenTelemetry::Trace::Span::INVALID, 'name', SpanKind::INTERNAL, nil, span_limits,
-             span_processor, nil, nil, Time.now, nil, nil)
+             [], nil, nil, Time.now, nil, nil)
   end
 
   describe '#attributes' do
@@ -434,7 +434,7 @@ describe OpenTelemetry::SDK::Trace::Span do
       mock_span_processor.expect(:on_start, nil) { |_| true }
       span = Span.new(context, Context.empty, OpenTelemetry::Trace::Span::INVALID,
                       'name', SpanKind::INTERNAL, nil, span_limits,
-                      mock_span_processor, nil, nil, Time.now, nil, nil)
+                      [mock_span_processor], nil, nil, Time.now, nil, nil)
       mock_span_processor.expect(:on_finish, nil, [span])
       span.finish
       mock_span_processor.verify
@@ -459,7 +459,7 @@ describe OpenTelemetry::SDK::Trace::Span do
       yielded_span = nil
       mock_span_processor.expect(:on_start, nil) { |s| yielded_span = s }
       span = Span.new(context, Context.empty, OpenTelemetry::Trace::Span::INVALID, 'name', SpanKind::INTERNAL, nil, span_limits,
-                      mock_span_processor, nil, nil, Time.now, nil, nil)
+                      [mock_span_processor], nil, nil, Time.now, nil, nil)
       _(yielded_span).must_equal(span)
       mock_span_processor.verify
     end
@@ -467,7 +467,7 @@ describe OpenTelemetry::SDK::Trace::Span do
     it 'trims excess attributes' do
       attributes = { 'foo': 'bar', 'other': 'attr' }
       span = Span.new(context, Context.empty, OpenTelemetry::Trace::Span::INVALID, 'name', SpanKind::INTERNAL, nil, span_limits,
-                      span_processor, attributes, nil, Time.now, nil, nil)
+                      [], attributes, nil, Time.now, nil, nil)
       _(span.to_span_data.total_recorded_attributes).must_equal(2)
       _(span.attributes.length).must_equal(1)
     end
@@ -475,21 +475,21 @@ describe OpenTelemetry::SDK::Trace::Span do
     it 'truncates attributes if configured' do
       attributes = { 'foo': 'oldbaroldbaroldbaroldbaroldbaroldbar' }
       span = Span.new(context, Context.empty, OpenTelemetry::Trace::Span::INVALID, 'name', SpanKind::INTERNAL, nil, span_limits,
-                      span_processor, attributes, nil, Time.now, nil, nil)
+                      [], attributes, nil, Time.now, nil, nil)
       _(span.attributes[:foo]).must_equal('oldbaroldbaroldbaroldbaroldba...')
     end
 
     it 'counts attributes' do
       attributes = { 'foo': 'bar', 'other': 'attr' }
       span = Span.new(context, Context.empty, OpenTelemetry::Trace::Span::INVALID, 'name', SpanKind::INTERNAL, nil, span_limits,
-                      span_processor, attributes, nil, Time.now, nil, nil)
+                      [], attributes, nil, Time.now, nil, nil)
       _(span.to_span_data.total_recorded_attributes).must_equal(2)
     end
 
     it 'counts links' do
       links = [OpenTelemetry::Trace::Link.new(context), OpenTelemetry::Trace::Link.new(context)]
       span = Span.new(context, Context.empty, OpenTelemetry::Trace::Span::INVALID, 'name', SpanKind::INTERNAL, nil, span_limits,
-                      span_processor, nil, links, Time.now, nil, nil)
+                      [], nil, links, Time.now, nil, nil)
       _(span.to_span_data.total_recorded_links).must_equal(2)
     end
 


### PR DESCRIPTION
This is a followup to #717 addressing #709 (which I probably should not have closed). It uses monotonic clock offsets to compute timestamps for `Span` and `Event` unless explicit timestamps are provided.

## TODO:
- [ ] tests
- [x] the approach here does not use monotonic offsets to compute other timestamps if the `start_timestamp` was explicitly provided. Should it? The tradeoff is that we need to store a `realtime_start_timestamp` separately from `start_timestamp`.