### PR TITLE
fix: handle OTLP exporter encoding exceptions

### DIFF
--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -341,6 +341,9 @@ module OpenTelemetry
 
         def as_otlp_key_value(key, value)
           Opentelemetry::Proto::Common::V1::KeyValue.new(key: key, value: as_otlp_any_value(value))
+        rescue Encoding::UndefinedConversionError => e
+          OpenTelemetry.handle_error(exception: e, message: "encoding error for key #{key} and value #{value}")
+          Opentelemetry::Proto::Common::V1::KeyValue.new(key: key, value: as_otlp_any_value('Encoding Error'))
         end
 
         def as_otlp_any_value(value)


### PR DESCRIPTION

```
gems/opentelemetry-exporter-otlp-0.18.0/lib/opentelemetry/exporter/otlp/exporter.rb:338:in `method_missing': "\xC3" from ASCII-8BIT to UTF-8 (Encoding::UndefinedConversionError)
    from gems/opentelemetry-exporter-otlp-0.18.0/lib/opentelemetry/exporter/otlp/exporter.rb:338:in `as_otlp_any_value'
    from gems/opentelemetry-exporter-otlp-0.18.0/lib/opentelemetry/exporter/otlp/exporter.rb:331:in `as_otlp_key_value'
    from gems/opentelemetry-exporter-otlp-0.18.0/lib/opentelemetry/exporter/otlp/exporter.rb:294:in `block (2 levels) in as_otlp_span'
    from gems/opentelemetry-exporter-otlp-0.18.0/lib/opentelemetry/exporter/otlp/exporter.rb:294:in `each'
    from gems/opentelemetry-exporter-otlp-0.18.0/lib/opentelemetry/exporter/otlp/exporter.rb:294:in `map'
    from gems/opentelemetry-exporter-otlp-0.18.0/lib/opentelemetry/exporter/otlp/exporter.rb:294:in `block in as_otlp_span'
    from gems/opentelemetry-exporter-otlp-0.18.0/lib/opentelemetry/exporter/otlp/exporter.rb:290:in `map'
    from gems/opentelemetry-exporter-otlp-0.18.0/lib/opentelemetry/exporter/otlp/exporter.rb:290:in `as_otlp_span'
    from gems/opentelemetry-exporter-otlp-0.18.0/lib/opentelemetry/exporter/otlp/exporter.rb:269:in `block (3 levels) in encode'
    from gems/opentelemetry-exporter-otlp-0.18.0/lib/opentelemetry/exporter/otlp/exporter.rb:269:in `map'
    from gems/opentelemetry-exporter-otlp-0.18.0/lib/opentelemetry/exporter/otlp/exporter.rb:269:in `block (2 levels) in encode'
    from gems/opentelemetry-exporter-otlp-0.18.0/lib/opentelemetry/exporter/otlp/exporter.rb:263:in `each'
    from gems/opentelemetry-exporter-otlp-0.18.0/lib/opentelemetry/exporter/otlp/exporter.rb:263:in `map'
    from gems/opentelemetry-exporter-otlp-0.18.0/lib/opentelemetry/exporter/otlp/exporter.rb:263:in `block in encode'
    from gems/opentelemetry-exporter-otlp-0.18.0/lib/opentelemetry/exporter/otlp/exporter.rb:256:in `each'
    from gems/opentelemetry-exporter-otlp-0.18.0/lib/opentelemetry/exporter/otlp/exporter.rb:256:in `map'
    from gems/opentelemetry-exporter-otlp-0.18.0/lib/opentelemetry/exporter/otlp/exporter.rb:256:in `encode'
    from gems/opentelemetry-exporter-otlp-0.18.0/lib/opentelemetry/exporter/otlp/exporter.rb:76:in `export'
    from gems/opentelemetry-sdk-1.0.0.rc1/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb:187:in `block in export_batch'
    from gems/opentelemetry-sdk-1.0.0.rc1/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb:187:in `synchronize'
    from gems/opentelemetry-sdk-1.0.0.rc1/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb:187:in `export_batch'
    from gems/opentelemetry-sdk-1.0.0.rc1/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb:170:in `block in work'
    from gems/opentelemetry-sdk-1.0.0.rc1/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb:159:in `loop'
    from gems/opentelemetry-sdk-1.0.0.rc1/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb:159:in `work'
    from gems/opentelemetry-sdk-1.0.0.rc1/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb:180:in `block in reset_on_fork'
