### PR TITLE
Use 55681 as the default OLTP exporter port

### DIFF
--- a/exporter/otlp/README.md
+++ b/exporter/otlp/README.md
@@ -2,6 +2,8 @@
 
 The `opentelemetry-exporter-otlp` gem provides an [OTLP](https://github.com/open-telemetry/opentelemetry-proto) exporter for OpenTelemetry for Ruby. Using `opentelemetry-exporter-otlp`, an application can configure OpenTelemetry to export collected tracing data to [the OpenTelemetry Collector][opentelemetry-collector-home].
 
+This OTLP exporter only supports OTLP/HTTP at this time.
+
 ## What is OpenTelemetry?
 
 [OpenTelemetry][opentelemetry-home] is an open source observability framework, providing a general-purpose API, SDK, and related tools required for the instrumentation of cloud-native software, frameworks, and libraries.
@@ -69,15 +71,17 @@ For additional examples, see the [examples on github][examples-github].
 
 The collector exporter can be configured explicitly in code, as shown above, or via environment variables. The configuration parameters, environment variables, and defaults are shown below.
 
-| Parameter           | Environment variable                         | Default                             |
-| ------------------- | -------------------------------------------- | ----------------------------------- |
-| `endpoint:`         | `OTEL_EXPORTER_OTLP_ENDPOINT`                | `"http://localhost:4317/v1/traces"` |
-| `certificate_file: `| `OTEL_EXPORTER_OTLP_CERTIFICATE`             |                                     |
-| `headers:`          | `OTEL_EXPORTER_OTLP_HEADERS`                 |                                     |
-| `compression:`      | `OTEL_EXPORTER_OTLP_COMPRESSION`             |                                     |
-| `timeout:`          | `OTEL_EXPORTER_OTLP_TIMEOUT`                 | `10`                                |
-| `ssl_verify_mode:`  | `OTEL_RUBY_EXPORTER_OTLP_SSL_VERIFY_PEER` or | `OpenSSL::SSL:VERIFY_PEER`          |
-|                     | `OTEL_RUBY_EXPORTER_OTLP_SSL_VERIFY_NONE`    |                                     |
+| Parameter           | Environment variable                         | Default                              |
+| ------------------- | -------------------------------------------- | ------------------------------------ |
+| `endpoint:`         | `OTEL_EXPORTER_OTLP_ENDPOINT`                | `"http://localhost:55681/v1/traces"` |
+| `certificate_file: `| `OTEL_EXPORTER_OTLP_CERTIFICATE`             |                                      |
+| `headers:`          | `OTEL_EXPORTER_OTLP_HEADERS`                 |                                      |
+| `compression:`      | `OTEL_EXPORTER_OTLP_COMPRESSION`             |                                      |
+| `timeout:`          | `OTEL_EXPORTER_OTLP_TIMEOUT`                 | `10`                                 |
+| `ssl_verify_mode:`  | `OTEL_RUBY_EXPORTER_OTLP_SSL_VERIFY_PEER` or | `OpenSSL::SSL:VERIFY_PEER`           |
+|                     | `OTEL_RUBY_EXPORTER_OTLP_SSL_VERIFY_NONE`    |                                      |
+
+The default value for `endpoint:` intentionally differs from the specification. Because this exporter does not support OTLP/GRPC, and `4317` is the OpenTelemetry collector's GRPC port, such a configuration would be broken by default. Instead, we set the default port to `55681`, which is the OTLP/HTTP port in the collector.
 
 `ssl_verify_mode:` parameter values should be flags for server certificate verification: `OpenSSL::SSL:VERIFY_PEER` and `OpenSSL::SSL:VERIFY_NONE` are acceptable. These values can also be set using the appropriately named environment variables as shown where `VERIFY_PEER` will take precedence over `VERIFY_NONE`.  Please see [the Net::HTTP docs](https://ruby-doc.org/stdlib-2.5.1/libdoc/net/http/rdoc/Net/HTTP.html#verify_mode) for more information about these flags.
 

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -41,7 +41,7 @@ module OpenTelemetry
           end
         end
 
-        def initialize(endpoint: config_opt('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', 'OTEL_EXPORTER_OTLP_ENDPOINT', default: 'https://localhost:4317/v1/traces'), # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength
+        def initialize(endpoint: config_opt('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', 'OTEL_EXPORTER_OTLP_ENDPOINT', default: 'https://localhost:55681/v1/traces'), # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength
                        certificate_file: config_opt('OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE', 'OTEL_EXPORTER_OTLP_CERTIFICATE'),
                        ssl_verify_mode: Exporter.ssl_verify_mode,
                        headers: config_opt('OTEL_EXPORTER_OTLP_TRACES_HEADERS', 'OTEL_EXPORTER_OTLP_HEADERS'),

--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -23,7 +23,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       _(http.use_ssl?).must_equal true
       _(http.address).must_equal 'localhost'
       _(http.verify_mode).must_equal OpenSSL::SSL::VERIFY_PEER
-      _(http.port).must_equal 4317
+      _(http.port).must_equal 55681
     end
 
     it 'refuses invalid headers' do
@@ -139,27 +139,27 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       skip unless ENV['TRACING_INTEGRATION_TEST']
       WebMock.disable_net_connect!(allow: 'localhost')
       span_data = create_span_data
-      exporter = OpenTelemetry::Exporter::OTLP::Exporter.new(endpoint: 'http://localhost:4317', compression: 'gzip')
+      exporter = OpenTelemetry::Exporter::OTLP::Exporter.new(endpoint: 'http://localhost:55681', compression: 'gzip')
       result = exporter.export([span_data])
       _(result).must_equal(SUCCESS)
     end
 
     it 'retries on timeout' do
-      stub_request(:post, 'https://localhost:4317/v1/traces').to_timeout.then.to_return(status: 200)
+      stub_request(:post, 'https://localhost:55681/v1/traces').to_timeout.then.to_return(status: 200)
       span_data = create_span_data
       result = exporter.export([span_data])
       _(result).must_equal(SUCCESS)
     end
 
     it 'returns TIMEOUT on timeout' do
-      stub_request(:post, 'https://localhost:4317/v1/traces').to_return(status: 200)
+      stub_request(:post, 'https://localhost:55681/v1/traces').to_return(status: 200)
       span_data = create_span_data
       result = exporter.export([span_data], timeout: 0)
       _(result).must_equal(TIMEOUT)
     end
 
     it 'returns TIMEOUT on timeout after retrying' do
-      stub_request(:post, 'https://localhost:4317/v1/traces').to_timeout.then.to_raise('this should not be reached')
+      stub_request(:post, 'https://localhost:55681/v1/traces').to_timeout.then.to_raise('this should not be reached')
       span_data = create_span_data
 
       @retry_count = 0
@@ -183,7 +183,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
     end
 
     it 'exports a span_data' do
-      stub_request(:post, 'https://localhost:4317/v1/traces').to_return(status: 200)
+      stub_request(:post, 'https://localhost:55681/v1/traces').to_return(status: 200)
       span_data = create_span_data
       result = exporter.export([span_data])
       _(result).must_equal(SUCCESS)
@@ -194,7 +194,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       logger = OpenTelemetry.logger
       OpenTelemetry.logger = ::Logger.new(log_stream)
 
-      stub_request(:post, 'https://localhost:4317/v1/traces').to_return(status: 200)
+      stub_request(:post, 'https://localhost:55681/v1/traces').to_return(status: 200)
       span_data = create_span_data(total_recorded_attributes: 1, attributes: { 'a' => "\xC2".dup.force_encoding(::Encoding::ASCII_8BIT) })
 
       result = exporter.export([span_data])
@@ -211,7 +211,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
     end
 
     it 'exports a span from a tracer' do
-      stub_post = stub_request(:post, 'https://localhost:4317/v1/traces').to_return(status: 200)
+      stub_post = stub_request(:post, 'https://localhost:55681/v1/traces').to_return(status: 200)
       processor = OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(exporter, max_queue_size: 1, max_export_batch_size: 1)
       OpenTelemetry.tracer_provider.add_span_processor(processor)
       OpenTelemetry.tracer_provider.tracer.start_root_span('foo').finish
@@ -221,7 +221,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
 
     it 'compresses with gzip if enabled' do
       exporter = OpenTelemetry::Exporter::OTLP::Exporter.new(compression: 'gzip')
-      stub_post = stub_request(:post, 'https://localhost:4317/v1/traces').to_return do |request|
+      stub_post = stub_request(:post, 'https://localhost:55681/v1/traces').to_return do |request|
         Opentelemetry::Proto::Collector::Trace::V1::ExportTraceServiceRequest.decode(Zlib.gunzip(request.body))
         { status: 200 }
       end
@@ -235,7 +235,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
 
     it 'batches per resource' do
       etsr = nil
-      stub_post = stub_request(:post, 'https://localhost:4317/v1/traces').to_return do |request|
+      stub_post = stub_request(:post, 'https://localhost:55681/v1/traces').to_return do |request|
         etsr = Opentelemetry::Proto::Collector::Trace::V1::ExportTraceServiceRequest.decode(request.body)
         { status: 200 }
       end
@@ -251,7 +251,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
     end
 
     it 'translates all the things' do
-      stub_request(:post, 'https://localhost:4317/v1/traces').to_return(status: 200)
+      stub_request(:post, 'https://localhost:55681/v1/traces').to_return(status: 200)
       processor = OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(exporter)
       tracer = OpenTelemetry.tracer_provider.tracer('tracer', 'v0.0.1')
       other_tracer = OpenTelemetry.tracer_provider.tracer('other_tracer')
@@ -412,7 +412,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
         )
       )
 
-      assert_requested(:post, 'https://localhost:4317/v1/traces') do |req|
+      assert_requested(:post, 'https://localhost:55681/v1/traces') do |req|
         req.body == encoded_etsr
       end
     end


### PR DESCRIPTION
In the interest of making this library easier to use by default, this PR
proposes a simple change: allow our OTLP exporter to default to using
port 55681, rather than 4317. Port 4317 is the collector's GRPC port,
and our exporter doesn't support GRPC. The default HTTP port is 55681,
and so we use it throughout.

However, this does seem to be against the specification in some ways.
The specification doesn't *require* that you support GRPC, however it
defines the default value for the environment variable as if you do.

I think this is acceptable; and we can default to port 4317 and GRPC
once we have support for it and are comfortable that it performs well.

https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/README.md#getting-started
