### PR TITLE
chore: fix ci flake

### DIFF
--- a/sdk/test/opentelemetry/sdk/trace/tracer_provider_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/tracer_provider_test.rb
@@ -60,8 +60,8 @@ describe OpenTelemetry::SDK::Trace::TracerProvider do
     it 'warns if called more than once' do
       mock_logger = Minitest::Mock.new
       mock_logger.expect(:warn, nil, [String])
+      tracer_provider.shutdown
       OpenTelemetry.stub :logger, mock_logger do
-        tracer_provider.shutdown
         tracer_provider.shutdown
       end
       mock_logger.verify


### PR DESCRIPTION
```
Run options: --seed=29606 -v

# Running:

OpenTelemetry::SDK::Trace::Samplers::.parent_based#test_0003_delegates sampling of remote not sampled spans = 0.00 s = .
OpenTelemetry::SDK::Trace::Samplers::.parent_based#test_0005_delegates sampling of local not sampled spans = 0.00 s = .
OpenTelemetry::SDK::Trace::Samplers::.parent_based#test_0006_delegates sampling of root spans = 0.00 s = .
OpenTelemetry::SDK::Trace::Samplers::.parent_based#test_0001_provides defaults for parent samplers = 0.00 s = .
OpenTelemetry::SDK::Trace::Samplers::.parent_based#test_0002_delegates sampling of remote sampled spans = 0.00 s = .
OpenTelemetry::SDK::Trace::Samplers::.parent_based#test_0004_delegates sampling of local sampled spans = 0.00 s = .
OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor::fork safety test#test_0001_when ThreadError is raised it handles it gracefully = 0.00 s = .
OpenTelemetry::SDK::Trace::TracerProvider::#shutdown#test_0002_warns if called more than once = 0.00 s = E
OpenTelemetry::SDK::Trace::TracerProvider::#shutdown#test_0003_only notifies the span processor once = 0.00 s = .
OpenTelemetry::SDK::Trace::TracerProvider::#shutdown#test_0001_notifies the span processor = 0.00 s = .
OpenTelemetry::SDK::Trace::TracerProvider::#shutdown#test_0004_supports multiple span processors = 0.00 s = .
OpenTelemetry::SDK::Trace::TracerProvider::#shutdown#test_0005_does not deadlock if span processor is traced = 0.00 s = .
OpenTelemetry::SDK::Trace::TracerProvider::#force_flush#test_0001_notifies the span processor = 0.00 s = .
OpenTelemetry::SDK::Trace::TracerProvider::#force_flush#test_0002_supports multiple span processors = 0.00 s = .
OpenTelemetry::SDK::Configurator::#logger#test_0002_assigns the logger to OpenTelemetry.logger = 0.00 s = .
OpenTelemetry::SDK::Configurator::#logger#test_0001_returns a logger instance = 0.00 s = .
OpenTelemetry::SDK::Configurator::#logger#test_0003_respects the supplied loggers severity level = 0.00 s = .
OpenTelemetry::SDK::Configurator::#logger#test_0004_allows control of the otel log level = 0.00 s = .
OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor::fork safety test::when a process fork occurs#test_0001_creates new work thread when on_finish is called = 0.00 s = .
OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor::fork safety test::when a process fork occurs#test_0002_creates new work thread when force_flush = 0.00 s = .
OpenTelemetry::SDK::API_trace::tracing child-of-local spans#test_0001_traces child-of-local spans = 0.00 s = .
OpenTelemetry::SDK::Resources::Resource::.new#test_0001_is private = 0.00 s = .
OpenTelemetry::SDK::Trace::Samplers::Result::#initialize#test_0001_accepts Decision constants = 0.00 s = .
OpenTelemetry::SDK::Trace::Samplers::Result::#initialize#test_0002_replaces invalid decisions with default = 0.00 s = .
OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor::#force_flush#test_0001_reenqueues excess spans on timeout = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#name=#test_0001_sets the name = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#name=#test_0002_does not set the name if span is ended = 0.00 s = .
OpenTelemetry::SDK::Trace::Samplers::.ALWAYS_ON#test_0002_passes through the tracestate from context = 0.00 s = .
OpenTelemetry::SDK::Trace::Samplers::.ALWAYS_ON#test_0001_samples = 0.00 s = .
OpenTelemetry::SDK::Trace::TracerProvider::#add_span_processor#test_0001_does not add the processor if stopped = 0.00 s = .
OpenTelemetry::SDK::Trace::TracerProvider::#add_span_processor#test_0003_adds multiple span processors to the active span processors = 0.00 s = .
OpenTelemetry::SDK::Trace::TracerProvider::#add_span_processor#test_0002_adds the span processor to the active span processors = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#set_attribute#test_0003_truncates attribute value length based if configured = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#set_attribute#test_0008_reports an error for an invalid key = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#set_attribute#test_0005_counts attributes = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#set_attribute#test_0001_sets an attribute = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#set_attribute#test_0007_reports an error for an invalid value = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#set_attribute#test_0004_does not set an attribute if span is ended = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#set_attribute#test_0002_trims the oldest attribute = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#set_attribute#test_0006_accepts an array value = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#add_event#test_0006_accepts array-valued attributes if the elements are true and false = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#add_event#test_0011_truncates event attributes values if configured = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#add_event#test_0002_add event with attributes = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#add_event#test_0012_trims event attributes with array values = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#add_event#test_0004_does not accept array-valued attributes if any elements are invalid = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#add_event#test_0005_does not accept array-valued attributes if the elements are different types = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#add_event#test_0014_trims excess events = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#add_event#test_0008_add event with timestamp = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#add_event#test_0003_accepts array-valued attributes = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#add_event#test_0010_trims event attributes = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#add_event#test_0007_accepts array-valued attributes if the array is empty = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#add_event#test_0001_add a named event = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#add_event#test_0013_counts events = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#add_event#test_0009_does not add an event if span is ended = 0.00 s = .
OpenTelemetry::SDK::#configure#test_0001_logs the original error when a configuration error occurs = 0.00 s = .
OpenTelemetry::SDK::global_tracer_configurations::global tracer configurations::#finished_spans#test_0002_first span is child1 = 0.00 s = .
OpenTelemetry::SDK::global_tracer_configurations::global tracer configurations::#finished_spans#test_0003_are all SpanData = 0.00 s = .
OpenTelemetry::SDK::global_tracer_configurations::global tracer configurations::#finished_spans#test_0001_has 3 = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_root_span#test_0011_ignores the implicit current span context = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_root_span#test_0010_creates a span with sampler attributes added after supplied attributes = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_root_span#test_0002_returns a valid span = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_root_span#test_0003_creates a span with IDs generated by the configured id_generator = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_root_span#test_0001_provides a default name = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_root_span#test_0009_creates a span with all supplied parameters = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_root_span#test_0006_returns a sampled span if sampler says sample = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_root_span#test_0004_returns a no-op span if sampler says do not record events = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_root_span#test_0013_trims links = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_root_span#test_0007_calls the sampler with all parameters except parent_context = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_root_span#test_0005_returns an unsampled span if sampler says record, but do not sample = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_root_span#test_0008_returns a no-op span if tracer has shutdown = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_root_span#test_0012_trims link attributes = 0.00 s = .
OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor::lifecycle#test_0001_should stop and start correctly = 0.00 s = .
OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor::lifecycle#test_0002_should flush everything on shutdown = 0.00 s = .
OpenTelemetry::SDK::Trace::Samplers::Result::#recording?#test_0001_returns true when decision is RECORD_AND_SAMPLE = 0.00 s = .
OpenTelemetry::SDK::Trace::Samplers::Result::#recording?#test_0002_returns true when decision is RECORD_ONLY = 0.00 s = .
OpenTelemetry::SDK::Trace::Samplers::Result::#recording?#test_0003_returns false when decision is DROP = 0.00 s = .
OpenTelemetry::SDK::API_trace::tracing root spans#test_0001_traces root spans = 0.00 s = .
OpenTelemetry::SDK::API_trace::tracing root spans#test_0002_root has a child = 0.00 s = .
OpenTelemetry::SDK::API_trace::tracing root spans#test_0003_root has accurate total_recorded_links = 0.00 s = .
OpenTelemetry::SDK::API_trace::tracing root spans#test_0004_doesn't have links = 0.00 s = .
OpenTelemetry::SDK::API_trace::tracing with links#test_0001_span has links = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_span#test_0004_returns a span with the parent context span ID = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_span#test_0010_returns a no-op span with parent trace ID if tracer has shutdown = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_span#test_0016_uses the implicit current span context by default = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_span#test_0018_trims links = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_span#test_0008_returns a sampled span if sampler says sample = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_span#test_0006_returns a no-op span if sampler says do not record events = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_span#test_0012_creates a span with the provided instrumentation library = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_span#test_0014_creates a span with sampler attributes added after supplied attributes = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_span#test_0015_uses the context from parent if supplied = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_span#test_0003_returns a span with the same trace ID as the parent context = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_span#test_0011_creates a span with IDs generated by the configured id_generator = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_span#test_0002_returns a valid span = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_span#test_0005_returns a span with the parent context tracestate = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_span#test_0007_returns an unsampled span if sampler says record, but do not sample = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_span#test_0009_calls the sampler with all parameters = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_span#test_0013_creates a span with all supplied parameters = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_span#test_0017_trims link attributes = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#start_span#test_0001_provides a default name = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#initialize#test_0003_truncates attributes if configured = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#initialize#test_0006_trims excess links = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#initialize#test_0005_counts links = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#initialize#test_0001_calls the span processor #on_start callback = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#initialize#test_0002_trims excess attributes = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#initialize#test_0004_counts attributes = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#initialize#test_0007_prunes invalid links = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#add_attributes#test_0003_truncates attribute value length based if configured = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#add_attributes#test_0002_trims the oldest attributes = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#add_attributes#test_0001_sets attributes = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#add_attributes#test_0004_does not set an attribute if span is ended = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#add_attributes#test_0006_accepts an array value = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#add_attributes#test_0005_counts attributes = 0.00 s = .
OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor::#shutdown#test_0002_works if the thread is not running = 0.00 s = .
OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor::#shutdown#test_0001_respects the timeout = 0.00 s = .
OpenTelemetry::SDK::Trace::SpanProcessor#test_0003_implements #force_flush = 0.00 s = .
OpenTelemetry::SDK::Trace::SpanProcessor#test_0001_implements #on_start = 0.00 s = .
OpenTelemetry::SDK::Trace::SpanProcessor#test_0002_implements #on_finish = 0.00 s = .
OpenTelemetry::SDK::Trace::SpanProcessor#test_0004_implements #shutdown = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#status=#test_0001_sets the status = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#status=#test_0003_does not set the status if asked to set to UNSET = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#status=#test_0004_does not override the status once set to OK = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#status=#test_0005_allows overriding ERROR with OK = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#status=#test_0002_does not set the status if span is ended = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#events#test_0001_is frozen = 0.00 s = .
OpenTelemetry::SDK::global_tracer_configurations::using tracestate in extracted span context::#finished_spans#test_0001_propogates tracestate through span lifecycle into SpanData = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#record_exception#test_0003_encodes the stacktrace = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#record_exception#test_0001_records error as an event = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#record_exception#test_0002_merges optional attributes = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#record_exception#test_0004_records multiple errors = 0.00 s = .
OpenTelemetry::SDK::Trace::Tracer::#in_span#test_0001_records and reraises exceptions = 0.00 s = .
OpenTelemetry::SDK::Trace::SpanLimits::#initialize#test_0002_reflects environment variables = 0.00 s = .
OpenTelemetry::SDK::Trace::SpanLimits::#initialize#test_0003_reflects explicit overrides = 0.00 s = .
OpenTelemetry::SDK::Trace::SpanLimits::#initialize#test_0001_provides defaults = 0.00 s = .
OpenTelemetry::SDK::Trace::Samplers::.ALWAYS_OFF#test_0001_does not sample = 0.00 s = .
OpenTelemetry::SDK::Trace::Samplers::.ALWAYS_OFF#test_0002_passes through the tracestate from context = 0.00 s = .
OpenTelemetry::SDK::Resources::Resource::.telemetry_sdk#test_0001_returns a resource for the telemetry sdk = 0.00 s = .
OpenTelemetry::SDK::Trace::Samplers::Result::#tracestate#test_0001_reflects the value passed in = 0.00 s = .
OpenTelemetry::SDK::Resources::Resource::.telemetry_sdk::when the environment variable is present#test_0001_includes environment resources = 0.00 s = .
OpenTelemetry::SDK::Trace::TracerProvider::#initialize#test_0001_activates a default SpanLimits and Sampler = 0.00 s = .
OpenTelemetry::SDK::Trace::TracerProvider::#initialize#test_0002_configures samplers from environment = 0.00 s = .
OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor::batching#test_0001_should batch up to but not over the max_batch = 0.00 s = .
OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor::batching#test_0002_should batch only recording samples = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#recording?#test_0001_returns true = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#recording?#test_0002_returns false when span is finished = 0.00 s = .
OpenTelemetry::SDK::Resources::Resource::.process#test_0001_returns a resource for the process and runtime = 0.00 s = .
OpenTelemetry::SDK::Trace::TracerProvider::#tracer#test_0002_returns different tracers for different names = 0.00 s = .
OpenTelemetry::SDK::Trace::TracerProvider::#tracer#test_0003_returns different tracers for different versions = 0.00 s = .
OpenTelemetry::SDK::Trace::TracerProvider::#tracer#test_0001_returns the same tracer for the same arguments = 0.00 s = .
OpenTelemetry::SDK::Trace::TracerProvider::#tracer#test_0004_warn when no name is passed for the tracer = 0.00 s = .
OpenTelemetry::SDK::Trace::Span::#attributes#test_0001_is frozen = 0.00 s = .
OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter#test_0006_returns error from #export after #shutdown called = 0.00 s = .
OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter#test_0002_accepts an Enumerable of SpanDatas as argument to #export = 0.00 s = .
OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter#test_0007_returns an empty array from #export after #shutdown called = 0.00 s = .
OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter#test_0001_accepts an Array of SpanDatas as argument to #export = 0.00 s = .
OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter#test_0004_allows additional calls to #export after #finished_spans = 0.00 s = .
OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter#test_0008_records nothing if #recording is false = 0.00 s = .
OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter#test_0003_freezes the return of #finished_spans = 0.00 s = .
OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter#test_0005_returns success from #export = 0.00 s = .
OpenTelemetry::SDK::Configurator::#configure::propagators#test_0004_defaults to none with invalid env var = 0.00 s = .
OpenTelemetry::SDK::Configurator::#configure::propagators#test_0001_defaults to trace context and baggage = 0.00 s = .
OpenTelemetry::SDK::Configurator::#configure::propagators#test_0003_can be set by environment variable = 0.00 s = .
OpenTelemetry::SDK::Configurator::#configure::propagators#test_0002_is user settable = 0.00 s = .
OpenTelemetry::SDK::Configurator::#configure::instrumentation installation#test_0001_installs single instrumentation = 0.00 s = .
OpenTelemetry::SDK::Configurator::#configure::instrumentation installation#test_0002_installs all = 0.00 s = .
OpenTelemetry::SDK::Configurator::#configure::span processors#test_0003_can be set by environment variable = 0.00 s = .
OpenTelemetry::SDK::Configurator::#configure::span processors#test_0002_reflects configured value = 0.00 s = .
OpenTelemetry::SDK::Configurator::#configure::span processors#test_0005_accepts comma separated list as an environment variable = 0.00 s = .
OpenTelemetry::SDK::Configurator::#configure::span processors#test_0001_defaults to no processors if no valid exporter is available = 0.00 s = .
OpenTelemetry::SDK::Configurator::#configure::span processors#test_0007_accepts "console" as an environment variable value = 0.00 s = .
OpenTelemetry::SDK::Configurator::#configure::span processors#test_0004_accepts "none" as an environment variable value = 0.00 s = .
OpenTelemetry::SDK::Configurator::#configure::span processors#test_0006_accepts comma separated list with preceeding or trailing spaces as an environment variable = 0.00 s = .
OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor::stress test#test_0001_shouldnt blow up with a lot of things = 
Finished in 0.710633s, 240.6305 runs/s, 408.0869 assertions/s.

  1) Error:
OpenTelemetry::SDK::Trace::TracerProvider::#shutdown#test_0002_warns if called more than once:
NameError: undefined method `debug' for class `#<Class:#<Minitest::Mock:0x00007f86b258e400>>'
Did you mean?  debugger
    /Users/terrpi/src/github.com/open-telemetry/opentelemetry-ruby/sdk/test/opentelemetry/sdk/trace/tracer_provider_test.rb:62:in `block (3 levels) in <top (required)>'

171 runs, 290 assertions, 0 failures, 1 errors, 0 skips
Coverage report generated for Integration Tests to /Users/terrpi/src/github.com/open-telemetry/opentelemetry-ruby/sdk/coverage. 1983 / 2323 LOC (85.36%) covered.

```