### PR TITLE
refactor: split out active support from rails gem

### DIFF
--- a/instrumentation/action_view/lib/opentelemetry/instrumentation/action_view/fanout.rb
+++ b/instrumentation/action_view/lib/opentelemetry/instrumentation/action_view/fanout.rb
@@ -6,7 +6,7 @@
 
 module OpenTelemetry
   module Instrumentation
-    module Rails
+    module ActionView
       # This is a replacement for the default Fanout notifications queue, which adds special
       # handling around returned context from the SpanSubscriber notification handlers.
       # Used together, it allows us to trace arbitrary ActiveSupport::Notifications safely.

--- a/instrumentation/action_view/lib/opentelemetry/instrumentation/action_view/instrumentation.rb
+++ b/instrumentation/action_view/lib/opentelemetry/instrumentation/action_view/instrumentation.rb
@@ -22,9 +22,14 @@ module OpenTelemetry
           Gem.loaded_specs['actionview'].version >= MINIMUM_VERSION
         end
 
+        option :disallowed_notification_payload_keys, default: [],  validate: :array
+        option :notification_payload_transform,       default: nil, validate: :callable
+
         private
 
         def require_dependencies
+          require_relative 'fanout'
+          require_relative 'span_subscriber'
           require_relative 'railtie'
         end
       end

--- a/instrumentation/action_view/lib/opentelemetry/instrumentation/action_view/railtie.rb
+++ b/instrumentation/action_view/lib/opentelemetry/instrumentation/action_view/railtie.rb
@@ -16,12 +16,12 @@ module OpenTelemetry
       # This Railtie sets up subscriptions to relevant ActionView notifications
       class Railtie < ::Rails::Railtie
         config.before_initialize do
-          OpenTelemetry::Instrumentation::Rails::Instrumentation.instance.install({})
+          ::ActiveSupport::Notifications.notifier = Fanout.new
         end
 
         config.after_initialize do
           SUBSCRIPTIONS.each do |subscription_name|
-            subscriber = OpenTelemetry::Instrumentation::Rails::SpanSubscriber.new(
+            subscriber = OpenTelemetry::Instrumentation::ActionView::SpanSubscriber.new(
               name: subscription_name,
               tracer: ActionView::Instrumentation.instance.tracer
             )

--- a/instrumentation/action_view/lib/opentelemetry/instrumentation/action_view/span_subscriber.rb
+++ b/instrumentation/action_view/lib/opentelemetry/instrumentation/action_view/span_subscriber.rb
@@ -6,7 +6,7 @@
 
 module OpenTelemetry
   module Instrumentation
-    module Rails
+    module ActionView
       # The SpanSubscriber is a special ActiveSupport::Notification subscription
       # handler which turns notifications into generic spans, taking care to handle
       # context appropriately.
@@ -50,7 +50,7 @@ module OpenTelemetry
         private
 
         def instrumentation_config
-          Rails::Instrumentation.instance.config
+          ActionView::Instrumentation.instance.config
         end
 
         def transform_payload(payload)

--- a/instrumentation/action_view/opentelemetry-instrumentation-action_view.gemspec
+++ b/instrumentation/action_view/opentelemetry-instrumentation-action_view.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk'
+  spec.add_development_dependency 'rails'
   spec.add_development_dependency 'rake', '~> 12.3.3'
   spec.add_development_dependency 'rubocop', '~> 0.73.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'

--- a/instrumentation/action_view/test/opentelemetry/instrumentation/action_view/fanout_test.rb
+++ b/instrumentation/action_view/test/opentelemetry/instrumentation/action_view/fanout_test.rb
@@ -6,13 +6,13 @@
 
 require 'test_helper'
 
-describe OpenTelemetry::Instrumentation::Rails::Fanout do
-  let(:tracer) { OpenTelemetry::Instrumentation::Rails::Instrumentation.instance.tracer }
+describe OpenTelemetry::Instrumentation::ActionView::Fanout do
+  let(:tracer) { OpenTelemetry::Instrumentation::ActionView::Instrumentation.instance.tracer }
   let(:exporter) { EXPORTER }
   let(:spans) { exporter.finished_spans }
   let(:last_span) { spans.last }
   let(:span_subscriber) do
-    OpenTelemetry::Instrumentation::Rails::SpanSubscriber.new(
+    OpenTelemetry::Instrumentation::ActionView::SpanSubscriber.new(
       name: 'bar.foo',
       tracer: tracer
     )
@@ -20,7 +20,7 @@ describe OpenTelemetry::Instrumentation::Rails::Fanout do
 
   before do
     exporter.reset
-    ::ActiveSupport::Notifications.notifier = OpenTelemetry::Instrumentation::Rails::Fanout.new
+    ::ActiveSupport::Notifications.notifier = OpenTelemetry::Instrumentation::ActionView::Fanout.new
   end
 
   it 'sorts span subscribers first' do

--- a/instrumentation/action_view/test/opentelemetry/instrumentation/action_view/span_subscriber_test.rb
+++ b/instrumentation/action_view/test/opentelemetry/instrumentation/action_view/span_subscriber_test.rb
@@ -6,13 +6,13 @@
 
 require 'test_helper'
 
-describe OpenTelemetry::Instrumentation::Rails::SpanSubscriber do
-  let(:instrumentation) { OpenTelemetry::Instrumentation::Rails::Instrumentation.instance }
+describe OpenTelemetry::Instrumentation::ActionView::SpanSubscriber do
+  let(:instrumentation) { OpenTelemetry::Instrumentation::ActionView::Instrumentation.instance }
   let(:tracer) { instrumentation.tracer }
   let(:exporter) { EXPORTER }
   let(:last_span) { exporter.finished_spans.last }
   let(:subscriber) do
-    OpenTelemetry::Instrumentation::Rails::SpanSubscriber.new(
+    OpenTelemetry::Instrumentation::ActionView::SpanSubscriber.new(
       name: 'bar.foo',
       tracer: tracer
     )
@@ -30,7 +30,7 @@ describe OpenTelemetry::Instrumentation::Rails::SpanSubscriber do
   end
 
   it 'uses the provided tracer' do
-    subscriber = OpenTelemetry::Instrumentation::Rails::SpanSubscriber.new(
+    subscriber = OpenTelemetry::Instrumentation::ActionView::SpanSubscriber.new(
       name: 'oh.hai',
       tracer: OpenTelemetry.tracer_provider.tracer('foo')
     )

--- a/instrumentation/rails/lib/opentelemetry/instrumentation/rails/instrumentation.rb
+++ b/instrumentation/rails/lib/opentelemetry/instrumentation/rails/instrumentation.rb
@@ -23,15 +23,11 @@ module OpenTelemetry
         end
 
         option :enable_recognize_route, default: false, validate: :boolean
-        option :disallowed_notification_payload_keys, default: [], validate: :array
-        option :notification_payload_transform, default: nil, validate: :callable
 
         private
 
         def require_dependencies
           require_relative 'patches/action_controller/metal'
-          require_relative 'fanout'
-          require_relative 'span_subscriber'
         end
 
         def require_railtie

--- a/instrumentation/rails/lib/opentelemetry/instrumentation/rails/railtie.rb
+++ b/instrumentation/rails/lib/opentelemetry/instrumentation/rails/railtie.rb
@@ -12,8 +12,6 @@ module OpenTelemetry
       # the Rails application through its initialization hooks.
       class Railtie < ::Rails::Railtie
         config.before_initialize do |app|
-          ::ActiveSupport::Notifications.notifier = Fanout.new
-
           OpenTelemetry::Instrumentation::ActiveRecord::Instrumentation.instance.install({})
           OpenTelemetry::Instrumentation::Rack::Instrumentation.instance.install({})
 


### PR DESCRIPTION
Splitting apart the rails component instrumentation dependencies from the rails instrumentation gem itself.

Similar to https://github.com/open-telemetry/opentelemetry-ruby/pull/878