### PR TITLE
fix: flakey tracer provider test

### DIFF
--- a/sdk/test/opentelemetry/sdk/trace/tracer_provider_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/tracer_provider_test.rb
@@ -143,7 +143,7 @@ describe OpenTelemetry::SDK::Trace::TracerProvider do
     before do
       @log_stream = StringIO.new
       @_logger = OpenTelemetry.logger
-      OpenTelemetry.logger = ::Logger.new(@log_stream)
+      OpenTelemetry.logger = ::Logger.new(@log_stream, level: 'WARN')
     end
 
     after do


### PR DESCRIPTION
The logger was sometimes receiving a debug message from the tracer provider
when it was being upgraded.  Setting the log level to warn remedies that
as the test is concerned with not receiving a warning log.