### PR TITLE
fix: rails instrumentation to not explicitly install sub gems

### DIFF
--- a/instrumentation/action_pack/README.md
+++ b/instrumentation/action_pack/README.md
@@ -30,6 +30,17 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
+### Configuration options
+
+The `http.route` attribute is disabled by default because we use [.recognize](https://github.com/rails/rails/blob/v6.1.3/actionpack/lib/action_dispatch/journey/router.rb#L65)
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::ActionPack', {
+    enable_recognize_route: true
+  }
+end
+```
+
 ## Examples
 
 Example usage can be seen in the `./example/trace_demonstration.rb` file [here](https://github.com/open-telemetry/opentelemetry-ruby/blob/main/instrumentation/action_pack/example/trace_demonstration.ru)

--- a/instrumentation/rails/README.md
+++ b/instrumentation/rails/README.md
@@ -14,15 +14,7 @@ Or, if you use [bundler][bundler-home], include `opentelemetry-instrumentation-r
 
 ## Usage
 
-To use the instrumentation, call `use` with the name of the instrumentation:
-
-```ruby
-OpenTelemetry::SDK.configure do |c|
-  c.use 'OpenTelemetry::Instrumentation::Rails'
-end
-```
-
-Alternatively, you can also call `use_all` to install all the available instrumentation.
+To use the Rails instrumentation, call `use_all` so it installs all the instrumentation gems.
 
 ```ruby
 OpenTelemetry::SDK.configure do |c|
@@ -30,15 +22,14 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
-
 ### Configuration options
 
-The `http.route` attribute is disabled by default because we use [.recognize](https://github.com/rails/rails/blob/v6.1.3/actionpack/lib/action_dispatch/journey/router.rb#L65)
+The Rails instrumentation attempts to mirror the structure of the Ruby on Rails.  It is a collection of instrumentation gems for components of Rails such as Action View, Active Record, Action Pack, etc...
+
+You may want to include all of the Rails instrumentation but disable a single instrumentation gem that it includes.  Here is an example of how you can disable Active Record when using this instrumentation gem.
 ```ruby
 OpenTelemetry::SDK.configure do |c|
-  c.use 'OpenTelemetry::Instrumentation::Rails', {
-    enable_recognize_route: true
-  }
+  c.use_all({ 'OpenTelemetry::Instrumentation::ActiveRecord' => { enabled: false } })
 end
 ```
 

--- a/instrumentation/rails/lib/opentelemetry/instrumentation/rails/instrumentation.rb
+++ b/instrumentation/rails/lib/opentelemetry/instrumentation/rails/instrumentation.rb
@@ -14,19 +14,12 @@ module OpenTelemetry
       class Instrumentation < OpenTelemetry::Instrumentation::Base
         MINIMUM_VERSION = Gem::Version.new('5.2.0')
 
-        install do |_config|
-          OpenTelemetry::Instrumentation::ActionPack::Instrumentation.instance.install({})
-          OpenTelemetry::Instrumentation::ActionView::Instrumentation.instance.install({})
-          OpenTelemetry::Instrumentation::ActiveRecord::Instrumentation.instance.install({})
-        end
-
-        present do
-          defined?(::Rails)
-        end
-
-        compatible do
-          gem_version >= MINIMUM_VERSION
-        end
+        # This gem requires the instrumentantion gems for the different
+        # components of Rails, as a result it does not have any explicit
+        # work to do in the install step.
+        install { true }
+        present { defined?(::Rails) }
+        compatible { gem_version >= MINIMUM_VERSION }
 
         private
 

--- a/instrumentation/rails/test/opentelemetry/instrumentation/rails/instrumentation_test.rb
+++ b/instrumentation/rails/test/opentelemetry/instrumentation/rails/instrumentation_test.rb
@@ -7,7 +7,7 @@
 require 'test_helper'
 
 describe OpenTelemetry::Instrumentation::Rails::Instrumentation do
-  it 'adds the tracing middleware' do
+  it 'adds the rack tracing middleware' do
     _(DEFAULT_RAILS_APP.config.middleware).must_include OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware
   end
 end

--- a/instrumentation/rails/test/test_helper.rb
+++ b/instrumentation/rails/test/test_helper.rb
@@ -20,7 +20,7 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
-  c.use 'OpenTelemetry::Instrumentation::Rails'
+  c.use_all
   c.add_span_processor span_processor
 end
 


### PR DESCRIPTION
> Add config options for opting out of any sub gem instrumentation.

Follow up from https://github.com/open-telemetry/opentelemetry-ruby/pull/878

