### PR TITLE
fix: instrumentation all sidekiq

### DIFF
--- a/instrumentation/all/opentelemetry-instrumentation-all.gemspec
+++ b/instrumentation/all/opentelemetry-instrumentation-all.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-instrumentation-resque', '~> 0.1.0'
   spec.add_dependency 'opentelemetry-instrumentation-restclient', '~> 0.19.0'
   spec.add_dependency 'opentelemetry-instrumentation-ruby_kafka', '~> 0.18.1'
-  spec.add_dependency 'opentelemetry-instrumentation-sidekiq', '~> 0.19.0'
+  spec.add_dependency 'opentelemetry-instrumentation-sidekiq', '~> 0.20.0'
   spec.add_dependency 'opentelemetry-instrumentation-sinatra', '~> 0.19.0'
 
   spec.add_development_dependency 'bundler', '>= 1.17'


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-ruby/issues/922
```
opentelemetry-instrumentation-all: bundle
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Bundler could not find compatible versions for gem
"opentelemetry-instrumentation-sidekiq":
  In Gemfile:
    opentelemetry-instrumentation-sidekiq

    opentelemetry-instrumentation-all was resolved to 0.20.0, which depends on
      opentelemetry-instrumentation-sidekiq (~> 0.19.0)

Could not find gem 'opentelemetry-instrumentation-sidekiq (~> 0.19.0)', which is
required by gem 'opentelemetry-instrumentation-all', in source at `../sidekiq`.
FAILURE
opentelemetry-instrumentation-all: test
```
