### PR TITLE
chore: Add .ruby-version to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ instrumentation/**/*.gemfile.lock
 
 # IDE Settings
 /.idea/
+
+# rbenv configuration
+.ruby-version


### PR DESCRIPTION
Twice now I have committed a `.ruby-version` in my PRs, and so I have decided "never again". The `.ruby-version` file is only needed if you're using some kind of ruby version manager like `rbenv`, and is otherwise unneeded in this project. 
