### PR TITLE
rfc: Allow reading current context for another thread

### DIFF
--- a/api/lib/opentelemetry/context.rb
+++ b/api/lib/opentelemetry/context.rb
@@ -28,8 +28,9 @@ module OpenTelemetry
       # Returns current context, which is never nil
       #
       # @return [Context]
-      def current
-        stack.last || ROOT
+      def current(thread = Thread.current)
+        # Avoid calling #stack directly so as to not have races in initializing the storage
+        thread[STACK_KEY]&.last || ROOT
       end
 
       # Associates a Context with the caller's current Fiber. Every call to


### PR DESCRIPTION
I've been working on integrating Datadog's continuous profiler with opentelemetry traces (see Datadog/dd-trace-rb#1568).

The profiler runs on a background thread, and needs to be able to access the current context for a thread, to be able to get the current span's trace id and span ids (if any active).

To do so, I was originally using

```ruby
thread = ...
::OpenTelemetry::Trace.current_span(thread[::OpenTelemetry::Context::KEY])
```

Unfortunately, after #807, this interface was changed, and more importantly, `Context::KEY` was removed and replaced with `Context::STACK_KEY`. `STACK_KEY` was marked as `private_constant`.

With 1.0.0.rc2, the only way of getting this information is by relying on private implementation details, which isn't great.

Thus, I would like to ask if it'd be reasonable to add an optional `thread` parameter to `Context.current`. This would make it easy to access the needed information, and it would even be more future-proof as the outside code doesn't need to care anymore where and how the context is stored.