### PR TITLE
fix!: span limits env vars

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/span_limits.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span_limits.rb
@@ -22,10 +22,10 @@ module OpenTelemetry
         attr_reader :link_count_limit
 
         # The global default max number of attributes per {OpenTelemetry::SDK::Trace::Event}.
-        attr_reader :attribute_per_event_count_limit
+        attr_reader :event_attribute_count_limit
 
         # The global default max number of attributes per {OpenTelemetry::Trace::Link}.
-        attr_reader :attribute_per_link_count_limit
+        attr_reader :link_attribute_count_limit
 
         # Returns a {SpanLimits} with the desired values.
         #
@@ -35,21 +35,21 @@ module OpenTelemetry
                        attribute_length_limit: ENV['OTEL_RUBY_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT'],
                        event_count_limit: Integer(ENV.fetch('OTEL_SPAN_EVENT_COUNT_LIMIT', 128)),
                        link_count_limit: Integer(ENV.fetch('OTEL_SPAN_LINK_COUNT_LIMIT', 128)),
-                       attribute_per_event_count_limit: attribute_count_limit,
-                       attribute_per_link_count_limit: attribute_count_limit)
+                       event_attribute_count_limit: Integer(ENV.fetch('OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT', 128)),
+                       link_attribute_count_limit: Integer(ENV.fetch('OTEL_LINK_ATTRIBUTE_COUNT_LIMIT', 128)))
           raise ArgumentError, 'attribute_count_limit must be positive' unless attribute_count_limit.positive?
           raise ArgumentError, 'attribute_length_limit must not be less than 32' unless attribute_length_limit.nil? || Integer(attribute_length_limit) >= 32
           raise ArgumentError, 'event_count_limit must be positive' unless event_count_limit.positive?
           raise ArgumentError, 'link_count_limit must be positive' unless link_count_limit.positive?
-          raise ArgumentError, 'attribute_per_event_count_limit must be positive' unless attribute_per_event_count_limit.positive?
-          raise ArgumentError, 'attribute_per_link_count_limit must be positive' unless attribute_per_link_count_limit.positive?
+          raise ArgumentError, 'event_attribute_count_limit must be positive' unless event_attribute_count_limit.positive?
+          raise ArgumentError, 'link_attribute_count_limit must be positive' unless link_attribute_count_limit.positive?
 
           @attribute_count_limit = attribute_count_limit
           @attribute_length_limit = attribute_length_limit.nil? ? nil : Integer(attribute_length_limit)
           @event_count_limit = event_count_limit
           @link_count_limit = link_count_limit
-          @attribute_per_event_count_limit = attribute_per_event_count_limit
-          @attribute_per_link_count_limit = attribute_per_link_count_limit
+          @event_attribute_count_limit = event_attribute_count_limit
+          @link_attribute_count_limit = link_attribute_count_limit
         end
 
         # The default {SpanLimits}.

--- a/sdk/test/opentelemetry/sdk/trace/span_limits_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/span_limits_test.rb
@@ -15,8 +15,8 @@ describe OpenTelemetry::SDK::Trace::SpanLimits do
       _(config.attribute_count_limit).must_equal 128
       _(config.event_count_limit).must_equal 128
       _(config.link_count_limit).must_equal 128
-      _(config.attribute_per_event_count_limit).must_equal 128
-      _(config.attribute_per_link_count_limit).must_equal 128
+      _(config.event_attribute_count_limit).must_equal 128
+      _(config.link_attribute_count_limit).must_equal 128
     end
 
     it 'reflects environment variables' do
@@ -24,14 +24,16 @@ describe OpenTelemetry::SDK::Trace::SpanLimits do
                'OTEL_SPAN_EVENT_COUNT_LIMIT' => '2',
                'OTEL_SPAN_LINK_COUNT_LIMIT' => '3',
                'OTEL_RUBY_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '32',
+               'OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT' => '5',
+               'OTEL_LINK_ATTRIBUTE_COUNT_LIMIT' => '6',
                'OTEL_TRACES_SAMPLER' => 'always_on') do
         config = subject.new
         _(config.attribute_count_limit).must_equal 1
         _(config.event_count_limit).must_equal 2
         _(config.link_count_limit).must_equal 3
         _(config.attribute_length_limit).must_equal 32
-        _(config.attribute_per_event_count_limit).must_equal 1
-        _(config.attribute_per_link_count_limit).must_equal 1
+        _(config.event_attribute_count_limit).must_equal 5
+        _(config.link_attribute_count_limit).must_equal 6
       end
     end
 
@@ -40,18 +42,20 @@ describe OpenTelemetry::SDK::Trace::SpanLimits do
                'OTEL_SPAN_EVENT_COUNT_LIMIT' => '2',
                'OTEL_SPAN_LINK_COUNT_LIMIT' => '3',
                'OTEL_RUBY_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '4',
+               'OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT' => '5',
+               'OTEL_LINK_ATTRIBUTE_COUNT_LIMIT' => '6',
                'OTEL_TRACES_SAMPLER' => 'always_on') do
         config = subject.new(attribute_count_limit: 10,
                              event_count_limit: 11,
                              link_count_limit: 12,
-                             attribute_per_event_count_limit: 13,
-                             attribute_per_link_count_limit: 14,
+                             event_attribute_count_limit: 13,
+                             link_attribute_count_limit: 14,
                              attribute_length_limit: 32)
         _(config.attribute_count_limit).must_equal 10
         _(config.event_count_limit).must_equal 11
         _(config.link_count_limit).must_equal 12
-        _(config.attribute_per_event_count_limit).must_equal 13
-        _(config.attribute_per_link_count_limit).must_equal 14
+        _(config.event_attribute_count_limit).must_equal 13
+        _(config.link_attribute_count_limit).must_equal 14
         _(config.attribute_length_limit).must_equal 32
       end
     end

--- a/sdk/test/opentelemetry/sdk/trace/span_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/span_test.rb
@@ -19,8 +19,8 @@ describe OpenTelemetry::SDK::Trace::Span do
       attribute_count_limit: 1,
       event_count_limit: 1,
       link_count_limit: 1,
-      attribute_per_event_count_limit: 1,
-      attribute_per_link_count_limit: 1,
+      event_attribute_count_limit: 1,
+      link_attribute_count_limit: 1,
       attribute_length_limit: 32
     )
   end
@@ -250,7 +250,7 @@ describe OpenTelemetry::SDK::Trace::Span do
       SpanLimits.new(
         attribute_count_limit: 10,
         event_count_limit: 5,
-        attribute_per_event_count_limit: 10
+        event_attribute_count_limit: 10
       )
     end
 

--- a/sdk/test/opentelemetry/sdk/trace/tracer_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/tracer_test.rb
@@ -130,7 +130,7 @@ describe OpenTelemetry::SDK::Trace::Tracer do
     end
 
     it 'trims link attributes' do
-      tracer_provider.span_limits = SpanLimits.new(attribute_per_link_count_limit: 1)
+      tracer_provider.span_limits = SpanLimits.new(link_attribute_count_limit: 1)
       link = OpenTelemetry::Trace::Link.new(OpenTelemetry::Trace::SpanContext.new, '1' => 1, '2' => 2)
       span = tracer.start_root_span('root', links: [link])
       _(span.links.first.attributes.size).must_equal(1)
@@ -285,7 +285,7 @@ describe OpenTelemetry::SDK::Trace::Tracer do
     end
 
     it 'trims link attributes' do
-      tracer_provider.span_limits = SpanLimits.new(attribute_per_link_count_limit: 1)
+      tracer_provider.span_limits = SpanLimits.new(link_attribute_count_limit: 1)
       link = OpenTelemetry::Trace::Link.new(OpenTelemetry::Trace::SpanContext.new, '1' => 1, '2' => 2)
       span = tracer.start_span('op', with_parent: context, links: [link])
       _(span.links.first.attributes.size).must_equal(1)


### PR DESCRIPTION
This renames the `attribute_per_event_count_limit` to `event_attribute_count_limit` and `attribute_per_link_count_limit` to `link_attribute_count_limit` in `SpanLimits` to better align with the [environment variable names in the spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#span-collection-limits). It also adds the required environment variables (previously those values inherited their default from the `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT` env var).