### PR TITLE
feat: trace update_all and delete_all calls in ActiveRecord

### DIFF
--- a/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/instrumentation.rb
+++ b/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/instrumentation.rb
@@ -50,6 +50,8 @@ module OpenTelemetry
           ::ActiveRecord::Base.prepend(Patches::PersistenceInsertClassMethods) if insert_class_methods_supported?
           ::ActiveRecord::Base.prepend(Patches::TransactionsClassMethods)
           ::ActiveRecord::Base.prepend(Patches::Validations)
+
+          ::ActiveRecord::Relation.prepend(Patches::RelationPersistence)
         end
 
         def require_dependencies
@@ -59,6 +61,7 @@ module OpenTelemetry
           require_relative 'patches/persistence_insert_class_methods' if insert_class_methods_supported?
           require_relative 'patches/transactions_class_methods'
           require_relative 'patches/validations'
+          require_relative 'patches/relation_persistence'
         end
       end
     end

--- a/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/patches/relation_persistence.rb
+++ b/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/patches/relation_persistence.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Instrumentation
+    module ActiveRecord
+      module Patches
+        # Module to prepend to ActiveRecord::Relation for instrumentation
+        module RelationPersistence
+          def update_all(*)
+            tracer.in_span("#{model.name}.update_all") do
+              super
+            end
+          end
+
+          def delete_all(*)
+            tracer.in_span("#{model.name}.delete_all") do
+              super
+            end
+          end
+
+          private
+
+          def tracer
+            ActiveRecord::Instrumentation.instance.tracer
+          end
+        end
+      end
+    end
+  end
+end

--- a/instrumentation/active_record/test/instrumentation/active_record/patches/relation_persistence_test.rb
+++ b/instrumentation/active_record/test/instrumentation/active_record/patches/relation_persistence_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+require_relative '../../../../lib/opentelemetry/instrumentation/active_record'
+require_relative '../../../../lib/opentelemetry/instrumentation/active_record/patches/relation_persistence'
+
+describe OpenTelemetry::Instrumentation::ActiveRecord::Patches::RelationPersistence do
+  let(:exporter) { EXPORTER }
+  let(:spans) { exporter.finished_spans }
+
+  before { exporter.reset }
+
+  describe '.update_all' do
+    it 'traces' do
+      User.update_all(name: 'new name')
+      update_all_span = spans.find { |s| s.name == 'User.update_all' }
+      _(update_all_span).wont_be_nil
+      _(spans.count).must_equal(1)
+    end
+
+    it 'traces scoped calls' do
+      User.recently_created.update_all(name: 'new name')
+      update_all_span = spans.find { |s| s.name == 'User.update_all' }
+      _(update_all_span).wont_be_nil
+      _(spans.count).must_equal(1)
+    end
+  end
+
+  describe '.delete_all' do
+    it 'traces' do
+      User.delete_all
+      delete_all_span = spans.find { |s| s.name == 'User.delete_all' }
+      _(delete_all_span).wont_be_nil
+      _(spans.count).must_equal(1)
+    end
+
+    it 'traces scoped calls' do
+      User.recently_created.delete_all
+      delete_all_span = spans.find { |s| s.name == 'User.delete_all' }
+      _(delete_all_span).wont_be_nil
+      _(spans.count).must_equal(1)
+    end
+  end
+end

--- a/instrumentation/active_record/test/test_helper.rb
+++ b/instrumentation/active_record/test/test_helper.rb
@@ -29,6 +29,8 @@ ActiveRecord::Base.establish_connection(
 class User < ActiveRecord::Base
   validate :name_if_present
 
+  scope :recently_created, -> { where('created_at > ?', Time.now - 3600) }
+
   def name_if_present
     errors.add(:base, 'must be otel') if name.present? && name != 'otel'
   end


### PR DESCRIPTION
We often use code like:
```
  Product
    .where(...)
    .where(...)
    .update_all(attributes)
```
This allows doing atomic updates and avoid N+1 queries. `update_all` and
`delete_all` however were not traced.

I initially thought about putting these to `PersistenceClassMethods`
module but that doesn't work when scopes are used. These calls create
`ActiveRecord::Relation` instance which seemed a better place to patch.
I also added tests to ensure these calls are also traced when scopes are
not used.