### PR TITLE
feat: Update to semantic conventions v1.6.0

### DIFF
--- a/semantic_conventions/Rakefile
+++ b/semantic_conventions/Rakefile
@@ -10,7 +10,7 @@ require 'yard'
 require 'rubocop/rake_task'
 require 'tmpdir'
 
-SPEC_VERSION = '1.5.0'
+SPEC_VERSION = '1.6.0'
 
 RuboCop::RakeTask.new
 

--- a/semantic_conventions/lib/opentelemetry/semantic_conventions/resource.rb
+++ b/semantic_conventions/lib/opentelemetry/semantic_conventions/resource.rb
@@ -13,11 +13,11 @@ module OpenTelemetry
       # The cloud account ID the resource is assigned to
       CLOUD_ACCOUNT_ID = 'cloud.account.id'
 
-      # The geographical region the resource is running. Refer to your provider's docs to see the available regions, for example [AWS regions](https://aws.amazon.com/about-aws/global-infrastructure/regions_az/), [Azure regions](https://azure.microsoft.com/en-us/global-infrastructure/geographies/), or [Google Cloud regions](https://cloud.google.com/about/locations)
+      # The geographical region the resource is running. Refer to your provider's docs to see the available regions, for example [Alibaba Cloud regions](https://www.alibabacloud.com/help/doc-detail/40654.htm), [AWS regions](https://aws.amazon.com/about-aws/global-infrastructure/regions_az/), [Azure regions](https://azure.microsoft.com/en-us/global-infrastructure/geographies/), or [Google Cloud regions](https://cloud.google.com/about/locations)
       CLOUD_REGION = 'cloud.region'
 
       # Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the zone where the resource is running
-      # @note Availability zones are called "zones" on Google Cloud
+      # @note Availability zones are called "zones" on Alibaba Cloud and Google Cloud
       CLOUD_AVAILABILITY_ZONE = 'cloud.availability_zone'
 
       # The cloud platform in use

--- a/semantic_conventions/lib/opentelemetry/semantic_conventions/trace.rb
+++ b/semantic_conventions/lib/opentelemetry/semantic_conventions/trace.rb
@@ -193,6 +193,24 @@ module OpenTelemetry
       # Local hostname or similar, see note below
       NET_HOST_NAME = 'net.host.name'
 
+      # The internet connection type currently being used by the host
+      NET_HOST_CONNECTION_TYPE = 'net.host.connection.type'
+
+      # This describes more details regarding the connection.type. It may be the type of cell technology connection, but it could be used for describing details about a wifi connection
+      NET_HOST_CONNECTION_SUBTYPE = 'net.host.connection.subtype'
+
+      # The name of the mobile carrier
+      NET_HOST_CARRIER_NAME = 'net.host.carrier.name'
+
+      # The mobile carrier country code
+      NET_HOST_CARRIER_MCC = 'net.host.carrier.mcc'
+
+      # The mobile carrier network code
+      NET_HOST_CARRIER_MNC = 'net.host.carrier.mnc'
+
+      # The ISO 3166-1 alpha-2 2-character country code associated with the mobile carrier network
+      NET_HOST_CARRIER_ICC = 'net.host.carrier.icc'
+
       # A string identifying the messaging system
       MESSAGING_SYSTEM = 'messaging.system'
 

--- a/semantic_conventions/lib/opentelemetry/semantic_conventions/version.rb
+++ b/semantic_conventions/lib/opentelemetry/semantic_conventions/version.rb
@@ -6,6 +6,6 @@
 
 module OpenTelemetry
   module SemanticConventions
-    VERSION = '1.5.0'
+    VERSION = '1.6.0'
   end
 end


### PR DESCRIPTION
Other than documentation updates which reference the Alibaba cloud, this
release adds support for a few new network conventions:

- `net.host.connection.type`
- `net.host.connection.subtype`
- `net.host.carrier.name`
- `net.host.carrier.mcc`
- `net.host.carrier.mnc`
- `net.host.carrier.icc`
