### PR TITLE
Use 4318 as the default OLTP exporter port

### DIFF
--- a/exporter/otlp/README.md
+++ b/exporter/otlp/README.md
@@ -70,7 +70,7 @@ The collector exporter can be configured explicitly in code, or via environment 
 
 | Parameter           | Environment variable                         | Default                             |
 | ------------------- | -------------------------------------------- | ----------------------------------- |
-| `endpoint:`         | `OTEL_EXPORTER_OTLP_ENDPOINT`                | `"http://localhost:4317/v1/traces"` |
+| `endpoint:`         | `OTEL_EXPORTER_OTLP_ENDPOINT`                | `"http://localhost:4318/v1/traces"` |
 | `certificate_file: `| `OTEL_EXPORTER_OTLP_CERTIFICATE`             |                                     |
 | `headers:`          | `OTEL_EXPORTER_OTLP_HEADERS`                 |                                     |
 | `compression:`      | `OTEL_EXPORTER_OTLP_COMPRESSION`             |                                     |

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -41,7 +41,7 @@ module OpenTelemetry
           end
         end
 
-        def initialize(endpoint: config_opt('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', 'OTEL_EXPORTER_OTLP_ENDPOINT', default: 'https://localhost:4317/v1/traces'), # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength
+        def initialize(endpoint: config_opt('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', 'OTEL_EXPORTER_OTLP_ENDPOINT', default: 'https://localhost:4318/v1/traces'), # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength
                        certificate_file: config_opt('OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE', 'OTEL_EXPORTER_OTLP_CERTIFICATE'),
                        ssl_verify_mode: Exporter.ssl_verify_mode,
                        headers: config_opt('OTEL_EXPORTER_OTLP_TRACES_HEADERS', 'OTEL_EXPORTER_OTLP_HEADERS'),

--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -23,7 +23,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       _(http.use_ssl?).must_equal true
       _(http.address).must_equal 'localhost'
       _(http.verify_mode).must_equal OpenSSL::SSL::VERIFY_PEER
-      _(http.port).must_equal 4317
+      _(http.port).must_equal 4318
     end
 
     it 'refuses invalid headers' do
@@ -139,27 +139,27 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       skip unless ENV['TRACING_INTEGRATION_TEST']
       WebMock.disable_net_connect!(allow: 'localhost')
       span_data = create_span_data
-      exporter = OpenTelemetry::Exporter::OTLP::Exporter.new(endpoint: 'http://localhost:4317', compression: 'gzip')
+      exporter = OpenTelemetry::Exporter::OTLP::Exporter.new(endpoint: 'http://localhost:4318', compression: 'gzip')
       result = exporter.export([span_data])
       _(result).must_equal(SUCCESS)
     end
 
     it 'retries on timeout' do
-      stub_request(:post, 'https://localhost:4317/v1/traces').to_timeout.then.to_return(status: 200)
+      stub_request(:post, 'https://localhost:4318/v1/traces').to_timeout.then.to_return(status: 200)
       span_data = create_span_data
       result = exporter.export([span_data])
       _(result).must_equal(SUCCESS)
     end
 
     it 'returns TIMEOUT on timeout' do
-      stub_request(:post, 'https://localhost:4317/v1/traces').to_return(status: 200)
+      stub_request(:post, 'https://localhost:4318/v1/traces').to_return(status: 200)
       span_data = create_span_data
       result = exporter.export([span_data], timeout: 0)
       _(result).must_equal(TIMEOUT)
     end
 
     it 'returns TIMEOUT on timeout after retrying' do
-      stub_request(:post, 'https://localhost:4317/v1/traces').to_timeout.then.to_raise('this should not be reached')
+      stub_request(:post, 'https://localhost:4318/v1/traces').to_timeout.then.to_raise('this should not be reached')
       span_data = create_span_data
 
       @retry_count = 0
@@ -183,7 +183,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
     end
 
     it 'returns FAILURE when encryption to receiver endpoint fails' do
-      stub_request(:post, 'https://localhost:4317/v1/traces').to_raise(OpenSSL::SSL::SSLError.new('enigma wedged'))
+      stub_request(:post, 'https://localhost:4318/v1/traces').to_raise(OpenSSL::SSL::SSLError.new('enigma wedged'))
       span_data = create_span_data
       exporter.stub(:backoff?, ->(**_) { false }) do
         _(exporter.export([span_data])).must_equal(FAILURE)
@@ -191,7 +191,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
     end
 
     it 'exports a span_data' do
-      stub_request(:post, 'https://localhost:4317/v1/traces').to_return(status: 200)
+      stub_request(:post, 'https://localhost:4318/v1/traces').to_return(status: 200)
       span_data = create_span_data
       result = exporter.export([span_data])
       _(result).must_equal(SUCCESS)
@@ -202,7 +202,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       logger = OpenTelemetry.logger
       OpenTelemetry.logger = ::Logger.new(log_stream)
 
-      stub_request(:post, 'https://localhost:4317/v1/traces').to_return(status: 200)
+      stub_request(:post, 'https://localhost:4318/v1/traces').to_return(status: 200)
       span_data = create_span_data(total_recorded_attributes: 1, attributes: { 'a' => "\xC2".dup.force_encoding(::Encoding::ASCII_8BIT) })
 
       result = exporter.export([span_data])
@@ -217,7 +217,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
     end
 
     it 'exports a span from a tracer' do
-      stub_post = stub_request(:post, 'https://localhost:4317/v1/traces').to_return(status: 200)
+      stub_post = stub_request(:post, 'https://localhost:4318/v1/traces').to_return(status: 200)
       processor = OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(exporter, max_queue_size: 1, max_export_batch_size: 1)
       OpenTelemetry.tracer_provider.add_span_processor(processor)
       OpenTelemetry.tracer_provider.tracer.start_root_span('foo').finish
@@ -227,7 +227,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
 
     it 'compresses with gzip if enabled' do
       exporter = OpenTelemetry::Exporter::OTLP::Exporter.new(compression: 'gzip')
-      stub_post = stub_request(:post, 'https://localhost:4317/v1/traces').to_return do |request|
+      stub_post = stub_request(:post, 'https://localhost:4318/v1/traces').to_return do |request|
         Opentelemetry::Proto::Collector::Trace::V1::ExportTraceServiceRequest.decode(Zlib.gunzip(request.body))
         { status: 200 }
       end
@@ -241,7 +241,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
 
     it 'batches per resource' do
       etsr = nil
-      stub_post = stub_request(:post, 'https://localhost:4317/v1/traces').to_return do |request|
+      stub_post = stub_request(:post, 'https://localhost:4318/v1/traces').to_return do |request|
         etsr = Opentelemetry::Proto::Collector::Trace::V1::ExportTraceServiceRequest.decode(request.body)
         { status: 200 }
       end
@@ -257,7 +257,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
     end
 
     it 'translates all the things' do
-      stub_request(:post, 'https://localhost:4317/v1/traces').to_return(status: 200)
+      stub_request(:post, 'https://localhost:4318/v1/traces').to_return(status: 200)
       processor = OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(exporter)
       tracer = OpenTelemetry.tracer_provider.tracer('tracer', 'v0.0.1')
       other_tracer = OpenTelemetry.tracer_provider.tracer('other_tracer')
@@ -418,7 +418,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
         )
       )
 
-      assert_requested(:post, 'https://localhost:4317/v1/traces') do |req|
+      assert_requested(:post, 'https://localhost:4318/v1/traces') do |req|
         req.body == encoded_etsr
       end
     end


### PR DESCRIPTION
The collector has changed to use port 4318 by default in https://github.com/open-telemetry/opentelemetry-collector/pull/3743.