### PR TITLE
fix: Rescue error in Faraday instrumentaion

### DIFF
--- a/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
+++ b/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
@@ -50,6 +50,9 @@ module OpenTelemetry
             instrumentation_attrs.merge(
               OpenTelemetry::Common::HTTP::ClientContext.attributes
             )
+          rescue StandardError => e
+            OpenTelemetry.logger.debug("[Faraday] Error creating span attrs: #{e}")
+            {}
           end
 
           def tracer


### PR DESCRIPTION
We have added some customizations to OTel ruby in our projects and noticed errors in the faraday instrumentation causing our deployments to fail.  The errors being thrown did need to be fixed, but ideally OTel would fail gracefully and log the error to allow deployments to go ahead.
The specific error we experienced was
`#<NameError: uninitialized constant OpenTelemetry::Common>`