### PR TITLE
Add example and tests for Concurrent::Async

### DIFF
--- a/instrumentation/concurrent_ruby/example/concurrent_ruby.rb
+++ b/instrumentation/concurrent_ruby/example/concurrent_ruby.rb
@@ -26,3 +26,22 @@ tracer.in_span('outer_span') do
   end
   future.result
 end
+
+# Worker: an example Async worker
+class Worker
+  include Concurrent::Async
+  def initialize(tracer)
+    @tracer = tracer
+  end
+
+  def action
+    @tracer.in_span('async:inner_span') {}
+  end
+end
+
+worker = Worker.new(tracer)
+
+tracer.in_span('async:outer_span') do
+  worker.await.action
+  worker.async.action.wait
+end


### PR DESCRIPTION
The recent changes to the concurrent-ruby instrumentation also added context propagation support to classes that mixin `Concurrent::Async` so I've added an example and test to demonstrate this behaviour.

It's possible that other features of `concurrent-ruby` will also behave similarly but I haven't explored this.