### PR TITLE
fix: Return the original context if the baggage header value is empty

### DIFF
--- a/api/lib/opentelemetry/baggage/propagation/text_map_propagator.rb
+++ b/api/lib/opentelemetry/baggage/propagation/text_map_propagator.rb
@@ -39,7 +39,8 @@ module OpenTelemetry
         end
 
         # Extract remote baggage from the supplied carrier.
-        # If extraction fails, the original context will be returned
+        # If extraction fails or there is no baggage to extract,
+        # then the original context will be returned
         #
         # @param [Carrier] carrier The carrier to get the header from
         # @param [optional Context] context Context to be updated with the baggage
@@ -52,7 +53,7 @@ module OpenTelemetry
         #   if extraction fails
         def extract(carrier, context: Context.current, getter: Context::Propagation.text_map_getter)
           header = getter.get(carrier, BAGGAGE_KEY)
-          return context unless header
+          return context if header.nil? || header.empty?
 
           entries = header.gsub(/\s/, '').split(',')
 

--- a/api/test/opentelemetry/baggage/propagation/text_map_propagator_test.rb
+++ b/api/test/opentelemetry/baggage/propagation/text_map_propagator_test.rb
@@ -47,6 +47,29 @@ describe OpenTelemetry::Baggage::Propagation::TextMapPropagator do
         assert_value(context, 'key:2', 'val2,2')
       end
     end
+
+    describe 'invalid or no-op headers' do
+      it 'returns the same context object when the headers are not present' do
+        carrier = {}
+        empty_context = Context.empty
+        context = propagator.extract(carrier, context: empty_context)
+        _(context.object_id).must_equal(empty_context.object_id)
+      end
+
+      it 'returns the same context object when the baggage value is a 0-length string' do
+        carrier = { header_key => '' }
+        empty_context = Context.empty
+        context = propagator.extract(carrier, context: empty_context)
+        _(context.object_id).must_equal(empty_context.object_id)
+      end
+
+      it 'does not test for an "empty" string and still replaces the context' do
+        carrier = { header_key => '   ' }
+        empty_context = Context.empty
+        context = propagator.extract(carrier, context: empty_context)
+        _(context.object_id).wont_equal(empty_context.object_id)
+      end
+    end
   end
 
   describe '#inject' do


### PR DESCRIPTION
We don't test for a zero-length string, because I can really only think
of two ways to do it: regular expressions (can be slow) and
`.strip.empty?` (which `dup`s the string and therefore allocates, I
believe). And slowing down or allocating defeats the purpose of what
this change is trying to achieve: *not* slowing down or allocating in
the relatively common case of "there's no baggage to extract."

Note: https://github.com/rails/rails/blob/83217025a171593547d1268651b446d3533e2019/activesupport/lib/active_support/core_ext/object/blank.rb#L122-L124

Fixes #811
