### PR TITLE
feat: allow disabling of install messages

### DIFF
--- a/instrumentation/base/lib/opentelemetry/instrumentation/registry.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/registry.rb
@@ -75,11 +75,10 @@ module OpenTelemetry
       end
 
       def install_instrumentation(instrumentation, config)
-        log_install_messages = ENV['OTEL_RUBY_INSTRUMENTATION_INSTALL_MESSAGES'] != 'false'
         if instrumentation.install(config)
-          OpenTelemetry.logger.info "Instrumentation: #{instrumentation.name} was successfully installed" if log_install_messages
+          OpenTelemetry.logger.info "Instrumentation: #{instrumentation.name} was successfully installed"
         else
-          OpenTelemetry.logger.warn "Instrumentation: #{instrumentation.name} failed to install" if log_install_messages
+          OpenTelemetry.logger.warn "Instrumentation: #{instrumentation.name} failed to install"
         end
       rescue => e # rubocop:disable Style/RescueStandardError
         OpenTelemetry.handle_error(exception: e, message: "Instrumentation: #{instrumentation.name} unhandled exception during install: #{e.backtrace}")

--- a/instrumentation/base/lib/opentelemetry/instrumentation/registry.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/registry.rb
@@ -75,10 +75,11 @@ module OpenTelemetry
       end
 
       def install_instrumentation(instrumentation, config)
+        log_install_messages = ENV['OTEL_RUBY_INSTRUMENTATION_INSTALL_MESSAGES'] != 'false'
         if instrumentation.install(config)
-          OpenTelemetry.logger.info "Instrumentation: #{instrumentation.name} was successfully installed"
+          OpenTelemetry.logger.info "Instrumentation: #{instrumentation.name} was successfully installed" if log_install_messages
         else
-          OpenTelemetry.logger.warn "Instrumentation: #{instrumentation.name} failed to install"
+          OpenTelemetry.logger.warn "Instrumentation: #{instrumentation.name} failed to install" if log_install_messages
         end
       rescue => e # rubocop:disable Style/RescueStandardError
         OpenTelemetry.handle_error(exception: e, message: "Instrumentation: #{instrumentation.name} unhandled exception during install: #{e.backtrace}")

--- a/sdk/lib/opentelemetry/sdk.rb
+++ b/sdk/lib/opentelemetry/sdk.rb
@@ -74,6 +74,7 @@ module OpenTelemetry
 end
 
 require 'opentelemetry/sdk/configurator'
+require 'opentelemetry/sdk/forwarding_logger'
 require 'opentelemetry/sdk/internal'
 require 'opentelemetry/sdk/instrumentation_library'
 require 'opentelemetry/sdk/resources'

--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -15,7 +15,7 @@ module OpenTelemetry
 
       private_constant :USE_MODE_UNSPECIFIED, :USE_MODE_ONE, :USE_MODE_ALL
 
-      attr_writer :logger, :propagators, :error_handler, :id_generator
+      attr_writer :propagators, :error_handler, :id_generator
 
       def initialize
         @instrumentation_names = []
@@ -29,6 +29,10 @@ module OpenTelemetry
 
       def logger
         @logger ||= OpenTelemetry.logger
+      end
+
+      def logger=(new_logger)
+        @logger = ForwardingLogger.new(new_logger, level: ENV['OTEL_LOG_LEVEL'] || Logger::INFO)
       end
 
       def error_handler

--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -31,6 +31,11 @@ module OpenTelemetry
         @logger ||= OpenTelemetry.logger
       end
 
+      # Accepts a logger and wraps it in the {ForwardingLogger} which allows
+      # for controlling the severity level emitted by the OpenTelemetry.logger
+      # independently of the supplied logger.
+      #
+      # @param [Logger] new_logger The logger for OpenTelemetry to use
       def logger=(new_logger)
         @logger = ForwardingLogger.new(new_logger, level: ENV['OTEL_LOG_LEVEL'] || Logger::INFO)
       end

--- a/sdk/lib/opentelemetry/sdk/forwarding_logger.rb
+++ b/sdk/lib/opentelemetry/sdk/forwarding_logger.rb
@@ -1,0 +1,62 @@
+require 'logger'
+
+module OpenTelemetry
+  module SDK
+    class ForwardingLogger
+      def initialize(logger, level:)
+        @logger = logger
+
+        if level.is_a?(Integer)
+          @level = level
+        else
+          case level.to_s.downcase
+          when 'debug'
+            @level = Logger::DEBUG
+          when 'info'
+            @level = Logger::INFO
+          when 'warn'
+            @level = Logger::WARN
+          when 'error'
+            @level = Logger::ERROR
+          when 'fatal'
+            @level = Logger::FATAL
+          when 'unknown'
+            @level = Logger::UNKNOWN
+          else
+            raise ArgumentError, "invalid log level: #{level}"
+          end
+        end
+      end
+
+      def debug(progname = nil, &block)
+        return true if Logger::DEBUG < @level
+        @logger.debug(progname, &block)
+      end
+
+      def info(progname = nil, &block)
+        return true if Logger::INFO < @level
+        @logger.info(progname, &block)
+      end
+
+      def warn(progname = nil, &block)
+        return true if Logger::WARN < @level
+        @logger.warn(progname, &block)
+      end
+
+      def error(progname = nil, &block)
+        return true if Logger::ERROR < @level
+        @logger.error(progname, &block)
+      end
+
+      def fatal(progname = nil, &block)
+        return true if Logger::FATAL < @level
+        @logger.fatal(progname, &block)
+      end
+
+      def unknown(progname = nil, &block)
+        return true if Logger::UNKNOWN < @level
+        @logger.unknown(progname, &block)
+      end
+    end
+  end
+end

--- a/sdk/lib/opentelemetry/sdk/forwarding_logger.rb
+++ b/sdk/lib/opentelemetry/sdk/forwarding_logger.rb
@@ -1,9 +1,16 @@
+# frozen_string_literal: true
+
 require 'logger'
 
 module OpenTelemetry
   module SDK
+    # The ForwardingLogger provides a wrapper to control the OpenTelemetry
+    # log level, while respecting the configured level of the supplied logger.
+    # If the OTEL_LOG_LEVEL is set to debug, and the supplied logger is configured
+    # with an ERROR log level, only OpenTelemetry logs at the ERROR level or higher
+    # will be emitted.
     class ForwardingLogger
-      def initialize(logger, level:)
+      def initialize(logger, level:) # rubocop:disable Metrics/CyclomaticComplexity
         @logger = logger
 
         if level.is_a?(Integer)
@@ -30,6 +37,7 @@ module OpenTelemetry
 
       def add(severity, message = nil, progname = nil)
         return true if severity < @level
+
         @logger.add(severity, message, progname)
       end
 

--- a/sdk/lib/opentelemetry/sdk/forwarding_logger.rb
+++ b/sdk/lib/opentelemetry/sdk/forwarding_logger.rb
@@ -28,34 +28,33 @@ module OpenTelemetry
         end
       end
 
+      def add(severity, message = nil, progname = nil)
+        return true if severity < @level
+        @logger.add(severity, message, progname)
+      end
+
       def debug(progname = nil, &block)
-        return true if Logger::DEBUG < @level
-        @logger.debug(progname, &block)
+        add(Logger::DEBUG, nil, progname, &block)
       end
 
       def info(progname = nil, &block)
-        return true if Logger::INFO < @level
-        @logger.info(progname, &block)
+        add(Logger::INFO, nil, progname, &block)
       end
 
       def warn(progname = nil, &block)
-        return true if Logger::WARN < @level
-        @logger.warn(progname, &block)
+        add(Logger::WARN, nil, progname, &block)
       end
 
       def error(progname = nil, &block)
-        return true if Logger::ERROR < @level
-        @logger.error(progname, &block)
+        add(Logger::ERROR, nil, progname, &block)
       end
 
       def fatal(progname = nil, &block)
-        return true if Logger::FATAL < @level
-        @logger.fatal(progname, &block)
+        add(Logger::FATAL, nil, progname, &block)
       end
 
       def unknown(progname = nil, &block)
-        return true if Logger::UNKNOWN < @level
-        @logger.unknown(progname, &block)
+        add(Logger::UNKNOWN, nil, progname, &block)
       end
     end
   end


### PR DESCRIPTION
Allows controlling the severity of the opentelemetry log messages emitted independently of the logger supplied.

This still allows for a user to override the `OpenTelemetry.logger` entirely via the accessor `OpenTelemetry.logger =`, if you wish to supply a logger and still respect the `OTEL_LOG_LEVEL` supplied environment variable this is done through the configuration.

```rb
OpenTelemetry::SDK.configure { |c| c.logger = Logger.new(....) }
```