### PR TITLE
Support Active Jobs with keyword args across ruby versions 

### DIFF
--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/patches/base.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/patches/base.rb
@@ -20,6 +20,7 @@ module OpenTelemetry
             @metadata = {}
             super
           end
+          ruby2_keywords(:initialize) if respond_to?(:ruby2_keywords, true)
 
           def serialize
             super.merge('metadata' => serialize_arguments(metadata))

--- a/instrumentation/active_job/test/instrumentation/active_job/patches/active_job_callbacks_test.rb
+++ b/instrumentation/active_job/test/instrumentation/active_job/patches/active_job_callbacks_test.rb
@@ -46,6 +46,12 @@ describe OpenTelemetry::Instrumentation::ActiveJob::Patches::ActiveJobCallbacks 
     end
   end
 
+  describe 'compatibility' do
+    it 'works with keyword args' do
+      _(KeywordArgsJob.perform_now(keyword: :keyword)).must_be_nil # Make sure this runs without raising an error
+    end
+  end
+
   describe 'exception handling' do
     it 'sets span status to error' do
       _ { ExceptionJob.perform_now }.must_raise StandardError, 'This job raises an exception'

--- a/instrumentation/active_job/test/instrumentation/active_job/patches/active_job_callbacks_test.rb
+++ b/instrumentation/active_job/test/instrumentation/active_job/patches/active_job_callbacks_test.rb
@@ -47,8 +47,16 @@ describe OpenTelemetry::Instrumentation::ActiveJob::Patches::ActiveJobCallbacks 
   end
 
   describe 'compatibility' do
+    it 'works with positional args' do
+      _(PositionalOnlyArgsJob.perform_now('arg1')).must_be_nil # Make sure this runs without raising an error
+    end
+
     it 'works with keyword args' do
-      _(KeywordArgsJob.perform_now(keyword: :keyword)).must_be_nil # Make sure this runs without raising an error
+      _(KeywordOnlyArgsJob.perform_now(keyword2: :keyword2)).must_be_nil # Make sure this runs without raising an error
+    end
+
+    it 'works with mixed args' do
+      _(MixedArgsJob.perform_now('arg1', 'arg2', keyword2: :keyword2)).must_be_nil # Make sure this runs without raising an error
     end
   end
 

--- a/instrumentation/active_job/test/test_helper.rb
+++ b/instrumentation/active_job/test/test_helper.rb
@@ -37,6 +37,10 @@ class BaggageJob < ::ActiveJob::Base
   end
 end
 
+class KeywordArgsJob < ::ActiveJob::Base
+  def perform(keyword:); end
+end
+
 ::ActiveJob::Base.queue_adapter = :inline
 ::ActiveJob::Base.logger = Logger.new(File::NULL)
 

--- a/instrumentation/active_job/test/test_helper.rb
+++ b/instrumentation/active_job/test/test_helper.rb
@@ -37,8 +37,15 @@ class BaggageJob < ::ActiveJob::Base
   end
 end
 
-class KeywordArgsJob < ::ActiveJob::Base
-  def perform(keyword:); end
+class PositionalOnlyArgsJob < ::ActiveJob::Base
+  def perform(arg1, arg2 = 'default'); end
+end
+class KeywordOnlyArgsJob < ::ActiveJob::Base
+  def perform(keyword1: 'default', keyword2:); end
+end
+
+class MixedArgsJob < ::ActiveJob::Base
+  def perform(arg1, arg2, keyword1: 'default', keyword2:); end
 end
 
 ::ActiveJob::Base.queue_adapter = :inline


### PR DESCRIPTION
Ruby 2.7 / 3.0 changes the way that keyword args work: see [Separation of positional and keyword arguments in Ruby 3.0](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/) for full details.

In order to support passing keyword args in ruby versions both prior to and after this change, we need to make use of the `ruby2_keywords` method in ruby versions where it is defined. [ActiveJob base](https://github.com/rails/rails/blob/6-0-stable/activejob/lib/active_job/core.rb#L90) (Starting in Rails 6) does this as well, so we're also following their lead

Running the new test without the code change produces the following error on ruby 3

```ArgumentError: wrong number of arguments (given 1, expected 0; required keyword: keyword)```