### PR TITLE
Update active-job gem for rc2 Trace::Status syntax

### DIFF
--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/patches/active_job_callbacks.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/patches/active_job_callbacks.rb
@@ -47,7 +47,7 @@ module OpenTelemetry
                       block.call
                     rescue Exception => e # rubocop:disable Lint/RescueException
                       span.record_exception(e)
-                      span.status = OpenTelemetry::Trace::Status.new(OpenTelemetry::Trace::Status::ERROR, description: "Unhandled exception of type: #{e.class}")
+                      span.status = OpenTelemetry::Trace::Status.error("Unhandled exception of type: #{e.class}")
                       raise e
                     ensure
                       root_span.finish

--- a/instrumentation/active_job/opentelemetry-instrumentation-active_job.gemspec
+++ b/instrumentation/active_job/opentelemetry-instrumentation-active_job.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-api', '~> 1.0.0.rc2'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.18.1'
 
+  spec.add_development_dependency 'activejob', '>= 5.2.0'
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'minitest', '~> 5.0'

--- a/instrumentation/active_job/test/test_helper.rb
+++ b/instrumentation/active_job/test/test_helper.rb
@@ -25,6 +25,12 @@ class RetryJob < ::ActiveJob::Base
   end
 end
 
+class ExceptionJob < ::ActiveJob::Base
+  def perform
+    raise StandardError, 'This job raises an exception'
+  end
+end
+
 class BaggageJob < ::ActiveJob::Base
   def perform
     OpenTelemetry::Trace.current_span['success'] = true if OpenTelemetry::Baggage.value('testing_baggage') == 'it_worked'


### PR DESCRIPTION
#805 removed the ability to call `OpenTelemetry::Trace::Status.new` in favor of class level helper methods like `OpenTelemetry::Trace::Status.error`

This PR updates the usage of `OpenTelemetry::Trace::Status` within active_job instrumentation to conform with the new API as well as writes tests for the exception handling codepaths