### PR TITLE
chore: Revert pin of toys

### DIFF
--- a/.github/workflows/release-retry.yml
+++ b/.github/workflows/release-retry.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Install Toys
-        run: "gem install --no-document toys:0.11.5"
+        run: "gem install --no-document toys"
       - name: Retry release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Toys 0.12.1 is released, which should fix #912.

attn: @robertlaurin 