### PR TITLE
fix: rack middleware assuming script_name presence

### DIFF
--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
@@ -121,18 +121,11 @@ module OpenTelemetry
               'http.method' => env['REQUEST_METHOD'],
               'http.host' => env['HTTP_HOST'] || 'unknown',
               'http.scheme' => env['rack.url_scheme'],
-              'http.target' => fullpath(env)
+              'http.target' => env['QUERY_STRING'].empty? ? env['PATH_INFO'] : "#{env['PATH_INFO']}?#{env['QUERY_STRING']}"
             }
+
             attributes['http.user_agent'] = env['HTTP_USER_AGENT'] if env['HTTP_USER_AGENT']
-            attributes.merge(allowed_request_headers(env))
-          end
-
-          # e.g., "/webshop/articles/4?s=1":
-          def fullpath(env)
-            query_string = env['QUERY_STRING']
-            path = env['SCRIPT_NAME'] + env['PATH_INFO']
-
-            query_string.empty? ? path : "#{path}?#{query_string}"
+            attributes.merge!(allowed_request_headers(env))
           end
 
           # https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-http.md#name


### PR DESCRIPTION
```
Minitest::UnexpectedError: NoMethodError: undefined method `+' for nil:NilClass
--
  | /app/vendor/bundle/ruby/2.7.0/gems/opentelemetry-instrumentation-rack-0.19.0/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb:133:in `fullpath'
```

It seems it is not safe to assume that `SCRIPT_NAME` will always be present.

>SCRIPT_NAME
>The initial portion of the request URL's “path” that corresponds to the application object, so that the application knows its >virtual “location”. This may be an empty string, if the application corresponds to the “root” of the server.
https://github.com/rack/rack/blob/master/SPEC.rdoc