### PR TITLE
feat: OTEL_EXPORTER_JAEGER_TIMEOUT env var

### DIFF
--- a/exporter/jaeger/lib/opentelemetry/exporter/jaeger/collector_exporter.rb
+++ b/exporter/jaeger/lib/opentelemetry/exporter/jaeger/collector_exporter.rb
@@ -28,6 +28,7 @@ module OpenTelemetry
         def initialize(endpoint: ENV.fetch('OTEL_EXPORTER_JAEGER_ENDPOINT', 'http://localhost:14268/api/traces'),
                        username: ENV['OTEL_EXPORTER_JAEGER_USER'],
                        password: ENV['OTEL_EXPORTER_JAEGER_PASSWORD'],
+                       timeout: ENV.fetch('OTEL_EXPORTER_JAEGER_TIMEOUT', 10),
                        ssl_verify_mode: CollectorExporter.ssl_verify_mode)
           raise ArgumentError, "invalid url for Jaeger::CollectorExporter #{endpoint}" if invalid_url?(endpoint)
           raise ArgumentError, 'username and password should either both be nil or both be set' if username.nil? != password.nil?

--- a/exporter/jaeger/test/opentelemetry/exporters/jaeger/agent_exporter_test.rb
+++ b/exporter/jaeger/test/opentelemetry/exporters/jaeger/agent_exporter_test.rb
@@ -11,6 +11,20 @@ describe OpenTelemetry::Exporter::Jaeger::AgentExporter do
       exporter = OpenTelemetry::Exporter::Jaeger::AgentExporter.new(host: '127.0.0.1', port: 6831)
       _(exporter).wont_be_nil
     end
+
+    it 'sets parameters from the environment' do
+      exp = with_env('OTEL_EXPORTER_JAEGER_TIMEOUT' => '42') do
+        OpenTelemetry::Exporter::Jaeger::AgentExporter.new
+      end
+      _(exp.instance_variable_get(:@timeout)).must_equal 42.0
+    end
+
+    it 'prefers explicit parameters rather than the environment' do
+      exp = with_env('OTEL_EXPORTER_JAEGER_TIMEOUT' => '42') do
+        OpenTelemetry::Exporter::Jaeger::AgentExporter.new(timeout: 60)
+      end
+      _(exp.instance_variable_get(:@timeout)).must_equal 60.0
+    end
   end
 
   describe '#export' do


### PR DESCRIPTION
Fixes #752

The Zipkin collector already supports the required env var.

Note that the timeout is ignored for the CollectorExporter because we don't have control over timeouts at this layer. We could use `Timeout::timeout` but I'm not confident that will work as designed, and not screw up some internal state in the Thrift gem.