### PR TITLE
feat: Initial logging SDK implementation

### DIFF
--- a/log/CHANGELOG.md
+++ b/log/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Release History: opentelemetry-sdk-log
+
+### Unreleased

--- a/log/Gemfile
+++ b/log/Gemfile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source 'https://rubygems.org'
+
+gemspec
+
+gem 'opentelemetry-sdk', path: '../sdk'

--- a/log/LICENSE
+++ b/log/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright The OpenTelemetry Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/log/README.md
+++ b/log/README.md
@@ -1,0 +1,48 @@
+# opentelemetry-sdk-log
+
+The `opentelemetry-sdk-log` gem provides the logging portion of the reference implementation of the OpenTelemetry Ruby API. Using `opentelemetry-sdk-log`, an application can collect, analyze, and export OpenTelemetry format logs.
+
+## What is OpenTelemetry?
+
+[OpenTelemetry][opentelemetry-home] is an open source observability framework, providing a general-purpose API, SDK, and related tools required for the instrumentation of cloud-native software, frameworks, and libraries.
+
+OpenTelemetry provides a single set of APIs, libraries, agents, and collector services to capture distributed traces and metrics from your application. You can analyze them using Prometheus, Jaeger, and other observability tools.
+
+## How does this gem fit in?
+
+TODO.
+
+## How do I get started?
+
+Install the gem using:
+
+```
+gem install opentelemetry-sdk-log
+```
+
+Or, if you use [bundler][bundler-home], include `opentelemetry-sdk-log` in your `Gemfile`.
+
+
+TODO
+
+For additional examples, see the [examples on github][examples-github].
+
+## How can I get involved?
+
+The `opentelemetry-sdk` gem source is [on github][repo-github], along with related gems including `opentelemetry-api`.
+
+The OpenTelemetry Ruby gems are maintained by the OpenTelemetry-Ruby special interest group (SIG). You can get involved by joining us in [GitHub Discussions][discussions-url] or attending our weekly meeting. See the [meeting calendar][community-meetings] for dates and times. For more information on this and other language SIGs, see the OpenTelemetry [community page][ruby-sig].
+
+## License
+
+The `opentelemetry-sdk` gem is distributed under the Apache 2.0 license. See [LICENSE][license-github] for more information.
+
+
+[opentelemetry-home]: https://opentelemetry.io
+[bundler-home]: https://bundler.io
+[repo-github]: https://github.com/open-telemetry/opentelemetry-ruby
+[license-github]: https://github.com/open-telemetry/opentelemetry-ruby/blob/main/LICENSE
+[examples-github]: https://github.com/open-telemetry/opentelemetry-ruby/tree/main/examples
+[ruby-sig]: https://github.com/open-telemetry/community#ruby-sig
+[community-meetings]: https://github.com/open-telemetry/community#community-meetings
+[discussions-url]: https://github.com/open-telemetry/opentelemetry-ruby/discussions

--- a/log/Rakefile
+++ b/log/Rakefile
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+require 'yard'
+
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new
+
+Rake::TestTask.new :test do |t|
+  t.libs << 'test'
+  t.libs << 'lib'
+  t.libs << '../api/lib'
+  t.test_files = FileList['test/**/*_test.rb']
+end
+
+YARD::Rake::YardocTask.new do |t|
+  t.stats_options = ['--list-undoc']
+end
+
+if RUBY_ENGINE == 'truffleruby'
+  task default: %i[test]
+else
+  task default: %i[test rubocop yard]
+end

--- a/log/example/Gemfile
+++ b/log/example/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem "semantic_logger", "~> 4.8"
+gem 'opentelemetry-sdk', path: '../../sdk'
+gem 'opentelemetry-sdk-log', path: '../../log'

--- a/log/example/logger_test.rb
+++ b/log/example/logger_test.rb
@@ -1,0 +1,30 @@
+#!/usr/bin/env ruby
+
+require 'semantic_logger'
+require 'opentelemetry/sdk'
+require 'opentelemetry/sdk/log'
+require 'opentelemetry/sdk/log/appender/semantic_logger_appender'
+
+OpenTelemetry::SDK.configure do |c|
+  c.configure_logging_sdk
+end
+
+appender = OpenTelemetry::SDK::Log::Appender::SemanticLoggerAppender.new(
+  log_emitter: OpenTelemetry.log_emitter_provider.log_emitter
+)
+
+SemanticLogger.on_log do |log|
+  # log processing happens on a different thread for semantic_logger, so
+  # we need to capture the current span in a callback before the log is
+  # actually handled by semantic_logger
+  log.set_context(:opentelemetry_span, OpenTelemetry::Trace.current_span)
+end
+SemanticLogger.add_appender(appender: appender)
+
+logger = SemanticLogger['test-logger-1']
+
+logger.info 'test 123'
+
+OpenTelemetry.tracer_provider.tracer('test-tracer').in_span('test-span') do
+  logger.info 'test from span', { additional: 'tags' }
+end

--- a/log/lib/opentelemetry-sdk-log.rb
+++ b/log/lib/opentelemetry-sdk-log.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry/sdk/log'

--- a/log/lib/opentelemetry/sdk/log.rb
+++ b/log/lib/opentelemetry/sdk/log.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  def log_emitter_provider=(log_emitter_provider)
+    @log_emitter_provider = log_emitter_provider
+  end
+
+  def log_emitter_provider
+    @log_emitter_provider
+  end
+
+  module SDK
+    # The Log module contains the OpenTelemetry logging reference
+    # implementation.
+    module Log
+    end
+  end
+end
+
+require 'opentelemetry/sdk/log/configurator'
+require 'opentelemetry/sdk/log/export'
+require 'opentelemetry/sdk/log/log_data'
+require 'opentelemetry/sdk/log/log_emitter'
+require 'opentelemetry/sdk/log/log_emitter_provider'
+require 'opentelemetry/sdk/log/log_record'
+require 'opentelemetry/sdk/log/multi_log_processor'
+require 'opentelemetry/sdk/log/noop_log_processor'

--- a/log/lib/opentelemetry/sdk/log/appender.rb
+++ b/log/lib/opentelemetry/sdk/log/appender.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Log
+      # The Appender module contains the built-in log appenders
+      # for various libraries.
+      module Appender
+      end
+    end
+  end
+end

--- a/log/lib/opentelemetry/sdk/log/appender/semantic_logger_appender.rb
+++ b/log/lib/opentelemetry/sdk/log/appender/semantic_logger_appender.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'semantic_logger'
+
+module OpenTelemetry
+  module SDK
+    module Log
+      module Appender
+        class SemanticLoggerAppender < SemanticLogger::Subscriber
+          def initialize(log_emitter:, **args, &block)
+            @log_emitter = log_emitter
+            super(**args, &block)
+          end
+
+          def log(log)
+            @log_emitter.emit(
+              Log::LogRecord.new(attributes_from_log_struct(log))
+            )
+          end
+
+          def flush
+            @log_emitter.log_emitter_provider.force_flush
+          end
+
+          def close
+            @log_emitter.log_emitter_provider.shutdown
+          end
+
+          def attributes_from_log_struct(log)
+            attributes = {
+              # TODO: I don't think this is the right precision
+              timestamp: log.time.to_i,
+              severity_text: log.level.to_s,
+              severity_number: severity_number_from_level(log.level),
+              name: log.name,
+              body: log.message
+            }
+
+            if log.payload.is_a? Hash
+              attributes[:attributes] = log.payload
+            end
+
+            if log.context[:opentelemetry_span]&.context.valid?
+              attributes[:trace_id] = log.context[:opentelemetry_span].context.hex_trace_id
+              attributes[:span_id] = log.context[:opentelemetry_span].context.hex_span_id
+              attributes[:trace_flags] = log.context[:opentelemetry_span].context.trace_flags
+            end
+
+            attributes
+          end
+
+          def severity_number_from_level(level)
+            # TODO: make this a constant somewhere
+            case level
+            when :trace
+              1 
+            when :debug
+              5
+            when :info
+              9
+            when :warn
+              13
+            when :error
+              17
+            when :fatal
+              21
+            else
+              9
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/log/lib/opentelemetry/sdk/log/configurator.rb
+++ b/log/lib/opentelemetry/sdk/log/configurator.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    class Configurator
+      def configure_logging_sdk
+        @log_processors = []
+        configure_log_processors
+        OpenTelemetry.log_emitter_provider = log_emitter_provider
+      end
+
+      # Add a log processor to the export pipeline
+      #
+      # @param [#on_emit, #shutdown, #force_flush] log_processor A log_processor
+      #   that satisfies the duck type #on_emit, #shutdown, #force_flush. See
+      #   {SimpleLogProcessor} for an example.
+      def add_log_processor(log_processor)
+        @log_processors << log_processor
+      end
+
+      private
+
+      def log_emitter_provider
+        @log_emitter_provider ||= Log::LogEmitterProvider.new(@resource)
+      end
+
+      def configure_log_processors
+        processors = @log_processors.empty? ? [wrapped_log_exporter_from_env].compact : @log_processors
+        processors.each { |p| log_emitter_provider.add_log_processor(p) }
+      end
+
+      def wrapped_log_exporter_from_env
+        exporter = ENV.fetch('OTEL_LOGS_EXPORTER', 'console') # TODO: OTLP
+        case exporter
+        when 'none' then nil
+        # when 'otlp' then fetch_exporter(exporter, 'OpenTelemetry::Exporter::OTLP::Exporter')
+        when 'console' then Log::Export::SimpleLogProcessor.new(Log::Export::ConsoleLogExporter.new)
+        else
+          OpenTelemetry.logger.warn "The #{exporter} exporter is unknown and cannot be configured, spans will not be exported"
+          nil
+        end
+      end
+    end
+  end
+end

--- a/log/lib/opentelemetry/sdk/log/export.rb
+++ b/log/lib/opentelemetry/sdk/log/export.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Log
+      # The Export module contains the built-in exporters and log processors for the OpenTelemetry reference implementation.
+      module Export
+        # Result codes for the LogExporter#export method and the LogProcessor#force_flush and LogProcessor#shutdown methods.
+
+        # The operation finished successfully.
+        SUCCESS = 0
+
+        # The operation finished with an error.
+        FAILURE = 1
+
+        # Additional result code for the LogProcessor#force_flush and LogProcessor#shutdown methods.
+
+        # The operation timed out.
+        TIMEOUT = 2
+      end
+    end
+  end
+end
+
+require 'opentelemetry/sdk/log/export/batch_log_processor'
+require 'opentelemetry/sdk/log/export/simple_log_processor'
+require 'opentelemetry/sdk/log/export/console_log_exporter'
+require 'opentelemetry/sdk/log/export/in_memory_log_exporter'
+require 'opentelemetry/sdk/log/export/metrics_reporter'
+require 'opentelemetry/sdk/log/export/multi_log_exporter'
+require 'opentelemetry/sdk/log/export/noop_log_exporter'

--- a/log/lib/opentelemetry/sdk/log/export/batch_log_processor.rb
+++ b/log/lib/opentelemetry/sdk/log/export/batch_log_processor.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'timeout'
+
+module OpenTelemetry
+  module SDK
+    module Log
+      module Export
+        # Implementation of the duck type LogProcessor that batches logs
+        # exported by the SDK then pushes them to the exporter pipeline.
+        #
+        # Typically, the BatchLogProcessor will be more suitable for
+        # production environments than the SimpleLogProcessor.
+        #
+        # All logs reported by the SDK implementation are first added to a
+        # synchronized queue (with a {max_queue_size} maximum size, after the
+        # size is reached logs are dropped) and exported every
+        # schedule_delay to the exporter pipeline in batches of
+        # max_export_batch_size.
+        #
+        # If the queue gets half full a preemptive notification is sent to the
+        # worker thread that exports the logs to wake up and start a new
+        # export cycle.
+        class BatchLogProcessor # rubocop:disable Metrics/ClassLength
+          # Returns a new instance of the {BatchLogProcessor}.
+          #
+          # @param [LogExporter] exporter the (duck type) LogExporter to where the
+          #   recorded LogDatas are pushed after batching.
+          # @param [Numeric] exporter_timeout the delay interval between two
+          #   consecutive exports. Defaults to the value of the OTEL_BLP_EXPORT_TIMEOUT
+          #   environment variable, if set, or 30,000 (30 seconds).
+          # @param [Numeric] schedule_delay the maximum allowed time to export data.
+          #   Defaults to the value of the OTEL_BLP_SCHEDULE_DELAY environment
+          #   variable, if set, or 5,000 (5 seconds).
+          # @param [Integer] max_queue_size the maximum queue size in logs.
+          #   Defaults to the value of the OTEL_BLP_MAX_QUEUE_SIZE environment
+          #   variable, if set, or 2048.
+          # @param [Integer] max_export_batch_size the maximum batch size in logs.
+          #   Defaults to the value of the OTEL_BLP_MAX_EXPORT_BATCH_SIZE environment
+          #   variable, if set, or 512.
+          #
+          # @return a new instance of the {BatchLogProcessor}.
+          def initialize(exporter,
+                         exporter_timeout: Float(ENV.fetch('OTEL_BLP_EXPORT_TIMEOUT', 30_000)),
+                         schedule_delay: Float(ENV.fetch('OTEL_BLP_SCHEDULE_DELAY', 5_000)),
+                         max_queue_size: Integer(ENV.fetch('OTEL_BLP_MAX_QUEUE_SIZE', 2048)),
+                         max_export_batch_size: Integer(ENV.fetch('OTEL_BLP_MAX_EXPORT_BATCH_SIZE', 512)),
+                         start_thread_on_boot: String(ENV['OTEL_RUBY_BLP_START_THREAD_ON_BOOT']) !~ /false/i,
+                         metrics_reporter: nil)
+            raise ArgumentError if max_export_batch_size > max_queue_size
+            raise ArgumentError, "exporter #{exporter.inspect} does not appear to be a valid exporter" unless Common::Utilities.valid_exporter?(exporter)
+
+            @exporter = exporter
+            @exporter_timeout_seconds = exporter_timeout / 1000.0
+            @mutex = Mutex.new
+            @export_mutex = Mutex.new
+            @condition = ConditionVariable.new
+            @keep_running = true
+            @delay_seconds = schedule_delay / 1000.0
+            @max_queue_size = max_queue_size
+            @batch_size = max_export_batch_size
+            @metrics_reporter = metrics_reporter || OpenTelemetry::SDK::Log::Export::MetricsReporter
+            @logs = []
+            @pid = nil
+            @thread = nil
+            reset_on_fork(restart_thread: start_thread_on_boot)
+          end
+
+          # Adds a log to the batch. Thread-safe; may block on lock.
+          def on_emit(log_data) # rubocop:disable Metrics/AbcSize
+            lock do
+              reset_on_fork
+              n = logs.size + 1 - max_queue_size
+              if n.positive?
+                logs.shift(n)
+                report_dropped_logs(n, reason: 'buffer-full')
+              end
+              logs << log
+              @condition.signal if logs.size > batch_size
+            end
+          end
+
+          # Export all emitted logs to the configured `Exporter` that have not yet
+          # been exported.
+          #
+          # This method should only be called in cases where it is absolutely
+          # necessary, such as when using some FaaS providers that may suspend
+          # the process after an invocation, but before the `Processor` exports
+          # the completed logs.
+          #
+          # @param [optional Numeric] timeout An optional timeout in seconds.
+          # @return [Integer] SUCCESS if no error occurred, FAILURE if a
+          #   non-specific failure occurred, TIMEOUT if a timeout occurred.
+          def force_flush(timeout: nil) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength
+            start_time = OpenTelemetry::Common::Utilities.timeout_timestamp
+            snapshot = lock do
+              reset_on_fork if @keep_running
+              logs.shift(logs.size)
+            end
+            until snapshot.empty?
+              remaining_timeout = OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time)
+              return TIMEOUT if remaining_timeout&.zero?
+
+              batch = snapshot.shift(@batch_size) #.map!(&:to_span_data)
+              result_code = export_batch(batch, timeout: remaining_timeout)
+              return result_code unless result_code == SUCCESS
+            end
+
+            @exporter.force_flush(timeout: OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time))
+          ensure
+            # Unshift the remaining logs if we timed out. We drop excess logs from
+            # the snapshot because they're older than any logs in the logs buffer.
+            lock do
+              n = logs.size + snapshot.size - max_queue_size
+              if n.positive?
+                snapshot.shift(n)
+                report_dropped_logs(n, reason: 'buffer-full')
+              end
+              logs.unshift(snapshot) unless snapshot.empty?
+              @condition.signal if logs.size > max_queue_size / 2
+            end
+          end
+
+          # Shuts the consumer thread down and flushes the current accumulated buffer
+          # will block until the thread is finished.
+          #
+          # @param [optional Numeric] timeout An optional timeout in seconds.
+          # @return [Integer] SUCCESS if no error occurred, FAILURE if a
+          #   non-specific failure occurred, TIMEOUT if a timeout occurred.
+          def shutdown(timeout: nil)
+            start_time = OpenTelemetry::Common::Utilities.timeout_timestamp
+            thread = lock do
+              @keep_running = false
+              @condition.signal
+              @thread
+            end
+
+            thread&.join(timeout)
+            force_flush(timeout: OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time))
+            @exporter.shutdown(timeout: OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time))
+            dropped_logs = lock { logs.size }
+            report_dropped_logs(dropped_logs, reason: 'terminating') if dropped_logs.positive?
+          end
+
+          private
+
+          attr_reader :logs, :max_queue_size, :batch_size
+
+          def work # rubocop:disable Metrics/AbcSize
+            loop do
+              batch = lock do
+                @condition.wait(@mutex, @delay_seconds) if logs.size < batch_size && @keep_running
+                @condition.wait(@mutex, @delay_seconds) while logs.empty? && @keep_running
+                return unless @keep_running
+
+                fetch_batch
+              end
+
+              @metrics_reporter.observe_value('otel.bsp.buffer_utilization', value: spans.size / max_queue_size.to_f)
+
+              export_batch(batch)
+            end
+          end
+
+          def reset_on_fork(restart_thread: true)
+            pid = Process.pid
+            return if @pid == pid
+
+            @pid = pid
+            logs.clear
+            @thread = restart_thread ? Thread.new { work } : nil
+          rescue ThreadError => e
+            @metrics_reporter.add_to_counter('otel.bsp.error', labels: { 'reason' => 'ThreadError' })
+            OpenTelemetry.handle_error(exception: e, message: 'unexpected error in BatchLogProcessor#reset_on_fork')
+          end
+
+          def export_batch(batch, timeout: @exporter_timeout_seconds)
+            result_code = @export_mutex.synchronize { @exporter.export(batch, timeout: timeout) }
+            report_result(result_code, batch)
+            result_code
+          end
+
+          def report_result(result_code, batch)
+            if result_code == SUCCESS
+              @metrics_reporter.add_to_counter('otel.bsp.export.success')
+              @metrics_reporter.add_to_counter('otel.bsp.exported_spans', increment: batch.size)
+            else
+              OpenTelemetry.handle_error(message: "Unable to export #{batch.size} logs")
+              @metrics_reporter.add_to_counter('otel.bsp.export.failure')
+              report_dropped_logs(batch.size, reason: 'export-failure')
+            end
+          end
+
+          def report_dropped_logs(count, reason:)
+            @metrics_reporter.add_to_counter('otel.bsp.dropped_spans', increment: count, labels: { 'reason' => reason })
+          end
+
+          def fetch_batch
+            logs.shift(@batch_size) #.map!(&:to_span_data)
+          end
+
+          def lock
+            @mutex.synchronize do
+              yield
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/log/lib/opentelemetry/sdk/log/export/console_log_exporter.rb
+++ b/log/lib/opentelemetry/sdk/log/export/console_log_exporter.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'pp'
+
+module OpenTelemetry
+  module SDK
+    module Log
+      module Export
+        # Outputs {LogData} to the console.
+        #
+        # Potentially useful for exploratory purposes.
+        class ConsoleLogExporter
+          def initialize
+            @stopped = false
+          end
+
+          def export(logs, timeout: nil)
+            return FAILURE if @stopped
+
+            Array(logs).each { |s| pp s }
+
+            SUCCESS
+          end
+
+          def force_flush(timeout: nil)
+            SUCCESS
+          end
+
+          def shutdown(timeout: nil)
+            @stopped = true
+            SUCCESS
+          end
+        end
+      end
+    end
+  end
+end

--- a/log/lib/opentelemetry/sdk/log/export/in_memory_log_exporter.rb
+++ b/log/lib/opentelemetry/sdk/log/export/in_memory_log_exporter.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Log
+      module Export
+        # A LogExporter implementation that can be used to test OpenTelemetry integration.
+        #
+        # Example usage in a test suite:
+        #
+        # class MyClassTest
+        #   def setup
+        #     @log_emitter_provider = LogEmitterProvider.new
+        #     # The default is `recording: true`, which is appropriate in non-test environments.
+        #     @exporter = InMemoryLogExporter.new(recording: false)
+        #     @log_emitter_provider.add_log_processor(SimpleLogProcessor.new(@exporter))
+        #   end
+        #
+        #   def test_finished_logs
+        #     @exporter.recording = true
+        #     @log_emitter_provider.log_emitter.emit(LogRecord.new(body: "test"))
+        #
+        #     logs = @exporter.emitted_logs
+        #     logs.wont_be_nil
+        #     logs.size.must_equal(1)
+        #     logs[0].body.must_equal("test")
+        #
+        #     @exporter.recording = false
+        #   end
+        class InMemoryLogExporter
+          # Controls whether or not the exporter will export logs, or discard them.
+          # @return [Boolean] when true, the exporter is recording. By default, this is true.
+          attr_accessor :recording
+
+          # Returns a new instance of the {InMemoryLogExporter}.
+          #
+          # @return a new instance of the {InMemoryLogExporter}.
+          def initialize(recording: true)
+            @emitted_logs = []
+            @stopped = false
+            @recording = recording
+            @mutex = Mutex.new
+          end
+
+          # Returns a frozen array of the emitted {LogData}s
+          #
+          # @return [Array<LogData>] a frozen array of the emitted {LogData}s.
+          def emitted_logs
+            @mutex.synchronize do
+              @emitted_logs.clone.freeze
+            end
+          end
+
+          # Clears the internal collection of emitted {LogData}s.
+          #
+          # Does not reset the state of this exporter if already shutdown.
+          def reset
+            @mutex.synchronize do
+              @emitted_logs.clear
+            end
+          end
+
+          # Called to export emitted {LogData}s.
+          #
+          # @param [Enumerable<LogData>] log_datas the list of sampled {LogData}s to be
+          #   exported.
+          # @param [optional Numeric] timeout An optional timeout in seconds.
+          # @return [Integer] the result of the export, SUCCESS or
+          #   FAILURE
+          def export(log_datas, timeout: nil)
+            @mutex.synchronize do
+              return FAILURE if @stopped
+
+              @emitted_logs.concat(log_datas.to_a) if @recording
+            end
+            SUCCESS
+          end
+
+          # Called when {LogEmitterProvider#force_flush} is called, if this exporter is
+          # registered to a {LogEmitterProvider} object.
+          #
+          # @param [optional Numeric] timeout An optional timeout in seconds.
+          # @return [Integer] SUCCESS if no error occurred, FAILURE if a
+          #   non-specific failure occurred, TIMEOUT if a timeout occurred.
+          def force_flush(timeout: nil)
+            SUCCESS
+          end
+
+          # Called when {LogEmitterProvider#shutdown} is called, if this exporter is
+          # registered to a {LogEmitterProvider} object.
+          #
+          # @param [optional Numeric] timeout An optional timeout in seconds.
+          # @return [Integer] SUCCESS if no error occurred, FAILURE if a
+          #   non-specific failure occurred, TIMEOUT if a timeout occurred.
+          def shutdown(timeout: nil)
+            @mutex.synchronize do
+              @emitted_logs.clear
+              @stopped = true
+            end
+            SUCCESS
+          end
+        end
+      end
+    end
+  end
+end

--- a/log/lib/opentelemetry/sdk/log/export/metrics_reporter.rb
+++ b/log/lib/opentelemetry/sdk/log/export/metrics_reporter.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Log
+      module Export
+        # MetricsReporter defines an interface used for reporting metrics from
+        # log processors (like the BatchLogProcessor) and exporters. It can
+        # be used to report metrics such as dropped logs, and successful and
+        # failed export attempts. This exists to decouple the Trace SDK from
+        # the unstable OpenTelemetry Metrics API. An example implementation in
+        # terms of StatsD is:
+        #
+        #   module MetricsReporter
+        #     def add_to_counter(metric, increment: 1, labels: {})
+        #       StatsD.increment(metric, increment, labels, no_prefix: true)
+        #     end
+        #     def record_value(metric, value:, labels: {})
+        #       StatsD.distribution(metric, value, labels, no_prefix: true)
+        #     end
+        #     def observe_value(metric, value:, labels: {})
+        #       StatsD.gauge(metric, value, labels, no_prefix: true)
+        #     end
+        #   end
+        module MetricsReporter
+          extend self
+
+          # Adds an increment to a metric with the provided labels.
+          #
+          # @param [String] metric The metric name.
+          # @param [optional Numeric] increment An optional increment to report.
+          # @param [optional Hash<String, String>] labels Optional labels to
+          #   associate with the metric.
+          def add_to_counter(metric, increment: 1, labels: {}); end
+
+          # Records a value for a metric with the provided labels.
+          #
+          # @param [String] metric The metric name.
+          # @param [Numeric] value The value to report.
+          # @param [optional Hash<String, String>] labels Optional labels to
+          #   associate with the metric.
+          def record_value(metric, value:, labels: {}); end
+
+          # Observes a value for a metric with the provided labels.
+          #
+          # @param [String] metric The metric name.
+          # @param [Numeric] value The value to observe.
+          # @param [optional Hash<String, String>] labels Optional labels to
+          #   associate with the metric.
+          def observe_value(metric, value:, labels: {}); end
+        end
+      end
+    end
+  end
+end

--- a/log/lib/opentelemetry/sdk/log/export/multi_log_exporter.rb
+++ b/log/lib/opentelemetry/sdk/log/export/multi_log_exporter.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Log
+      module Export
+        # Implementation of the LogExporter duck type that simply forwards all
+        # received logs to a collection of LogExporters.
+        #
+        # Can be used to export to multiple backends using the same
+        # LogProcessor like a {SimpleLogProcessor} or a
+        # {BatchLogProcessor}.
+        class MultiLogExporter
+          def initialize(log_exporters)
+            @log_exporters = log_exporters.clone.freeze
+          end
+
+          # Called to export emitted {LogData}s.
+          #
+          # @param [Enumerable<LogData>] spans the list of emitted {LogData}s to be
+          #   exported.
+          # @param [optional Numeric] timeout An optional timeout in seconds.
+          # @return [Integer] the result of the export.
+          def export(logs, timeout: nil)
+            start_time = OpenTelemetry::Common::Utilities.timeout_timestamp
+            results = @log_exporters.map do |log_exporter|
+              log_exporter.export(logs, timeout: OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time))
+            rescue => e # rubocop:disable Style/RescueStandardError
+              OpenTelemetry.logger.warn("exception raised by export - #{e}")
+              FAILURE
+            end
+            results.uniq.max || SUCCESS
+          end
+
+          # Called when {LogEmitterProvider#force_flush} is called, if this exporter is
+          # registered to a {LogEmitterProvider} object.
+          #
+          # @param [optional Numeric] timeout An optional timeout in seconds.
+          # @return [Integer] SUCCESS if no error occurred, FAILURE if a
+          #   non-specific failure occurred, TIMEOUT if a timeout occurred.
+          def force_flush(timeout: nil)
+            start_time = OpenTelemetry::Common::Utilities.timeout_timestamp
+            results = @log_exporters.map do |processor|
+              remaining_timeout = OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time)
+              return TIMEOUT if remaining_timeout&.zero?
+
+              processor.force_flush(timeout: remaining_timeout)
+            end
+            results.uniq.max || SUCCESS
+          end
+
+          # Called when {LogEmitterProvider#shutdown} is called, if this exporter is
+          # registered to a {LogEmitterProvider} object.
+          #
+          # @param [optional Numeric] timeout An optional timeout in seconds.
+          # @return [Integer] SUCCESS if no error occurred, FAILURE if a
+          #   non-specific failure occurred, TIMEOUT if a timeout occurred.
+          def shutdown(timeout: nil)
+            start_time = OpenTelemetry::Common::Utilities.timeout_timestamp
+            results = @log_exporters.map do |processor|
+              remaining_timeout = OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time)
+              return TIMEOUT if remaining_timeout&.zero?
+
+              processor.shutdown(timeout: remaining_timeout)
+            end
+            results.uniq.max || SUCCESS
+          end
+        end
+      end
+    end
+  end
+end

--- a/log/lib/opentelemetry/sdk/log/export/noop_log_exporter.rb
+++ b/log/lib/opentelemetry/sdk/log/export/noop_log_exporter.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Log
+      module Export
+        # A noop exporter that demonstrates and documents the LogExporter
+        # duck type. LogExporter allows different logging services to export
+        # emitted logs in their own format.
+        #
+        # To export data an exporter MUST be registered to the {LogEmitterProvider} using
+        # a {SimpleLogProcessor} or a {BatchLogProcessor}.
+        class NoopLogExporter
+          def initialize
+            @stopped = false
+          end
+
+          # Called to export emitted {LogData}s.
+          #
+          # @param [Enumerable<LogData>] spans the list of emitted logs to be exported.
+          # @param [optional Numeric] timeout An optional timeout in seconds.
+          # @return [Integer] the result of the export.
+          def export(logs, timeout: nil)
+            return SUCCESS unless @stopped
+
+            FAILURE
+          end
+
+          # Called when {LogEmitterProvider#force_flush} is called, if this exporter is
+          # registered to a {LogEmitterProvider} object.
+          #
+          # @param [optional Numeric] timeout An optional timeout in seconds.
+          # @return [Integer] SUCCESS if no error occurred, FAILURE if a
+          #   non-specific failure occurred, TIMEOUT if a timeout occurred.
+          def force_flush(timeout: nil)
+            SUCCESS
+          end
+
+          # Called when {LogEmitterProvider#shutdown} is called, if this exporter is
+          # registered to a {LogEmitterProvider} object.
+          #
+          # @param [optional Numeric] timeout An optional timeout in seconds.
+          def shutdown(timeout: nil)
+            @stopped = true
+            SUCCESS
+          end
+        end
+      end
+    end
+  end
+end

--- a/log/lib/opentelemetry/sdk/log/export/simple_log_processor.rb
+++ b/log/lib/opentelemetry/sdk/log/export/simple_log_processor.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Log
+      module Export
+        # An implementation of the duck type LogProcessor that converts the
+        # {Log} to {LogData} and passes it to the configured exporter.
+        #
+        # Typically, the SimpleLogProcessor will be most suitable for use in testing;
+        # it should be used with caution in production. It may be appropriate for
+        # production use in scenarios where creating multiple threads is not desirable
+        # as well as scenarios where different custom attributes should be added to
+        # individual logs based on code scopes.
+        class SimpleLogProcessor
+          # Returns a new {SimpleLogProcessor} that converts logs for export
+          # and forwards them to the given span_exporter.
+          #
+          # @param log_exporter the (duck type) LogExporter to where the
+          #   emitted logs are pushed.
+          # @return [SimpleLogProcessor]
+          # @raise ArgumentError if the span_exporter is nil.
+          def initialize(log_exporter)
+            raise ArgumentError, "exporter #{log_exporter.inspect} does not appear to be a valid exporter" unless Common::Utilities.valid_exporter?(log_exporter)
+
+            @log_exporter = log_exporter
+          end
+
+          # Called when a {LogRecord} is emitted.
+          #
+          # This method is called synchronously on the execution thread, should
+          # not throw or block the execution thread.
+          #
+          # @param [LogData] log_data the {LogData} that was emitted.
+          def on_emit(log_data)
+            @log_exporter&.export([log_data])
+          rescue => e # rubocop:disable Style/RescueStandardError
+            OpenTelemetry.handle_error(exception: e, message: 'unexpected error in on_emit')
+          end
+
+          # Export all emitted logs to the configured `Exporter` that have not yet
+          # been exported, then call {Exporter#force_flush}.
+          #
+          # This method should only be called in cases where it is absolutely
+          # necessary, such as when using some FaaS providers that may suspend
+          # the process after an invocation, but before the `Processor` exports
+          # the emitted logs.
+          #
+          # @param [optional Numeric] timeout An optional timeout in seconds.
+          # @return [Integer] SUCCESS if no error occurred, FAILURE if a
+          #   non-specific failure occurred, TIMEOUT if a timeout occurred.
+          def force_flush(timeout: nil)
+            @log_exporter&.force_flush(timeout: timeout) || SUCCESS
+          end
+
+          # Called when {LogEmitterProvider#shutdown} is called.
+          #
+          # @param [optional Numeric] timeout An optional timeout in seconds.
+          # @return [Integer] SUCCESS if no error occurred, FAILURE if a
+          #   non-specific failure occurred, TIMEOUT if a timeout occurred.
+          def shutdown(timeout: nil)
+            @log_exporter&.shutdown(timeout: timeout) || SUCCESS
+          end
+        end
+      end
+    end
+  end
+end

--- a/log/lib/opentelemetry/sdk/log/log_data.rb
+++ b/log/lib/opentelemetry/sdk/log/log_data.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    # The Log module contains the OpenTelemetry log reference implementation.
+    module Log
+      # LogData is a Struct containing {LogRecord} data for export.
+      LogData = Struct.new(:timestamp,               # Integer nanoseconds since Epoch
+                           :trace_id,                # optional String (16-byte binary)
+                           :span_id,                 # optional String (8-byte binary)
+                           :trace_flags,             # optional Integer (8-bit byte of bit flags)
+                           :severity_text,           # optional String
+                           :severity_number,         # optional Integer
+                           :name,                    # optional String
+                           :body,                    # optional any
+                           :attributes,              # optional Hash{String => any}
+                           :resource,                # optional OpenTelemetry::SDK::Resources::Resource
+                           :instrumentation_library) # OpenTelemetry::SDK::InstrumentationLibrary
+    end
+  end
+end

--- a/log/lib/opentelemetry/sdk/log/log_emitter.rb
+++ b/log/lib/opentelemetry/sdk/log/log_emitter.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Log
+      # {LogEmitter} emits LogRecords to the registered
+      # LogProcessors for eventual export via the LogExporters
+      class LogEmitter
+        attr_reader :name, :version, :log_emitter_provider
+
+        # @api private
+        #
+        # Returns a new {LogEmitter} instance.
+        #
+        # @param [String] name Instrumentation package name
+        # @param [String] version Instrumentation package version
+        # @param [LogEmitterProvider] log_emitter_provider LogEmitterProvider that initialized the LogEmitter
+        #
+        # @return [LogEmitter]
+        def initialize(name, version, log_emitter_provider)
+          @name = name
+          @version = version
+          @instrumentation_library = InstrumentationLibrary.new(name, version)
+          @log_emitter_provider = log_emitter_provider
+        end
+
+        # Emit a {LogRecord} for processing.
+        #
+        # @param [LogRecord] log_record The log record to be emitted. Callers are expected to have populated the log_record with relevant information from the {Context} if necessary.
+        def emit(log_record)
+          # TODO: if we move flush to this class, we'll also need
+          # to probably move the stopped? check to an appropriate
+          # place.
+          if !log_emitter_provider.stopped?
+            log_emitter_provider.active_log_processor.on_emit(
+              LogData.new(
+                log_record.timestamp,
+                log_record.trace_id,
+                log_record.span_id,
+                log_record.trace_flags,
+                log_record.severity_text,
+                log_record.severity_number,
+                log_record.name,
+                log_record.body,
+                log_record.attributes,
+                log_emitter_provider.resource,
+                @instrumentation_library
+              )
+            )
+          end
+        end
+
+        # @todo the sdk otep specifies that #force should
+        # be here, but the tracing sdks have it on the provider
+        # classes (not the tracer/"emitter" classes)
+        # def flush; end
+      end
+    end
+  end
+end

--- a/log/lib/opentelemetry/sdk/log/log_emitter_provider.rb
+++ b/log/lib/opentelemetry/sdk/log/log_emitter_provider.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Log
+      # Provides a way to construct {LogEmitter}s for use by SDK clients.
+      class LogEmitterProvider
+        Key = Struct.new(:name, :version)
+        private_constant(:Key)
+
+        attr_reader :active_log_processor, :stopped, :resource
+        alias stopped? stopped
+
+        # Returns a new {LogEmitterProvider} instance.
+        #
+        # @return [LogEmitterProvider]
+        def initialize(resource = OpenTelemetry::SDK::Resources::Resource.create)
+          @mutex = Mutex.new
+          @registry = {}
+          @active_log_processor = NoopLogProcessor.instance
+          @registered_log_processors = []
+          @stopped = false
+          @resource = resource
+        end
+
+        # Returns a {LogEmitter} instance.
+        #
+        # @param [optional String] name Instrumentation package name
+        # @param [optional String] version Instrumentation package version
+        #
+        # @return [Tracer]
+        def log_emitter(name = nil, version = nil)
+          name ||= ''
+          version ||= ''
+          @mutex.synchronize { @registry[Key.new(name, version)] ||= LogEmitter.new(name, version, self) }
+        end
+
+        # Attempts to stop all the activity for this {LogEmitter}. Calls
+        # LogProcessor#shutdown for all registered LogProcessors.
+        #
+        # This operation may block until all the Logs are processed. Must be
+        # called before turning off the main application to ensure all data are
+        # processed and exported.
+        #
+        # After this is called all the newly created {Logs}s will be no-op.
+        # @param [optional Numeric] timeout An optional timeout in seconds.
+        def shutdown(timeout: nil)
+          @mutex.synchronize do
+            if @stopped
+              OpenTelemetry.logger.warn('calling LogEmitter#shutdown multiple times.')
+              return
+            end
+            @active_log_processor.shutdown(timeout: timeout)
+            @stopped = true
+          end
+        end
+
+        # Immediately export all logs that have not yet been exported for all the
+        # registered LogProcessors.
+        #
+        # This method should only be called in cases where it is absolutely
+        # necessary, such as when using some FaaS providers that may suspend
+        # the process after an invocation, but before the `Processor` exports
+        # the completed logs.
+        #
+        # @param [optional Numeric] timeout An optional timeout in seconds.
+        # @return [Integer] Export::SUCCESS if no error occurred, Export::FAILURE if
+        #   a non-specific failure occurred, Export::TIMEOUT if a timeout occurred.
+        def force_flush(timeout: nil)
+          @mutex.synchronize do
+            return Export::SUCCESS if @stopped
+
+            @active_log_processor.force_flush(timeout: timeout)
+          end
+        end
+
+        # Adds a new LogProcessor to this {LogEmitter}.
+        #
+        # @param log_processor the new LogProcessor to be added.
+        def add_log_processor(log_processor)
+          @mutex.synchronize do
+            if @stopped
+              OpenTelemetry.logger.warn('calling LogEmitter#add_log_processor after shutdown.')
+              return
+            end
+            @registered_log_processors << log_processor
+            @active_log_processor = if @registered_log_processors.size == 1
+                                       log_processor
+                                     else
+                                       MultiLogProcessor.new(@registered_log_processors.dup)
+                                     end
+          end
+        end
+      end
+    end
+  end
+end

--- a/log/lib/opentelemetry/sdk/log/log_record.rb
+++ b/log/lib/opentelemetry/sdk/log/log_record.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Log
+      # A LogRecord is a single log event.
+      class LogRecord
+        attr_reader \
+          :timestamp,
+          :trace_id,
+          :span_id,
+          :trace_flags,
+          :severity_text,
+          :severity_number,
+          :name,
+          :body,
+          :attributes
+
+        def initialize(
+          timestamp:,
+          trace_id: nil,
+          span_id: nil,
+          trace_flags: nil,
+          severity_text: nil,
+          severity_number: nil,
+          name: nil,
+          body: nil,
+          attributes: nil
+        )
+          @timestamp = timestamp
+          @trace_id = trace_id
+          @span_id = span_id
+          @trace_flags = trace_flags
+          @severity_text = severity_text
+          @severity_number = severity_number
+          @name = name
+          @body = body
+          @attributes = attributes
+        end
+      end
+    end
+  end
+end

--- a/log/lib/opentelemetry/sdk/log/multi_log_processor.rb
+++ b/log/lib/opentelemetry/sdk/log/multi_log_processor.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Log
+      # Implementation of the LogProcessor duck type that simply forwards all
+      # received events to a list of LogProcessors.
+      class MultiLogProcessor
+        # Creates a new {MultiLogProcessor}.
+        #
+        # @param [Enumerable<LogProcessor>] log_processors a collection of
+        #   LogProcessors.
+        # @return [MultiLogProcessor]
+        def initialize(log_processors)
+          @log_processors = log_processors.to_a.freeze
+        end
+
+        # Called when a {LogRecord} is emitted from a {LogEmitter}.
+        #
+        # This method is called synchronously on the execution
+        # thread, should not throw or block the execution thread.
+        #
+        # @param [LogData]
+        def on_emit(log_data)
+          @log_processors.each { |processor| processor.on_emit(log_data) }
+        end
+
+        # Export all log records to the configured `Exporter` that have not yet
+        # been exported.
+        #
+        # This method should only be called in cases where it is absolutely
+        # necessary, such as when using some FaaS providers that may suspend
+        # the process after an invocation, but before the `Processor` exports
+        # the emitted logs.
+        #
+        # @param [optional Numeric] timeout An optional timeout in seconds.
+        # @return [Integer] Export::SUCCESS if no error occurred, Export::FAILURE if
+        #   a non-specific failure occurred, Export::TIMEOUT if a timeout occurred.
+        def force_flush(timeout: nil)
+          start_time = OpenTelemetry::Common::Utilities.timeout_timestamp
+          results = @log_processors.map do |processor|
+            remaining_timeout = OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time)
+            return Export::TIMEOUT if remaining_timeout&.zero?
+
+            processor.force_flush(timeout: remaining_timeout)
+          end
+          results.uniq.max
+        end
+
+        # Called when {LogEmitterProvider#shutdown} is called.
+        #
+        # @param [optional Numeric] timeout An optional timeout in seconds.
+        # @return [Integer] Export::SUCCESS if no error occurred, Export::FAILURE if
+        #   a non-specific failure occurred, Export::TIMEOUT if a timeout occurred.
+        def shutdown(timeout: nil)
+          start_time = OpenTelemetry::Common::Utilities.timeout_timestamp
+          results = @log_processors.map do |processor|
+            remaining_timeout = OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time)
+            return Export::TIMEOUT if remaining_timeout&.zero?
+
+            processor.shutdown(timeout: remaining_timeout)
+          end
+          results.uniq.max
+        end
+      end
+    end
+  end
+end

--- a/log/lib/opentelemetry/sdk/log/noop_log_processor.rb
+++ b/log/lib/opentelemetry/sdk/log/noop_log_processor.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'singleton'
+
+module OpenTelemetry
+  module SDK
+    module Log
+      # NoopLogProcessor is a singleton implementation of the duck type
+      # LogProcessor that provides synchronous no-op hooks for when a
+      # {LogRecord} is emitted.
+      class NoopLogProcessor
+        include Singleton
+
+        # Called when a {LogRecord} is emitted from a {LogEmitter}.
+        #
+        # This method is called synchronously on the execution
+        # thread, should not throw or block the execution thread.
+        #
+        # @param [LogData]
+        def on_emit(log_data); end
+
+        # Export all log records to the configured `Exporter` that have not yet
+        # been exported.
+        #
+        # This method should only be called in cases where it is absolutely
+        # necessary, such as when using some FaaS providers that may suspend
+        # the process after an invocation, but before the `Processor` exports
+        # the emitted logs.
+        #
+        # @param [optional Numeric] timeout An optional timeout in seconds.
+        # @return [Integer] Export::SUCCESS if no error occurred, Export::FAILURE if
+        #   a non-specific failure occurred, Export::TIMEOUT if a timeout occurred.
+        def force_flush(timeout: nil)
+          Export::SUCCESS
+        end
+
+        # Called when {LogEmitterProvider#shutdown} is called.
+        #
+        # @param [optional Numeric] timeout An optional timeout in seconds.
+        # @return [Integer] Export::SUCCESS if no error occurred, Export::FAILURE if
+        #   a non-specific failure occurred, Export::TIMEOUT if a timeout occurred.
+        def shutdown(timeout: nil)
+          Export::SUCCESS
+        end
+      end
+    end
+  end
+end

--- a/log/lib/opentelemetry/sdk/log/version.rb
+++ b/log/lib/opentelemetry/sdk/log/version.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Log
+      ## Current OpenTelemetry version
+      VERSION = '0.0.1'
+    end
+  end
+end

--- a/log/opentelemetry-sdk-log.gemspec
+++ b/log/opentelemetry-sdk-log.gemspec
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'opentelemetry/sdk/log/version'
+
+Gem::Specification.new do |spec|
+  spec.name        = 'opentelemetry-sdk-log'
+  spec.version     = OpenTelemetry::SDK::Log::VERSION
+  spec.authors     = ['OpenTelemetry Authors']
+  spec.email       = ['cncf-opentelemetry-contributors@lists.cncf.io']
+
+  spec.summary     = 'A stats collection and distributed tracing framework - logging component'
+  spec.description = 'A stats collection and distributed tracing framework - logging component'
+  spec.homepage    = 'https://github.com/open-telemetry/opentelemetry-ruby'
+  spec.license     = 'Apache-2.0'
+
+  spec.files = ::Dir.glob('lib/**/*.rb') +
+               ::Dir.glob('*.md') +
+               ['LICENSE', '.yardopts']
+  spec.require_paths = ['lib']
+  spec.required_ruby_version = '>= 2.5.0'
+
+  spec.add_dependency 'opentelemetry-sdk', '~> 1.0.0.rc2'
+
+  spec.add_development_dependency 'bundler', '>= 1.17'
+  spec.add_development_dependency 'faraday', '~> 0.13'
+  spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'rake', '~> 12.0'
+  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'simplecov', '~> 0.17'
+  spec.add_development_dependency 'yard', '~> 0.9'
+  spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-sdk/v#{OpenTelemetry::SDK::Log::VERSION}/file.CHANGELOG.html"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/main/sdk'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/issues'
+    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-sdk/v#{OpenTelemetry::SDK::Log::VERSION}"
+  end
+end


### PR DESCRIPTION
This implements most of the logging SDK otep [1], aside from the OTLP exporters. It uses a few since-removed concepts in the SDK, such a logging equivalent of the 'MultiSpanExporter', but that's okay for now.

I wanted to put this up for people to look at - not because I think it's really *ready* for anything, but I wanted any feedback that people care to offer on the general approach.

Notably:
- There exists, perhaps, an opportunity to generalize the batch span / log processors/exporters into something that can be re-used, somehow. And maybe the MetricsReporter, too!
- This gem is built as something that plugs into the sdk after it's been required, and the configuration is not precisely how I'd want to actually ship this.
- The gem isn't in the release data file, not yet anyways.
- The additional legwork in the example to associate trace/log context from a background thread is an interesting example as to what might be useful from a 'diagnostics api', or something like it.
- I have not yet written tests, so I can only assert that it works correctly because I can see it dump logs to my terminal. But it's probably broken in some ways.
- I copied and pasted a *lot* from the trace SDK, and I think that's obvious once you start reading through it.
- I included a Semantic Logger "appender", which is not required in the OTEP. However, it's not really easy to use the logging SDK without plugging it into another framework: so that shows how it could be done. We'd probably want to ship any "appenders" as their own gems or contribute them directly to the logging libraries in question.

We include a runnable example for people to try.

This is super, super experimental. It'll probably set your computer on fire.

[1] https://github.com/open-telemetry/oteps/blob/main/text/logs/0150-logging-library-sdk.md
