### PR TITLE
refactor: Remove redundant methods in instrumentation/rack

### DIFF
--- a/instrumentation/rack/gemfiles/rack_2.0.gemfile
+++ b/instrumentation/rack/gemfiles/rack_2.0.gemfile
@@ -3,10 +3,14 @@
 source "https://rubygems.org"
 
 gem "opentelemetry-api", path: "../../../api"
+gem "opentelemetry-instrumentation-base", path: "../../base"
 gem "rack", "2.0.8"
 
 group :test do
+  gem "byebug"
+  gem "opentelemetry-common", path: "../../../common"
   gem "opentelemetry-sdk", path: "../../../sdk"
+  gem "pry-byebug"
 end
 
 gemspec path: "../"

--- a/instrumentation/rack/gemfiles/rack_2.1.gemfile
+++ b/instrumentation/rack/gemfiles/rack_2.1.gemfile
@@ -3,10 +3,14 @@
 source "https://rubygems.org"
 
 gem "opentelemetry-api", path: "../../../api"
+gem "opentelemetry-instrumentation-base", path: "../../base"
 gem "rack", "~> 2.1.2"
 
 group :test do
+  gem "byebug"
+  gem "opentelemetry-common", path: "../../../common"
   gem "opentelemetry-sdk", path: "../../../sdk"
+  gem "pry-byebug"
 end
 
 gemspec path: "../"

--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack.rb
@@ -25,26 +25,6 @@ module OpenTelemetry
         context ||= Context.current
         context.value(CURRENT_SPAN_KEY) || OpenTelemetry::Trace::Span::INVALID
       end
-
-      # Returns a context containing the span, derived from the optional parent
-      # context, or the current context if one was not provided.
-      #
-      # @param [optional Context] context The context to use as the parent for
-      #   the returned context
-      def context_with_span(span, parent_context: Context.current)
-        parent_context.set_value(CURRENT_SPAN_KEY, span)
-      end
-
-      # Activates/deactivates the Span within the current Context, which makes the "current span"
-      # available implicitly.
-      #
-      # On exit, the Span that was active before calling this method will be reactivated.
-      #
-      # @param [Span] span the span to activate
-      # @yield [span, context] yields span and a context containing the span to the block.
-      def with_span(span)
-        Context.with_value(CURRENT_SPAN_KEY, span) { |c, s| yield s, c }
-      end
     end
   end
 end

--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
@@ -72,7 +72,7 @@ module OpenTelemetry
               tracer.in_span(request_span_name,
                              attributes: request_span_attributes(env: env),
                              kind: request_span_kind) do |request_span|
-                OpenTelemetry::Instrumentation::Rack.with_span(request_span) do
+                OpenTelemetry::Trace.with_span(request_span) do
                   @app.call(env).tap do |status, headers, response|
                     set_attributes_after_request(request_span, status, headers, response)
                   end

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack_test.rb
@@ -38,20 +38,4 @@ describe OpenTelemetry::Instrumentation::Rack do
       _(OpenTelemetry::Instrumentation::Rack.current_span(context)).must_equal(test_span)
     end
   end
-
-  describe '#with_span' do
-    it 'respects context nesting' do
-      test_span = new_span
-      test_span2 = new_span
-      OpenTelemetry::Instrumentation::Rack.with_span(test_span) do
-        _(OpenTelemetry::Instrumentation::Rack.current_span).must_equal(test_span)
-
-        OpenTelemetry::Instrumentation::Rack.with_span(test_span2) do
-          _(OpenTelemetry::Instrumentation::Rack.current_span).must_equal(test_span2)
-        end
-
-        _(OpenTelemetry::Instrumentation::Rack.current_span).must_equal(test_span)
-      end
-    end
-  end
 end


### PR DESCRIPTION
While I do not know the precise provenance of these methods (nor do I
care to futz around with `git` any further to find out), the current API
contains similar methods that we can rely upon for this functionality.

Specifically, we remove:

- `OpenTelemetry::Instrumentation::Rack.context_with_span`
- `OpenTelemetry::Instrumentation::Rack.with_span`

`with_span` was being used, but could be replaced by the API method.
`current_span` is not being used _here_ but is being used by the `Rails`
instrumentation, so it stays.