### PR TITLE
fix: otlp encoding exceptions again

### DIFF
--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -342,7 +342,8 @@ module OpenTelemetry
         def as_otlp_key_value(key, value)
           Opentelemetry::Proto::Common::V1::KeyValue.new(key: key, value: as_otlp_any_value(value))
         rescue Encoding::UndefinedConversionError => e
-          OpenTelemetry.handle_error(exception: e, message: "encoding error for key #{key} and value #{value}")
+          encoded_value = value.encode('UTF-8', invalid: :replace, undef: :replace, replace: '�')
+          OpenTelemetry.handle_error(exception: e, message: "encoding error for key #{key} and value #{encoded_value}")
           Opentelemetry::Proto::Common::V1::KeyValue.new(key: key, value: as_otlp_any_value('Encoding Error'))
         end
 

--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -199,12 +199,10 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
 
       result = exporter.export([span_data])
 
-      # Needed so it doesn't crash the test
-      encoded_logger_output = log_stream.string.encode('UTF-8', invalid: :replace, undef: :replace, replace: '?')
-
-      _(encoded_logger_output).must_match(
-        /ERROR -- : OpenTelemetry error: encoding error for key a and value ?/
+      _(log_stream.string).must_match(
+        /ERROR -- : OpenTelemetry error: encoding error for key a and value �/
       )
+
       _(result).must_equal(SUCCESS)
     ensure
       OpenTelemetry.logger = logger


### PR DESCRIPTION
Let's be kind to different error handlers and encode the value before passing it in, instead of assuming it can handle it.