### PR TITLE
fix: test ci error, pin toys

### DIFF
--- a/.github/workflows/release-retry.yml
+++ b/.github/workflows/release-retry.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Install Toys
-        run: "gem install --no-document toys"
+        run: "gem install --no-document toys:0.11.5"
       - name: Retry release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Testing a suspect ci issue by pinning toys to 0.11.5
https://github.com/open-telemetry/opentelemetry-ruby/runs/3343455325?check_suite_focus=true#step:5:429
https://github.com/dazuma/toys/commit/474cf17a0f2b6c37c5add20168d4914ffb118bd5#diff-5a2aea7ff7ffb53950632cc40ab93b62a922e4d24cb67c81656ce63d3109073aR30