### PR TITLE
fix: keep Active Support subscriptions intact when patching

### DIFF
--- a/instrumentation/action_view/lib/opentelemetry/instrumentation/action_view/fanout.rb
+++ b/instrumentation/action_view/lib/opentelemetry/instrumentation/action_view/fanout.rb
@@ -3,6 +3,8 @@
 # Copyright The OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+require 'delegate'
 
 module OpenTelemetry
   module Instrumentation
@@ -10,7 +12,11 @@ module OpenTelemetry
       # This is a replacement for the default Fanout notifications queue, which adds special
       # handling around returned context from the SpanSubscriber notification handlers.
       # Used together, it allows us to trace arbitrary ActiveSupport::Notifications safely.
-      class Fanout < ::ActiveSupport::Notifications::Fanout
+      class Fanout < DelegateClass(::ActiveSupport::Notifications::Fanout)
+        def initialize(notifier = ::ActiveSupport::Notifications::Fanout.new)
+          super(notifier)
+        end
+
         def start(name, id, payload)
           listeners_for(name).map do |s|
             result = [s]

--- a/instrumentation/action_view/lib/opentelemetry/instrumentation/action_view/railtie.rb
+++ b/instrumentation/action_view/lib/opentelemetry/instrumentation/action_view/railtie.rb
@@ -16,7 +16,7 @@ module OpenTelemetry
       # This Railtie sets up subscriptions to relevant ActionView notifications
       class Railtie < ::Rails::Railtie
         config.before_initialize do
-          ::ActiveSupport::Notifications.notifier = Fanout.new
+          ::ActiveSupport::Notifications.notifier = Fanout.new(::ActiveSupport::Notifications.notifier)
         end
 
         config.after_initialize do

--- a/instrumentation/action_view/test/opentelemetry/instrumentation/action_view/fanout_test.rb
+++ b/instrumentation/action_view/test/opentelemetry/instrumentation/action_view/fanout_test.rb
@@ -74,10 +74,13 @@ describe OpenTelemetry::Instrumentation::ActionView::Fanout do
       end
 
       ::ActiveSupport::Notifications.notifier = OpenTelemetry::Instrumentation::ActionView::Fanout.new(::ActiveSupport::Notifications.notifier)
+      ::ActiveSupport::Notifications.subscribe('render', span_subscriber)
 
       ActiveSupport::Notifications.instrument('render', extra: :information)
 
-      assert notification_fired
+      _(last_span).wont_be_nil
+      _(last_span.name).must_equal('foo bar')
+      _(notification_fired).must_equal(true)
     end
   end
 end

--- a/instrumentation/action_view/test/opentelemetry/instrumentation/action_view/fanout_test.rb
+++ b/instrumentation/action_view/test/opentelemetry/instrumentation/action_view/fanout_test.rb
@@ -68,9 +68,8 @@ describe OpenTelemetry::Instrumentation::ActionView::Fanout do
       exporter.reset
       ::ActiveSupport::Notifications.notifier = ActiveSupport::Notifications::Fanout.new
 
-
       notification_fired = false
-      ActiveSupport::Notifications.subscribe('render') do |*args|
+      ActiveSupport::Notifications.subscribe('render') do |*_args|
         notification_fired = true
       end
 


### PR DESCRIPTION
Recently encountered an issue where subscriptions that happen earlier get dropped when we override `notifier`. Here is my attempt at keeping the subscriptions by using `DelegateClass`

I confirmed by running the added test on main branch

![image](https://user-images.githubusercontent.com/38668303/132037910-1ef6b852-3d0d-4a0f-9856-604d61fdbb6c.png)
