### PR TITLE
fix: split lock in TracerProvider

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
@@ -33,6 +33,7 @@ module OpenTelemetry
                        span_limits: SpanLimits::DEFAULT)
           @mutex = Mutex.new
           @registry = {}
+          @registry_mutex = Mutex.new
           @span_processors = []
           @span_limits = span_limits
           @sampler = sampler
@@ -51,7 +52,7 @@ module OpenTelemetry
           name ||= ''
           version ||= ''
           OpenTelemetry.logger.warn 'calling TracerProvider#tracer without providing a tracer name.' if name.empty?
-          @mutex.synchronize { @registry[Key.new(name, version)] ||= Tracer.new(name, version, self) }
+          @registry_mutex.synchronize { @registry[Key.new(name, version)] ||= Tracer.new(name, version, self) }
         end
 
         # Attempts to stop all the activity for this {TracerProvider}. Calls

--- a/sdk/test/opentelemetry/sdk/trace/tracer_provider_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/tracer_provider_test.rb
@@ -84,6 +84,15 @@ describe OpenTelemetry::SDK::Trace::TracerProvider do
       mock_span_processor.verify
       mock_span_processor2.verify
     end
+
+    it 'does not deadlock if span processor is traced' do
+      span_processor = OpenTelemetry::SDK::Trace::SpanProcessor.new
+      tracer_provider.add_span_processor(span_processor)
+      span_processor.stub(:shutdown, ->(timeout: nil) { tracer_provider.tracer.in_span('shutdown') {} }) do
+        tracer_provider.shutdown
+      end
+      pass 'no deadlock'
+    end
   end
 
   describe '#force_flush' do

--- a/sdk/test/opentelemetry/sdk/trace/tracer_provider_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/tracer_provider_test.rb
@@ -88,7 +88,7 @@ describe OpenTelemetry::SDK::Trace::TracerProvider do
     it 'does not deadlock if span processor is traced' do
       span_processor = OpenTelemetry::SDK::Trace::SpanProcessor.new
       tracer_provider.add_span_processor(span_processor)
-      span_processor.stub(:shutdown, ->(timeout: nil) { tracer_provider.tracer.in_span('shutdown') {} }) do
+      span_processor.stub(:shutdown, ->(timeout: nil) { tracer_provider.tracer.in_span('shutdown') {} }) do # rubocop:disable Lint/UnusedBlockArgument
         tracer_provider.shutdown
       end
       pass 'no deadlock'


### PR DESCRIPTION
TracerProvider can deadlock trying to create a Tracer instance during shutdown. This happens because a single Mutex is used to protect all internal state. The Tracer registry is only accessed in the `#tracer` method, however, (and no other state is accessed in that method) and can be safely protected with its own Mutex.