### PR TITLE
fix: Prevent high cardinality rack span name as a default

### DIFF
--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
@@ -58,6 +58,7 @@ module OpenTelemetry
                 return @app.call(env)
               end
             end
+
             original_env = env.dup
             extracted_context = OpenTelemetry.propagation.extract(
               env,
@@ -141,7 +142,7 @@ module OpenTelemetry
             if (implementation = config[:url_quantization])
               implementation.call(request_uri_or_path_info, env)
             else
-              request_uri_or_path_info
+              "HTTP #{env['REQUEST_METHOD']}"
             end
           end
 


### PR DESCRIPTION
It is possible to maintain the high cardinality behaviour by passing in a
url quantization function that simply forwards the URI path.

> Instrumentation MUST NOT default to using URI path as span name, but MAY
> provide hooks to allow custom logic to override the default span name.

https://github.com/open-telemetry/opentelemetry-specification/blob/v1.0.0/specification/trace/semantic_conventions/http.md#name