### PR TITLE
fix: return early if carrier is nil

### DIFF
--- a/api/lib/opentelemetry/baggage/propagation/text_map_propagator.rb
+++ b/api/lib/opentelemetry/baggage/propagation/text_map_propagator.rb
@@ -52,6 +52,7 @@ module OpenTelemetry
         #   if extraction fails
         def extract(carrier, context: Context.current, getter: Context::Propagation.text_map_getter)
           header = getter.get(carrier, BAGGAGE_KEY)
+          return context unless header
 
           entries = header.gsub(/\s/, '').split(',')
 


### PR DESCRIPTION
Received reports from users getting log messages indicating that the text map propagator was raising when trying to extract.

`Error extracting W3C baggage: undefined method `gsub' for nil:NilClass`