### PR TITLE
docs: Add reference to otel versioning / stability doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ gems, including Rails, Rack, Sinatra, and others, so you can start
 using OpenTelemetry with minimal changes to your application. See the
 [instrumentation README](instrumentation/) for more.
 
+## Versioning
+
+OpenTelemetry Ruby follows the [versioning and stability document](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/versioning-and-stability.md) in the OpenTelemetry specification. Notably, we adhere to the outlined version numbering exception, which states that experimental signals may have a `0.x` version number.
+
 ## Who's using OpenTelemetry Ruby?
 
 OpenTelemetry Ruby is in use by a number of companies, including:


### PR DESCRIPTION
This inserts a reference to the OpenTelemetry client library stability document. #507 laid out an alternate proposal from last year, but our gems have not evolved in quite the way described and it didn't seem to provide much aside from what the upstream document already contains. Moreover, I think we're expected to adhere to the upstream stability document, so I'm not sure we really need a separate one.

This is not to say that we should never adopt additional policies or guarantees within this repo, but it is to say "none seem to be needed right now, and so it doesn't feel necessary to block 1.0 any longer." Anything we adopt in the future will necessarily be somehow compatibile with (or a superset of) the OpenTelemetry stability guarantees, so this feels like a good baseline to me.

Fixes #507
