### PR TITLE
feat!: Update opentelemetry-semantic_conventions to the 1.5.0 spec release

### DIFF
--- a/semantic_conventions/Rakefile
+++ b/semantic_conventions/Rakefile
@@ -10,7 +10,7 @@ require 'yard'
 require 'rubocop/rake_task'
 require 'tmpdir'
 
-SPEC_VERSION = '1.4.0'
+SPEC_VERSION = '1.5.0'
 
 RuboCop::RakeTask.new
 

--- a/semantic_conventions/lib/opentelemetry/semantic_conventions/resource.rb
+++ b/semantic_conventions/lib/opentelemetry/semantic_conventions/resource.rb
@@ -90,17 +90,41 @@ module OpenTelemetry
       # @note It's recommended this value represents a human readable version of the device model rather than a machine readable alternative
       DEVICE_MODEL_NAME = 'device.model.name'
 
-      # The name of the function being executed
+      # The name of the single function that this runtime instance executes
+      # @note This is the name of the function as configured/deployed on the FaaS platform and is usually different from the name of the callback function (which may be stored in the [`code.namespace`/`code.function`](../../trace/semantic_conventions/span-general.md#source-code-attributes) span attributes)
       FAAS_NAME = 'faas.name'
 
-      # The unique ID of the function being executed
-      # @note For example, in AWS Lambda this field corresponds to the [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) value, in GCP to the URI of the resource, and in Azure to the [FunctionDirectory](https://github.com/Azure/azure-functions-host/wiki/Retrieving-information-about-the-currently-running-function) field
+      # The unique ID of the single function that this runtime instance executes
+      # @note Depending on the cloud provider, use:
+      #  
+      #  * **AWS Lambda:** The function [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html).
+      #  Take care not to use the "invoked ARN" directly but replace any
+      #  [alias suffix](https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html) with the resolved function version, as the same runtime instance may be invokable with multiple
+      #  different aliases.
+      #  * **GCP:** The [URI of the resource](https://cloud.google.com/iam/docs/full-resource-names)
+      #  * **Azure:** The [Fully Qualified Resource ID](https://docs.microsoft.com/en-us/rest/api/resources/resources/get-by-id).
+      #  
+      #  On some providers, it may not be possible to determine the full ID at startup,
+      #  which is why this field cannot be made required. For example, on AWS the account ID
+      #  part of the ARN is not available without calling another AWS API
+      #  which may be deemed too slow for a short-running lambda function.
+      #  As an alternative, consider setting `faas.id` as a span attribute instead
       FAAS_ID = 'faas.id'
 
-      # The version string of the function being executed as defined in [Version Attributes](../../resource/semantic_conventions/README.md#version-attributes)
+      # The immutable version of the function being executed
+      # @note Depending on the cloud provider and platform, use:
+      #  
+      #  * **AWS Lambda:** The [function version](https://docs.aws.amazon.com/lambda/latest/dg/configuration-versions.html)
+      #    (an integer represented as a decimal string).
+      #  * **Google Cloud Run:** The [revision](https://cloud.google.com/run/docs/managing/revisions)
+      #    (i.e., the function name plus the revision suffix).
+      #  * **Google Cloud Functions:** The value of the
+      #    [`K_REVISION` environment variable](https://cloud.google.com/functions/docs/env-var#runtime_environment_variables_set_automatically).
+      #  * **Azure Functions:** Not applicable. Do not set this attribute
       FAAS_VERSION = 'faas.version'
 
-      # The execution environment ID as a string
+      # The execution environment ID as a string, that will be potentially reused for other invocations to the same function/function version
+      # @note * **AWS Lambda:** Use the (full) log stream name
       FAAS_INSTANCE = 'faas.instance'
 
       # The amount of memory available to the serverless function in MiB

--- a/semantic_conventions/lib/opentelemetry/semantic_conventions/trace.rb
+++ b/semantic_conventions/lib/opentelemetry/semantic_conventions/trace.rb
@@ -7,6 +7,10 @@
 module OpenTelemetry
   module SemanticConventions
     module Trace
+      # The full invoked ARN as provided on the `Context` passed to the function (`Lambda-Runtime-Invoked-Function-Arn` header on the `/runtime/invocation/next` applicable)
+      # @note This may be different from `faas.id` if an alias is involved
+      AWS_LAMBDA_INVOKED_ARN = 'aws.lambda.invoked_arn'
+
       # An identifier for the database management system (DBMS) product being used. See below for a list of well-known identifiers
       DB_SYSTEM = 'db.system'
 
@@ -277,9 +281,11 @@ module OpenTelemetry
       RPC_SYSTEM = 'rpc.system'
 
       # The name of the service to which a request is made, as returned by the AWS SDK
+      # @note This is the logical name of the service from the RPC interface perspective, which can be different from the name of any implementing class. The `code.namespace` attribute may be used to store the latter (despite the attribute name, it may include a class name; e.g., class with method actually executing the call on the server side, RPC client stub class on the client side)
       RPC_SERVICE = 'rpc.service'
 
       # The name of the operation corresponding to the request, as returned by the AWS SDK
+      # @note This is the logical name of the method from the RPC interface perspective, which can be different from the name of any implementing method/function. The `code.function` attribute may be used to store the latter (e.g., method actually executing the call on the server side, RPC client stub method on the client side)
       RPC_METHOD = 'rpc.method'
 
       # The keys in the `RequestItems` object field
@@ -375,9 +381,6 @@ module OpenTelemetry
 
       # Protocol version as in `jsonrpc` property of request/response. Since JSON-RPC 1.0 does not specify this, the value can be omitted
       RPC_JSONRPC_VERSION = 'rpc.jsonrpc.version'
-
-      # `method` property from request. Unlike `rpc.method`, this may not relate to the actual method being called. Useful for client-side traces since client does not know what will be called on the server
-      RPC_JSONRPC_METHOD = 'rpc.jsonrpc.method'
 
       # `id` property of request or response. Since protocol allows id to be int, string, `null` or missing (for notifications), value is expected to be cast to string for simplicity. Use empty string in case of `null` value. Omit entirely if this is a notification
       RPC_JSONRPC_REQUEST_ID = 'rpc.jsonrpc.request_id'

--- a/semantic_conventions/lib/opentelemetry/semantic_conventions/version.rb
+++ b/semantic_conventions/lib/opentelemetry/semantic_conventions/version.rb
@@ -6,6 +6,6 @@
 
 module OpenTelemetry
   module SemanticConventions
-    VERSION = '1.4.0'
+    VERSION = '1.5.0'
   end
 end


### PR DESCRIPTION
This is a small update. Other than updating the documentation, the spec release:

- Adds the `aws.lambda.invoked_arn` attribute (`OpenTelemetry::SemanticConventions::Trace::AWS_LAMBDA_INVOKED_ARN`)
- Removes the `rpc.jsonrpc.method` attribute (`OpenTelemetry::SemanticConventions::Trace::RPC_JSONRPC_METHOD`)

These do not seem in-use in our repo.
