### PR TITLE
Update bsp .shutdown return value

### DIFF
--- a/api/test/opentelemetry/context_test.rb
+++ b/api/test/opentelemetry/context_test.rb
@@ -77,11 +77,14 @@ describe OpenTelemetry::Context do
     before do
       @log_stream = StringIO.new
       @_logger = OpenTelemetry.logger
+      @_error_handler = OpenTelemetry.error_handler
       OpenTelemetry.logger = ::Logger.new(@log_stream)
     end
 
     after do
+      # Ensure we don't leak custom loggers and error handlers to other tests
       OpenTelemetry.logger = @_logger
+      OpenTelemetry.error_handler = @_error_handler
     end
 
     it 'restores the context' do
@@ -144,9 +147,6 @@ describe OpenTelemetry::Context do
       }
 
       _(-> { Context.detach('junk') }).must_raise(OpenTelemetry::Context::DetachError)
-
-    ensure
-      OpenTelemetry.error_handler = ->(exception: nil, message: nil) { OpenTelemetry.logger.error("OpenTelemetry error: #{[message, exception&.message].compact.join(' - ')}") }
     end
   end
 

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History: opentelemetry-sdk
 
+## Unreleased
+
+* FIXED: Batch Span Processor(BSP) .shutdown returns integer value matching specification
+
 ### v1.0.0.rc3 / 2021-08-12
 
 * BREAKING CHANGE: Remove optional parent_context from in_span

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Release History: opentelemetry-sdk
 
-## Unreleased
-
-* FIXED: Batch Span Processor(BSP) .shutdown returns integer value matching specification
-
 ### v1.0.0.rc3 / 2021-08-12
 
 * BREAKING CHANGE: Remove optional parent_context from in_span

--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -146,9 +146,9 @@ module OpenTelemetry
 
             thread&.join(timeout)
             force_flush(timeout: OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time))
-            @exporter.shutdown(timeout: OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time))
             dropped_spans = lock { spans.size }
             report_dropped_spans(dropped_spans, reason: 'terminating') if dropped_spans.positive?
+            @exporter.shutdown(timeout: OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time))
           end
 
           private


### PR DESCRIPTION
Addresses regression as mentioned in https://github.com/open-telemetry/opentelemetry-ruby/issues/959

Tests are pretty basic but should be enough to help prevent a similar regression.