### PR TITLE
Update CODEOWNERS to use OpenTelemetry team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth
+* @open-telemetry/ruby-approvers


### PR DESCRIPTION
Updates the codeowners file to use the Github team @open-telemetry/ruby-approvers instead of discrete list of users. This will make managing the group easier as it doesn't require code changes when the approvers list is updated.