### PR TITLE
docs: Fix compatibility issues with opentelemetry.io

### DIFF
--- a/website_docs/_index.md
+++ b/website_docs/_index.md
@@ -4,6 +4,11 @@ weight: 24
 description: >
   <img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Ruby_SDK.svg"></img>
   A language-specific implementation of OpenTelemetry in Ruby.
+cascade:
+  github_repo: &repo https://github.com/open-telemetry/opentelemetry-ruby
+  github_subdir: website_docs
+  path_base_for_github_subdir: content/en/docs/ruby/
+  github_project_repo: *repo
 ---
 
 This is the OpenTelemetry for Ruby documentation. OpenTelemetry is an observability framework -- an API, SDK, and tools that are designed to aid in the generation and collection of application telemetry data such as metrics, logs, and traces.
@@ -20,25 +25,13 @@ as follows:
 
 The current release can be found [here][releases]
 
-## Using OpenTelemetry Ruby
-
-- [Quick Start][quick-start]
-- [Context Propagation][context-propagation]
-- [Span Events][events]
-- [Manual Instrumentation][manual-instrumentation]
-
 ## Further Reading
 
 - [OpenTelemetry for Ruby on GitHub][repository]
 - [Ruby API Documentation][ruby-docs]
 - [Examples][examples]
 
-[quick-start]: quick_start.md
 [repository]: https://github.com/open-telemetry/opentelemetry-ruby
 [releases]: https://github.com/open-telemetry/opentelemetry-ruby/releases
-[auto-instrumenation]: https://github.com/open-telemetry/opentelemetry-ruby#instrumentation-libraries
-[context-propagation]: context_propagation.md
-[events]: events.md
-[manual-instrumentation]: manual_instrumentation.md
 [ruby-docs]: https://open-telemetry.github.io/opentelemetry-ruby/
 [examples]: https://github.com/open-telemetry/opentelemetry-ruby/tree/main/examples

--- a/website_docs/context_propagation.md
+++ b/website_docs/context_propagation.md
@@ -1,12 +1,7 @@
 ---
-title: "Ruby Context Propagation"
-weight: 24
-description: >
-  <img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Ruby_SDK.svg"></img>
-  A language-specific implementation of OpenTelemetry in Ruby.
+title: "Context Propagation"
+weight: 2
 ---
-
-## Context Propagation
 
 > Distributed Tracing tracks the progression of a single Request, called a Trace, as it is handled by Services that make up an Application. A Distributed Trace transverses process, network and security boundaries. [glossary][glossary]
 

--- a/website_docs/events.md
+++ b/website_docs/events.md
@@ -1,12 +1,7 @@
 ---
-title: "Ruby Span Events"
-weight: 24
-description: >
-  <img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Ruby_SDK.svg"></img>
-  A language-specific implementation of OpenTelemetry in Ruby.
+title: "Span Events"
+weight: 3
 ---
-
-## Events
 
 An event is a human-readable message on a span that represents "something happening" during it's lifetime. For example, imagine a function that requires exclusive access to a resource that is under a mutex. An event could be created at two points - once, when we try to gain access to the resource, and another when we acquire the mutex.
 

--- a/website_docs/getting_started.md
+++ b/website_docs/getting_started.md
@@ -1,12 +1,7 @@
 ---
-title: "Ruby Quick Start Guide"
-weight: 24
-description: >
-  <img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Ruby_SDK.svg"></img>
-  A language-specific implementation of OpenTelemetry in Ruby.
+title: "Getting Started"
+weight: 1
 ---
-
-## Quick Start
 
 [OpenTelemetry for Ruby][repository] can be used to add automatic and manual instrumentation to your applications.
 Automatic instrumentation is enabled by adding [instrumentation packages][auto-instrumentation].
@@ -91,6 +86,6 @@ Adding tracing to a single service is a great first step and although auto-instr
 [repository]: https://github.com/open-telemetry/opentelemetry-ruby
 [auto-instrumentation]: https://github.com/open-telemetry/opentelemetry-ruby#instrumentation-libraries
 [sdk-env]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options
-[context-propagation]: context_propagation.md
-[events]: events.md
-[manual-instrumentation]: manual_instrumentation.md
+[context-propagation]: ../context_propagation
+[events]: ../events
+[manual-instrumentation]: ../manual_instrumentation

--- a/website_docs/manual_instrumentation.md
+++ b/website_docs/manual_instrumentation.md
@@ -1,12 +1,7 @@
 ---
-title: "Ruby Manual Instrumentation"
-weight: 24
-description: >
-  <img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/Ruby_SDK.svg"></img>
-  A language-specific implementation of OpenTelemetry in Ruby.
+title: "Manual Instrumentation"
+weight: 4
 ---
-
-## Adding Manual Instrumentation
 
 Auto-instrumentation is the easiest way to get started with instrumenting your code, but in order to get the most insight into your system, you should add manual instrumentation where appropriate.
 To do this, use the OpenTelemetry SDK to access the currently executing span and add attributes to it, and/or to create new spans.


### PR DESCRIPTION
The changes I submitted in https://github.com/open-telemetry/opentelemetry-ruby/pull/930 were optimized for a GitHub markdown, however when I integrated them into opentelemetry.io I ran into issues with navigation, duplicate headers, and some odd rendering issues. 

The changes included in this PR update the Markdown to work better with Hugo and opentelemetry.io:

<img width="1202" alt="2021-09-22_13-35-01" src="https://user-images.githubusercontent.com/82798/134402053-7aadebf2-c523-46b9-b7f1-4d877311af73.png">

<img width="1234" alt="2021-09-22_13-40-09" src="https://user-images.githubusercontent.com/82798/134402746-b98388d9-b78e-49a9-800a-3b2b345aec44.png">
