### PR TITLE
fix: Remove Active Record instantiation patch

### DIFF
--- a/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/patches/persistence_class_methods.rb
+++ b/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/patches/persistence_class_methods.rb
@@ -30,12 +30,6 @@ module OpenTelemetry
               end
             end
 
-            def instantiate(attributes, column_types = {}, &block)
-              tracer.in_span("#{self}.instantiate") do
-                super
-              end
-            end
-
             def update(id = :all, attributes) # rubocop:disable Style/OptionalArguments
               tracer.in_span("#{self}.update") do
                 super

--- a/instrumentation/active_record/test/instrumentation/active_record/patches/persistence_class_methods_test.rb
+++ b/instrumentation/active_record/test/instrumentation/active_record/patches/persistence_class_methods_test.rb
@@ -41,14 +41,6 @@ describe OpenTelemetry::Instrumentation::ActiveRecord::Patches::PersistenceClass
     end
   end
 
-  describe '.instantiate' do
-    it 'traces' do
-      User.instantiate(updated_at: Time.current, created_at: Time.current)
-      instantiate_span = spans.find { |s| s.name == 'User.instantiate' }
-      _(instantiate_span).wont_be_nil
-    end
-  end
-
   describe '.update' do
     it 'traces' do
       last_user = User.create


### PR DESCRIPTION
The instantiation method has proven to be overly verbose and as a result we
have opted to remove it entirely from the Active Record instrumentation.

https://github.com/open-telemetry/opentelemetry-ruby/issues/950