### PR TITLE
fix: broken instrumentation all release

### DIFF
--- a/instrumentation/all/CHANGELOG.md
+++ b/instrumentation/all/CHANGELOG.md
@@ -2,12 +2,9 @@
 
 ### Unreleased
 
+* ADDED: Add resque instrumentation
+* ADDED: Add ActiveJob instrumentation
 * ADDED: Configuration option to enable or disable redis root spans [#777](https://github.com/open-telemetry/opentelemetry-ruby/pull/777)
-
-### v0.19.0 / 2021-06-23
-
-* ADDED: Add resque instrumentation 
-* ADDED: Add ActiveJob instrumentation 
 
 ### v0.18.0 / 2021-05-21
 

--- a/instrumentation/all/lib/opentelemetry/instrumentation/all/version.rb
+++ b/instrumentation/all/lib/opentelemetry/instrumentation/all/version.rb
@@ -7,7 +7,7 @@
 module OpenTelemetry
   module Instrumentation
     module All
-      VERSION = '0.19.0'
+      VERSION = '0.18.0'
     end
   end
 end


### PR DESCRIPTION
Just dancing around the release tools here.  Rolling back the version file, and remove the changelog entry so I can create a release for 0.19.0

https://github.com/open-telemetry/opentelemetry-ruby/pull/836#issuecomment-867870454
```
Failed to release opentelemetry-instrumentation-all 0.19.0:
The first changelog entry in instrumentation/all/CHANGELOG.md isn't for version 0.19.0.
It should start with:

v0.19.0 / 2021-06-24
But it actually starts with:

Unreleased
```

https://github.com/open-telemetry/opentelemetry-ruby/actions/runs/969317633
![image](https://user-images.githubusercontent.com/23463253/123443367-74bb2100-d59b-11eb-84af-2c142949f004.png)
