### PR TITLE
feat: Faraday instrumentation installs OTel middleware first in handler list

### DIFF
--- a/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/patches/rack_builder.rb
+++ b/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/patches/rack_builder.rb
@@ -11,12 +11,11 @@ module OpenTelemetry
         # Module to be prepended to force Faraday to use the middleware by
         # default so the user doesn't have to call `use` for every connection.
         module RackBuilder
-          def adapter(*args)
-            use(:open_telemetry) unless @handlers.any? do |handler|
-              handler.klass == Faraday::Middlewares::TracerMiddleware
+          def initialize(*args, &block)
+            super(*args) do |*bargs|
+              use :open_telemetry
+              block&.call(*bargs)
             end
-
-            super
           end
         end
       end

--- a/instrumentation/faraday/opentelemetry-instrumentation-faraday.gemspec
+++ b/instrumentation/faraday/opentelemetry-instrumentation-faraday.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'faraday', '~> 0.17.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.0.0.rc1'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'


### PR DESCRIPTION
This allows propagation headers to be added before other middleware that may depend on them being installed, such as
[faraday_middleware-aws-sigv4](/winebarrel/faraday_middleware-aws-sigv4), which does a signature calculation that hashes all headers. If the headers are installed last, the signature calculation will not match the servers's hash value.