### PR TITLE
fix: update context to match spec

### DIFF
--- a/api/lib/opentelemetry/context.rb
+++ b/api/lib/opentelemetry/context.rb
@@ -10,10 +10,9 @@ require 'opentelemetry/context/propagation'
 module OpenTelemetry
   # Manages context on a per-fiber basis
   class Context
-    KEY = :__opentelemetry_context__
     EMPTY_ENTRIES = {}.freeze
     STACK_KEY = :__opentelemetry_context_storage__
-    private_constant :KEY, :EMPTY_ENTRIES, :STACK_KEY
+    private_constant :EMPTY_ENTRIES, :STACK_KEY
 
     DetachError = Class.new(OpenTelemetry::Error)
 
@@ -33,10 +32,6 @@ module OpenTelemetry
         stack.last || ROOT
       end
 
-      # @api private
-      def current=(ctx)
-        Thread.current[KEY] = ctx
-      end
 
       # Associates a Context with the caller's current Fiber. Every call to
       # this operation should be paired with a corresponding call to detach.

--- a/api/lib/opentelemetry/context.rb
+++ b/api/lib/opentelemetry/context.rb
@@ -44,7 +44,7 @@ module OpenTelemetry
       # Returns a token to be used with the matching call to detach
       #
       # @param [Context] context The new context
-      # @return [Integer] A token to be used when detaching
+      # @return [Object] A token to be used when detaching
       def attach(context)
         prev = current
         self.current = context
@@ -57,7 +57,7 @@ module OpenTelemetry
       # with a corresponding attach call. A warning is logged if the
       # calls are unbalanced.
       #
-      # @param [Integer] token The token provided by the matching call to attach
+      # @param [Object] token The token provided by the matching call to attach
       # @return [Boolean] True if the calls matched, false otherwise
       def detach(token)
         calls_matched = (token == stack.size)

--- a/api/lib/opentelemetry/context.rb
+++ b/api/lib/opentelemetry/context.rb
@@ -12,6 +12,7 @@ module OpenTelemetry
   class Context
     KEY = :__opentelemetry_context__
     EMPTY_ENTRIES = {}.freeze
+    private_constant :KEY, :EMPTY_ENTRIES
 
     class << self
       # Returns a key used to index a value in a Context
@@ -100,6 +101,13 @@ module OpenTelemetry
         yield ctx, values
       ensure
         detach(prev)
+      end
+
+      # Returns the value associated with key in the current context
+      #
+      # @param [String] key The lookup key
+      def value(key)
+        current.value(key)
       end
 
       def clear

--- a/api/lib/opentelemetry/context.rb
+++ b/api/lib/opentelemetry/context.rb
@@ -12,7 +12,8 @@ module OpenTelemetry
   class Context
     KEY = :__opentelemetry_context__
     EMPTY_ENTRIES = {}.freeze
-    private_constant :KEY, :EMPTY_ENTRIES
+    STACK_KEY = :__opentelemetry_context_storage__
+    private_constant :KEY, :EMPTY_ENTRIES, :STACK_KEY
 
     class << self
       # Returns a key used to index a value in a Context
@@ -58,9 +59,9 @@ module OpenTelemetry
       # @return [Boolean] True if the calls matched, false otherwise
       def detach(token)
         calls_matched = (token == stack.size)
-        OpenTelemetry.logger.warn 'Calls to detach should match corresponding calls to attach' unless calls_matched
+        OpenTelemetry.handle_error(message: 'calls to detach should match corresponding calls to attach.') unless calls_matched
 
-        self.current = stack.pop || ROOT
+        self.current = stack.pop
         calls_matched
       end
 
@@ -128,7 +129,7 @@ module OpenTelemetry
       private
 
       def stack
-        @stack ||= []
+        Thread.current[STACK_KEY] ||= []
       end
     end
 

--- a/api/lib/opentelemetry/context.rb
+++ b/api/lib/opentelemetry/context.rb
@@ -32,7 +32,6 @@ module OpenTelemetry
         stack.last || ROOT
       end
 
-
       # Associates a Context with the caller's current Fiber. Every call to
       # this operation should be paired with a corresponding call to detach.
       #
@@ -116,7 +115,6 @@ module OpenTelemetry
 
       def clear
         stack.clear
-        self.current = ROOT
       end
 
       def empty

--- a/api/lib/opentelemetry/context.rb
+++ b/api/lib/opentelemetry/context.rb
@@ -15,6 +15,8 @@ module OpenTelemetry
     STACK_KEY = :__opentelemetry_context_storage__
     private_constant :KEY, :EMPTY_ENTRIES, :STACK_KEY
 
+    DetachError = Class.new(OpenTelemetry::Error)
+
     class << self
       # Returns a key used to index a value in a Context
       #
@@ -59,7 +61,7 @@ module OpenTelemetry
       # @return [Boolean] True if the calls matched, false otherwise
       def detach(token)
         calls_matched = (token == stack.size)
-        OpenTelemetry.handle_error(message: 'calls to detach should match corresponding calls to attach.') unless calls_matched
+        OpenTelemetry.handle_error(exception: DetachError.new('calls to detach should match corresponding calls to attach.')) unless calls_matched
 
         self.current = stack.pop
         calls_matched

--- a/api/test/opentelemetry/context_test.rb
+++ b/api/test/opentelemetry/context_test.rb
@@ -213,6 +213,17 @@ describe OpenTelemetry::Context do
     end
   end
 
+  describe '.value' do
+    it 'returns the value from the current context' do
+      Context.attach(new_context)
+      _(Context.value(foo_key)).must_equal('bar')
+
+      c2 = Context.current.set_value(bar_key, 'baz')
+      Context.attach(c2)
+      _(Context.value(bar_key)).must_equal('baz')
+    end
+  end
+
   describe '.clear' do
     it 'clears the context' do
       Context.attach(new_context)

--- a/api/test/opentelemetry/context_test.rb
+++ b/api/test/opentelemetry/context_test.rb
@@ -165,7 +165,7 @@ describe OpenTelemetry::Context do
 
     it 'resets context when an exception is raised' do
       c1 = new_context
-      Context.current = c1
+      Context.attach(c1)
 
       _(proc do
         c2 = Context.current.set_value(bar_key, 'baz')

--- a/api/test/opentelemetry/context_test.rb
+++ b/api/test/opentelemetry/context_test.rb
@@ -137,6 +137,17 @@ describe OpenTelemetry::Context do
       _(Context.current).must_equal(Context::ROOT)
       _(@log_stream.string).must_match(/OpenTelemetry error: calls to detach should match corresponding calls to attach/)
     end
+
+    it 'with a raising error handler' do
+      OpenTelemetry.error_handler = lambda { |exception: nil, message: nil|
+        raise exception, "OpenTelemetry error: #{[message, exception&.message].compact.join(' - ')}"
+      }
+
+      _(-> { Context.detach('junk') }).must_raise(OpenTelemetry::Context::DetachError)
+
+    ensure
+      OpenTelemetry.error_handler = ->(exception: nil, message: nil) { OpenTelemetry.logger.error("OpenTelemetry error: #{[message, exception&.message].compact.join(' - ')}") }
+    end
   end
 
   describe '.with_current' do


### PR DESCRIPTION
Moves the `attach` and `detach` methods from private instance methods to public global methods
https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/context.md

Related: https://github.com/open-telemetry/opentelemetry-ruby/pull/796/files#r647055849
