### PR TITLE
fix: Use Kafka::VERSION fallback for compatibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -180,6 +180,29 @@ services:
     image: memcached:alpine
     command: memcached -m 64
 
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    ports:
+      - 2181:2181
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  kafka:
+    image: confluentinc/cp-kafka:latest
+    ports:
+      - "9092:9092"
+      - "29092:29092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:29092,PLAINTEXT_HOST://kafka:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    depends_on:
+      - zookeeper
+
   sdk:
     <<: *base
     working_dir: /app/sdk

--- a/instrumentation/ruby_kafka/README.md
+++ b/instrumentation/ruby_kafka/README.md
@@ -40,6 +40,29 @@ The `opentelemetry-instrumentation-ruby_kafka` gem source is [on github][repo-gi
 
 The OpenTelemetry Ruby gems are maintained by the OpenTelemetry-Ruby special interest group (SIG). You can get involved by joining us in [GitHub Discussions][discussions-url] or attending our weekly meeting. See the [meeting calendar][community-meetings] for dates and times. For more information on this and other language SIGs, see the OpenTelemetry [community page][ruby-sig].
 
+### Running Tests
+
+Tests in this package require a running instance of Kafka and Zookeeper, which are made available via `docker-compose`:
+
+```bash
+ruby-kafka $> docker-compose up -d kafka
+ Creating network "ruby_kafka_default" with the default driver
+ Creating ruby_kafka_zookeeper_1 ... done
+ Creating ruby_kafka_kafka_1     ... done
+```
+
+The run tests using `rake`
+
+```bash
+ruby-kafka $> bundle exec rake test
+```
+
+To stop the dependent services
+
+```bash
+ruby-kafka $> docker-compose down
+```
+
 ## License
 
 The `opentelemetry-instrumentation-ruby_kafka` gem is distributed under the Apache 2.0 license. See [LICENSE][license-github] for more information.

--- a/instrumentation/ruby_kafka/docker-compose.yml
+++ b/instrumentation/ruby_kafka/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3.5"
+
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    ports:
+      - 2181:2181
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  kafka:
+    image: confluentinc/cp-kafka:latest
+    ports:
+      - "9092:9092"
+      - "29092:29092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:29092,PLAINTEXT_HOST://kafka:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    depends_on:
+      - zookeeper

--- a/instrumentation/ruby_kafka/lib/opentelemetry/instrumentation/ruby_kafka/instrumentation.rb
+++ b/instrumentation/ruby_kafka/lib/opentelemetry/instrumentation/ruby_kafka/instrumentation.rb
@@ -22,13 +22,13 @@ module OpenTelemetry
         end
 
         compatible do
-          gem_version >= MINIMUM_VERSION
+          (!gem_version.nil? && gem_version >= MINIMUM_VERSION)
         end
 
         private
 
         def gem_version
-          Gem.loaded_specs['ruby-kafka'].version
+          Gem.loaded_specs['ruby-kafka']&.version || Gem::Version.new(Kafka::VERSION)
         end
 
         def require_patches

--- a/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/instrumentation_test.rb
+++ b/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/instrumentation_test.rb
@@ -43,6 +43,21 @@ describe OpenTelemetry::Instrumentation::RubyKafka::Instrumentation do
         _(instrumentation.compatible?).must_equal true
       end
     end
+
+    describe "when the installing application bypasses RubyGems" do
+      it 'falls back to the VERSION constant' do
+        stub_const("Kafka::VERSION", "0.6.9")
+        Gem.stub(:loaded_specs, 'ruby-kafka' => nil) do
+          _(instrumentation.compatible?).must_equal false
+        end
+
+        version = ::OpenTelemetry::Instrumentation::RubyKafka::Instrumentation::MINIMUM_VERSION.version
+        stub_const("Kafka::VERSION", version)
+        Gem.stub(:loaded_specs, 'ruby-kafka' => nil) do
+          _(instrumentation.compatible?).must_equal true
+        end
+      end
+    end
   end
 
   describe '#install' do

--- a/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/instrumentation_test.rb
+++ b/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/instrumentation_test.rb
@@ -44,15 +44,15 @@ describe OpenTelemetry::Instrumentation::RubyKafka::Instrumentation do
       end
     end
 
-    describe "when the installing application bypasses RubyGems" do
+    describe 'when the installing application bypasses RubyGems' do
       it 'falls back to the VERSION constant' do
-        stub_const("Kafka::VERSION", "0.6.9")
+        stub_const('Kafka::VERSION', '0.6.9')
         Gem.stub(:loaded_specs, 'ruby-kafka' => nil) do
           _(instrumentation.compatible?).must_equal false
         end
 
         version = ::OpenTelemetry::Instrumentation::RubyKafka::Instrumentation::MINIMUM_VERSION.version
-        stub_const("Kafka::VERSION", version)
+        stub_const('Kafka::VERSION', version)
         Gem.stub(:loaded_specs, 'ruby-kafka' => nil) do
           _(instrumentation.compatible?).must_equal true
         end


### PR DESCRIPTION
Some applications bypass Ruby Gems when loading dependencies,
which results in a `nil` variable being returned by `Gem.loaded_specs`.

This change adds a fallback to use `Kafka::VERSION` constant to check
the minimum version when one is not available in Ruby Gems.

See https://github.com/open-telemetry/opentelemetry-ruby/issues/947