### PR TITLE
feat: add instrumentation for rspec

### DIFF
--- a/.toys/.data/releases.yml
+++ b/.toys/.data/releases.yml
@@ -179,6 +179,10 @@ gems:
     directory: instrumentation/restclient
     version_constant: [OpenTelemetry, Instrumentation, RestClient, VERSION]
 
+  - name: opentelemetry-instrumentation-rspec
+    directory: instrumentation/rspec
+    version_constant: [OpenTelemetry, Instrumentation, RSpec, VERSION]
+
   - name: opentelemetry-instrumentation-ruby_kafka
     directory: instrumentation/ruby_kafka
     version_constant: [OpenTelemetry, Instrumentation, RubyKafka, VERSION]

--- a/instrumentation/rspec/.rubocop.yml
+++ b/instrumentation/rspec/.rubocop.yml
@@ -1,0 +1,5 @@
+inherit_from: ../.rubocop-examples.yml
+
+Naming/FileName:
+  Exclude:
+    - "lib/opentelemetry-instrumentation-rspec.rb"

--- a/instrumentation/rspec/.yardopts
+++ b/instrumentation/rspec/.yardopts
@@ -1,0 +1,9 @@
+--no-private
+--title=OpenTelemetry Rspec Instrumentation
+--markup=markdown
+--main=README.md
+./lib/opentelemetry/instrumentation/**/*.rb
+./lib/opentelemetry/instrumentation.rb
+-
+README.md
+CHANGELOG.md

--- a/instrumentation/rspec/Appraisals
+++ b/instrumentation/rspec/Appraisals
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+## TODO: Include the supported version to be tested here.
+## Example:
+# appraise 'rack-2.1' do
+#   gem 'rack', '~> 2.1.2'
+# end
+
+# appraise 'rack-2.0' do
+#   gem 'rack', '2.0.8'
+# end
+

--- a/instrumentation/rspec/Appraisals
+++ b/instrumentation/rspec/Appraisals
@@ -6,11 +6,6 @@
 
 ## TODO: Include the supported version to be tested here.
 ## Example:
-# appraise 'rack-2.1' do
-#   gem 'rack', '~> 2.1.2'
+# appraise 'rspec-3.10' do
+#   gem 'rspec', '~> 3.10.0'
 # end
-
-# appraise 'rack-2.0' do
-#   gem 'rack', '2.0.8'
-# end
-

--- a/instrumentation/rspec/CHANGELOG.md
+++ b/instrumentation/rspec/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Release History: opentelemetry-instrumentation-rspec

--- a/instrumentation/rspec/Gemfile
+++ b/instrumentation/rspec/Gemfile
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source 'https://rubygems.org'
+
+gemspec
+
+gem 'opentelemetry-api', path: '../../api'
+
+gem 'rspec'
+
+group :test do
+  gem 'opentelemetry-common', path: '../../common'
+  gem 'opentelemetry-sdk', path: '../../sdk'
+  gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions'
+end

--- a/instrumentation/rspec/Gemfile
+++ b/instrumentation/rspec/Gemfile
@@ -10,7 +10,7 @@ gemspec
 
 gem 'opentelemetry-api', path: '../../api'
 
-gem 'rspec'
+gem 'rspec', '~>3'
 
 group :test do
   gem 'opentelemetry-common', path: '../../common'

--- a/instrumentation/rspec/LICENSE
+++ b/instrumentation/rspec/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright The OpenTelemetry Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/instrumentation/rspec/README.md
+++ b/instrumentation/rspec/README.md
@@ -49,6 +49,10 @@ end
 
 If you need to test trace behaviour in your specs then you should be able to use a custom tracer provider and the instrumentation's output should not interfere with your specs.
 
+### Sampling
+
+To avoid spans from being dropped, which will mean you lose insight into your specs, you may want to set sampling to 'ALWAYS_ON'. The easiest way to do this is by setting the `OTEL_TRACES_SAMPLER` environment variable to `always_on`.
+
 ## Examples
 
 Example usage can be seen in the `/example` directory [here](https://github.com/open-telemetry/opentelemetry-ruby/blob/main/instrumentation/rspec/example)

--- a/instrumentation/rspec/README.md
+++ b/instrumentation/rspec/README.md
@@ -1,6 +1,6 @@
-# OpenTelemetry Rspec Instrumentation
+# OpenTelemetry RSpec Instrumentation
 
-Todo: Add a description.
+The RSpec instrumentation is a community-maintained instrumentation for the [RSpec][rspec-home] BDD testing framework.
 
 ## How do I get started?
 
@@ -22,17 +22,36 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
-Alternatively, you can also call `use_all` to install all the available instrumentation.
+Alternatively, you can add it directly to RSpec as a customer formatter:
 
 ```ruby
-OpenTelemetry::SDK.configure do |c|
-  c.use_all
+RSpec.configure do |config|
+  config.formatter = OpenTelemetry::Instrumentation::RSpec::Formatter
 end
 ```
 
+### Using multiple tracer providers
+
+By default the instrumentation will use the global tracer provider.
+
+If you want the instrumentation to use something other than the global tracer provider you can configure the instrumentation with a custom tracer provider using the `OpenTelemetry::Instrumentation::RSpec::Formatter` constructor:
+
+```ruby
+exporter = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
+span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(exporter)
+tracer_provider = OpenTelemetry::SDK::Trace::TracerProvider.new
+tracer_provider.add_span_processor(span_processor)
+
+RSpec.configure do |config|
+  config.formatter = OpenTelemetry::Instrumentation::RSpec::Formatter.new(config.output_stream, tracer_provider)
+end
+```
+
+If you need to test trace behaviour in your specs then you should be able to use a custom tracer provider and the instrumentation's output should not interfere with your specs.
+
 ## Examples
 
-Example usage can be seen in the `./example/trace_demonstration.rb` file [here](https://github.com/open-telemetry/opentelemetry-ruby/blob/main/instrumentation/rspec/example/trace_demonstration.rb)
+Example usage can be seen in the `/example` directory [here](https://github.com/open-telemetry/opentelemetry-ruby/blob/main/instrumentation/rspec/example)
 
 ## How can I get involved?
 
@@ -50,3 +69,4 @@ The `opentelemetry-instrumentation-rspec` gem is distributed under the Apache 2.
 [ruby-sig]: https://github.com/open-telemetry/community#ruby-sig
 [community-meetings]: https://github.com/open-telemetry/community#community-meetings
 [discussions-url]: https://github.com/open-telemetry/opentelemetry-ruby/discussions
+[rspec-home]: https://rspec.info

--- a/instrumentation/rspec/README.md
+++ b/instrumentation/rspec/README.md
@@ -1,0 +1,52 @@
+# OpenTelemetry Rspec Instrumentation
+
+Todo: Add a description.
+
+## How do I get started?
+
+Install the gem using:
+
+```
+gem install opentelemetry-instrumentation-rspec
+```
+
+Or, if you use [bundler][bundler-home], include `opentelemetry-instrumentation-rspec` in your `Gemfile`.
+
+## Usage
+
+To use the instrumentation, call `use` with the name of the instrumentation:
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::Rspec'
+end
+```
+
+Alternatively, you can also call `use_all` to install all the available instrumentation.
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use_all
+end
+```
+
+## Examples
+
+Example usage can be seen in the `./example/trace_demonstration.rb` file [here](https://github.com/open-telemetry/opentelemetry-ruby/blob/main/instrumentation/rspec/example/trace_demonstration.rb)
+
+## How can I get involved?
+
+The `opentelemetry-instrumentation-rspec` gem source is [on github][repo-github], along with related gems including `opentelemetry-api` and `opentelemetry-sdk`.
+
+The OpenTelemetry Ruby gems are maintained by the OpenTelemetry-Ruby special interest group (SIG). You can get involved by joining us in [GitHub Discussions][discussions-url] or attending our weekly meeting. See the [meeting calendar][community-meetings] for dates and times. For more information on this and other language SIGs, see the OpenTelemetry [community page][ruby-sig].
+
+## License
+
+The `opentelemetry-instrumentation-rspec` gem is distributed under the Apache 2.0 license. See [LICENSE][license-github] for more information.
+
+[bundler-home]: https://bundler.io
+[repo-github]: https://github.com/open-telemetry/opentelemetry-ruby
+[license-github]: https://github.com/open-telemetry/opentelemetry-ruby/blob/main/LICENSE
+[ruby-sig]: https://github.com/open-telemetry/community#ruby-sig
+[community-meetings]: https://github.com/open-telemetry/community#community-meetings
+[discussions-url]: https://github.com/open-telemetry/opentelemetry-ruby/discussions

--- a/instrumentation/rspec/Rakefile
+++ b/instrumentation/rspec/Rakefile
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+require 'yard'
+require 'rubocop/rake_task'
+
+RuboCop::RakeTask.new
+
+Rake::TestTask.new :test do |t|
+  t.libs << 'test'
+  t.libs << 'lib'
+  t.test_files = FileList['test/**/*_test.rb']
+end
+
+YARD::Rake::YardocTask.new do |t|
+  t.stats_options = ['--list-undoc']
+end
+
+if RUBY_ENGINE == 'truffleruby'
+  task default: %i[test]
+else
+  task default: %i[test rubocop yard]
+end

--- a/instrumentation/rspec/example/Gemfile
+++ b/instrumentation/rspec/example/Gemfile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'opentelemetry-api', path: '../../../api'
+gem 'opentelemetry-common', path: '../../../common'
+gem 'opentelemetry-instrumentation-concurrent_ruby', path: '../../../instrumentation/concurrent_ruby'
+gem 'opentelemetry-sdk', path: '../../../sdk'
+
+gem 'rspec'

--- a/instrumentation/rspec/example/rspec_with_rspec_formatter_configuration.rb
+++ b/instrumentation/rspec/example/rspec_with_rspec_formatter_configuration.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rubygems'
+require 'bundler/setup'
+
+Bundler.require
+
+ENV['OTEL_TRACES_EXPORTER'] = 'console'
+OpenTelemetry::SDK.configure
+
+require 'rspec/autorun'
+
+require_relative '../lib/opentelemetry/instrumentation/rspec/formatter'
+
+RSpec.configure do |config|
+  config.formatter = OpenTelemetry::Instrumentation::RSpec::Formatter
+end
+
+RSpec.describe OpenTelemetry::Instrumentation::RSpec::Formatter do
+  describe 'when configured' do
+    it 'exports spans when configured as a formatter' do
+      tracer = OpenTelemetry.tracer_provider.tracer('default')
+      tracer.in_span('trace inside example') do
+        expect(true).to eql false
+      end
+    end
+  end
+end

--- a/instrumentation/rspec/example/rspec_with_sdk_configure.rb
+++ b/instrumentation/rspec/example/rspec_with_sdk_configure.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rubygems'
+require 'bundler/setup'
+
+Bundler.require
+
+require 'rspec/autorun'
+
+ENV['OTEL_TRACES_EXPORTER'] = 'console'
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::RSpec'
+end
+
+require_relative '../lib/opentelemetry/instrumentation/rspec/formatter'
+
+RSpec.configure do |config|
+  config.formatter = OpenTelemetry::Instrumentation::RSpec::Formatter
+end
+
+RSpec.describe OpenTelemetry::Instrumentation::RSpec::Formatter do
+  describe 'when configured' do
+    it 'exports spans when configured as a formatter' do
+      tracer = OpenTelemetry.tracer_provider.tracer('default')
+      tracer.in_span('trace inside example') do
+        expect(true).to eql false
+      end
+    end
+  end
+end

--- a/instrumentation/rspec/lib/opentelemetry-instrumentation-rspec.rb
+++ b/instrumentation/rspec/lib/opentelemetry-instrumentation-rspec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require_relative './opentelemetry/instrumentation'

--- a/instrumentation/rspec/lib/opentelemetry/instrumentation.rb
+++ b/instrumentation/rspec/lib/opentelemetry/instrumentation.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# OpenTelemetry is an open source observability framework, providing a
+# general-purpose API, SDK, and related tools required for the instrumentation
+# of cloud-native software, frameworks, and libraries.
+#
+# The OpenTelemetry module provides global accessors for telemetry objects.
+# See the documentation for the `opentelemetry-api` gem for details.
+module OpenTelemetry
+  # Instrumentation should be able to handle the case when the library is not installed on a user's system.
+  module Instrumentation
+  end
+end
+
+require_relative './instrumentation/rspec'

--- a/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec.rb
+++ b/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry'
+require 'opentelemetry-instrumentation-base'
+
+module OpenTelemetry
+  module Instrumentation
+    # Contains the OpenTelemetry instrumentation for the Rspec gem
+    module RSpec
+    end
+  end
+end
+
+require_relative './rspec/instrumentation'
+require_relative './rspec/version'

--- a/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec/formatter.rb
+++ b/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec/formatter.rb
@@ -21,13 +21,14 @@ module OpenTelemetry
           @clock.call
         end
 
-        def initialize(output)
+        def initialize(output = StringIO.new, tracer_provider = OpenTelemetry.tracer_provider)
           @spans_and_tokens = []
-          @output = ''
+          @output = output
+          @tracer_provider = tracer_provider
         end
 
         def tracer
-          @tracer ||= OpenTelemetry.tracer_provider.tracer('RSpec')
+          @tracer ||= @tracer_provider.tracer('RSpec')
         end
 
         def current_timestamp

--- a/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec/formatter.rb
+++ b/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec/formatter.rb
@@ -75,6 +75,7 @@ module OpenTelemetry
             if (exception = result.exception)
               span.record_exception(exception)
               span.set_attribute('rspec.example.failure_message', exception.message) if exception.is_a? ::RSpec::Expectations::ExpectationNotMetError
+              span.status = OpenTelemetry::Trace::Status.error
             end
           end
         end

--- a/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec/formatter.rb
+++ b/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec/formatter.rb
@@ -69,7 +69,6 @@ module OpenTelemetry
         def example_finished(notification)
           pop_and_finalize_span do |span|
             result = notification.example.execution_result
-            notification.example.metadata
 
             span.set_attribute('rspec.example.result', result.status.to_s)
 

--- a/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec/formatter.rb
+++ b/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec/formatter.rb
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require 'opentelemetry-api'
+require_relative './version'
 
 module OpenTelemetry
   module Instrumentation
@@ -28,7 +29,7 @@ module OpenTelemetry
         end
 
         def tracer
-          @tracer ||= @tracer_provider.tracer('RSpec')
+          @tracer ||= @tracer_provider.tracer('OpenTelemetry::Instrumentation::RSpec', OpenTelemetry::Instrumentation::RSpec::VERSION)
         end
 
         def current_timestamp

--- a/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec/formatter.rb
+++ b/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec/formatter.rb
@@ -75,7 +75,7 @@ module OpenTelemetry
             if (exception = result.exception)
               span.record_exception(exception)
               span.set_attribute('rspec.example.failure_message', exception.message) if exception.is_a? ::RSpec::Expectations::ExpectationNotMetError
-              span.status = OpenTelemetry::Trace::Status.error
+              span.status = OpenTelemetry::Trace::Status.error(exception.message)
             end
           end
         end

--- a/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec/formatter.rb
+++ b/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec/formatter.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry-api'
+
+module OpenTelemetry
+  module Instrumentation
+    module RSpec
+      # An RSpec Formatter that outputs Otel spans
+      class Formatter
+        attr_reader :output
+        ::RSpec::Core::Formatters.register self, :example_started, :example_finished, :example_group_started, :example_group_finished, :start, :stop
+
+        def initialize(output, tracer_provider: OpenTelemetry.tracer_provider)
+          @tracer_provider = tracer_provider
+          @spans_and_tokens = []
+          @output = ''
+        end
+
+        def tracer
+          @tracer ||= @tracer_provider.tracer('rspec')
+        end
+
+        def start(notification)
+          span = tracer.start_span('suite')
+          token = OpenTelemetry::Context.attach(
+            OpenTelemetry::Trace.context_with_span(span)
+          )
+          @spans_and_tokens.unshift([span, token])
+        end
+
+        def stop(notification)
+          span, token = *@spans_and_tokens.shift
+          return unless span.recording?
+
+          span.finish
+          OpenTelemetry::Context.detach(token)
+        end
+
+        def example_group_started(notification)
+          span = tracer.start_span(notification.group.description)
+          token = OpenTelemetry::Context.attach(
+            OpenTelemetry::Trace.context_with_span(span)
+          )
+          @spans_and_tokens.unshift([span, token])
+        end
+
+        def example_group_finished(notification)
+          span, token = *@spans_and_tokens.shift
+          return unless span.recording?
+
+          span.finish
+          OpenTelemetry::Context.detach(token)
+        end
+
+        def example_started(notification)
+          example = notification.example
+          attributes = {
+            'location' => example.location.to_s,
+            'full_description' => example.full_description.to_s,
+            'described_class' => example.metadata[:described_class].to_s
+          }
+          span = tracer.start_span(example.description, attributes: attributes)
+          token = OpenTelemetry::Context.attach(
+            OpenTelemetry::Trace.context_with_span(span)
+          )
+          @spans_and_tokens.unshift([span, token])
+        end
+
+        def example_finished(notification)
+          span, token = *@spans_and_tokens.shift
+          return unless span.recording?
+
+          span.finish
+          OpenTelemetry::Context.detach(token)
+        end
+      end
+    end
+  end
+end

--- a/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec/formatter.rb
+++ b/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec/formatter.rb
@@ -58,9 +58,9 @@ module OpenTelemetry
         def example_started(notification)
           example = notification.example
           attributes = {
-            'location' => example.location.to_s,
-            'full_description' => example.full_description.to_s,
-            'described_class' => example.metadata[:described_class].to_s
+            'rspec.example.location' => example.location.to_s,
+            'rspec.example.full_description' => example.full_description.to_s,
+            'rspec.example.described_class' => example.metadata[:described_class].to_s
           }
           span = tracer.start_span(example.description, attributes: attributes, start_timestamp: current_timestamp)
           track_span(span)
@@ -71,11 +71,11 @@ module OpenTelemetry
             result = notification.example.execution_result
             notification.example.metadata
 
-            span.set_attribute('result', result.status.to_s)
+            span.set_attribute('rspec.example.result', result.status.to_s)
 
             if (exception = result.exception)
               span.record_exception(exception)
-              span.set_attribute('message', exception.message) if exception.is_a? ::RSpec::Expectations::ExpectationNotMetError
+              span.set_attribute('rspec.example.failure_message', exception.message) if exception.is_a? ::RSpec::Expectations::ExpectationNotMetError
             end
           end
         end

--- a/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec/instrumentation.rb
+++ b/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec/instrumentation.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Instrumentation
+    module RSpec
+      # The Instrumentation class contains logic to detect and install the Rspec instrumentation
+      class Instrumentation < OpenTelemetry::Instrumentation::Base
+        install do |_config|
+          require_dependencies
+        end
+
+        present do
+          # TODO: Replace true with a definition check of the gem being instrumented
+          # Example: `defined?(::Rack)`
+          false
+        end
+
+        private
+
+        def require_dependencies
+          # TODO: Include instrumentation dependencies
+        end
+      end
+    end
+  end
+end

--- a/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec/instrumentation.rb
+++ b/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec/instrumentation.rb
@@ -11,18 +11,23 @@ module OpenTelemetry
       class Instrumentation < OpenTelemetry::Instrumentation::Base
         install do |_config|
           require_dependencies
+          add_formatter!
         end
 
         present do
-          # TODO: Replace true with a definition check of the gem being instrumented
-          # Example: `defined?(::Rack)`
-          false
+          defined?(::RSpec)
         end
 
         private
 
         def require_dependencies
-          # TODO: Include instrumentation dependencies
+          require_relative './formatter'
+        end
+
+        def add_formatter!
+          ::RSpec.configure do |config|
+            config.add_formatter(Formatter)
+          end
         end
       end
     end

--- a/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec/version.rb
+++ b/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec/version.rb
@@ -7,7 +7,7 @@
 module OpenTelemetry
   module Instrumentation
     module RSpec
-      VERSION = '0.0.0'
+      VERSION = '0.0.1'
     end
   end
 end

--- a/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec/version.rb
+++ b/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec/version.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Instrumentation
+    module RSpec
+      VERSION = '0.0.0'
+    end
+  end
+end

--- a/instrumentation/rspec/opentelemetry-instrumentation-rspec.gemspec
+++ b/instrumentation/rspec/opentelemetry-instrumentation-rspec.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.5.0'
 
-  spec.add_dependency 'opentelemetry-api', '~> 1.0.0.rc3'
+  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.18.2'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'

--- a/instrumentation/rspec/opentelemetry-instrumentation-rspec.gemspec
+++ b/instrumentation/rspec/opentelemetry-instrumentation-rspec.gemspec
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'opentelemetry/instrumentation/rspec/version'
+
+Gem::Specification.new do |spec|
+  spec.name        = 'opentelemetry-instrumentation-rspec'
+  spec.version     = OpenTelemetry::Instrumentation::RSpec::VERSION
+  spec.authors     = ['OpenTelemetry Authors']
+  spec.email       = ['cncf-opentelemetry-contributors@lists.cncf.io']
+
+  spec.summary     = 'Rspec instrumentation for the OpenTelemetry framework'
+  spec.description = 'Rspec instrumentation for the OpenTelemetry framework'
+  spec.homepage    = 'https://github.com/open-telemetry/opentelemetry-ruby'
+  spec.license     = 'Apache-2.0'
+
+  spec.files = ::Dir.glob('lib/**/*.rb') +
+               ::Dir.glob('*.md') +
+               ['LICENSE', '.yardopts']
+  spec.require_paths = ['lib']
+  spec.required_ruby_version = '>= 2.5.0'
+
+  spec.add_dependency 'opentelemetry-api', '~> 1.0.0.rc3'
+  spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.18.2'
+
+  spec.add_development_dependency 'appraisal', '~> 2.2.0'
+  spec.add_development_dependency 'bundler', '>= 1.17'
+  spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'opentelemetry-sdk'
+  spec.add_development_dependency 'rake', '~> 12.3.3'
+  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'simplecov', '~> 0.17.1'
+  spec.add_development_dependency 'webmock', '~> 3.7.6'
+  spec.add_development_dependency 'yard', '~> 0.9'
+  spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-rspec/v#{OpenTelemetry::Instrumentation::RSpec::VERSION}/file.CHANGELOG.html"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/main/instrumentation/rspec'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/issues'
+    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-rspec/v#{OpenTelemetry::Instrumentation::RSpec::VERSION}"
+  end
+end

--- a/instrumentation/rspec/test/.rubocop.yml
+++ b/instrumentation/rspec/test/.rubocop.yml
@@ -1,0 +1,4 @@
+inherit_from: ../.rubocop.yml
+
+Metrics/BlockLength:
+  Enabled: false

--- a/instrumentation/rspec/test/opentelemetry/instrumentation/rspec/formatter_test.rb
+++ b/instrumentation/rspec/test/opentelemetry/instrumentation/rspec/formatter_test.rb
@@ -184,6 +184,7 @@ describe OpenTelemetry::Instrumentation::RSpec::Formatter do
           \e[0m
         MESSAGE
         _(subject.attributes['rspec.example.failure_message']).must_equal message
+        _(subject.status.description).must_equal message
         _(subject.events.first.attributes['exception.message']).must_equal message
       end
 

--- a/instrumentation/rspec/test/opentelemetry/instrumentation/rspec/formatter_test.rb
+++ b/instrumentation/rspec/test/opentelemetry/instrumentation/rspec/formatter_test.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+require_relative '../../../../lib/opentelemetry/instrumentation/rspec/formatter'
+
+describe OpenTelemetry::Instrumentation::RSpec::Formatter do
+  before(:each) do
+    EXPORTER.reset
+  end
+
+  def run_rspec_configured_with_otel_formatter
+    options = RSpec::Core::ConfigurationOptions.new([])
+
+    configuration = RSpec::Core::Configuration.new
+
+    runner = RSpec::Core::Runner.new(options, configuration, RSpec::Core::World.new)
+    runner.configuration.formatter = OpenTelemetry::Instrumentation::RSpec::Formatter
+    yield runner if block_given?
+  end
+
+  def run_rspec_with_tracing
+    run_rspec_configured_with_otel_formatter do |runner|
+      groups = yield
+      runner.run_specs(Array(groups))
+    end
+    spans = EXPORTER.finished_spans
+    EXPORTER.reset
+    spans
+  end
+
+  it 'exports spans for suites' do
+    spans = run_rspec_with_tracing do
+      group_string = RSpec.describe(String) do
+        example('example string') {}
+      end
+      group_one = RSpec.describe('group one') do
+        example('example one') {}
+      end
+      group_two = RSpec.describe('group two') do
+        example('example two') {}
+      end
+      [group_string, group_one, group_two]
+    end
+    _(spans.map(&:name)).must_equal ['example string', 'String', 'example one', 'group one', 'example two', 'group two', 'RSpec suite']
+  end
+
+  describe 'exports spans for example groups' do
+    it 'describes the class if specified' do
+      spans = run_rspec_with_tracing do
+        RSpec.describe(String) do
+          describe('group description') do
+            example('example one') {}
+          end
+        end
+      end
+      _(spans.map(&:name)).must_equal ['example one', 'group description', 'String', 'RSpec suite']
+    end
+
+    it 'describes the group description if specified' do
+      spans = run_rspec_with_tracing do
+        RSpec.describe('group description') do
+          example('example one') {}
+        end
+      end
+      _(spans.map(&:name)).must_equal ['example one', 'group description', 'RSpec suite']
+    end
+  end
+
+  describe 'exports spans for examples' do
+    def run_example(&blk)
+      spans = run_rspec_with_tracing do
+        RSpec.describe('group one') do
+          instance_eval(&blk)
+        end
+      end
+      spans.first
+    end
+
+    describe 'that pass' do
+      subject do
+        run_example do
+          example('example one') {}
+        end
+      end
+
+      it 'has a name that matches the example description' do
+        _(subject.name).must_equal 'example one'
+      end
+
+      it 'has a description attribute matches the full example description' do
+        _(subject.attributes['full_description']).must_equal 'group one example one'
+      end
+
+      it 'has a description attribute matches the full example description' do
+        _(subject.attributes['location']).must_match %r{\./test/opentelemetry/instrumentation/rspec/formatter_test.rb:\d+}
+      end
+
+      it 'records when the example passes' do
+        _(subject.attributes['result']).must_equal 'passed'
+      end
+    end
+
+    describe 'that fail' do
+      subject do
+        run_example do
+          example('example one') { expect(true).to eql false }
+        end
+      end
+
+      it 'records when the example fails' do
+        _(subject.attributes['result']).must_equal 'failed'
+      end
+
+      it 'records the failure message' do
+        message = <<~MESSAGE.rstrip
+
+          expected: false
+               got: true
+
+          (compared using eql?)
+
+          Diff:\e[0m
+          \e[0m\e[34m@@ -1 +1 @@
+          \e[0m\e[31m-false
+          \e[0m\e[32m+true
+          \e[0m
+        MESSAGE
+        _(subject.attributes['message']).must_equal message
+      end
+
+      it 'records the exception' do
+        assert_nil(subject.attributes['exception.type'])
+      end
+    end
+
+    describe 'that error' do
+      subject do
+        run_example do
+          example('example one') { raise 'my-error-message' }
+        end
+      end
+
+      it 'records when the example fails' do
+        _(subject.attributes['result']).must_equal 'failed'
+      end
+
+      it 'records the exception' do
+        _(subject.events.first.attributes['exception.type']).must_equal 'RuntimeError'
+      end
+
+      it 'records the exception' do
+        _(subject.events.first.attributes['exception.message']).must_equal 'my-error-message'
+      end
+    end
+  end
+end

--- a/instrumentation/rspec/test/opentelemetry/instrumentation/rspec/formatter_test.rb
+++ b/instrumentation/rspec/test/opentelemetry/instrumentation/rspec/formatter_test.rb
@@ -58,7 +58,7 @@ describe OpenTelemetry::Instrumentation::RSpec::Formatter do
         end
       end
       _(spans.first.name).must_equal 'example one'
-      _(spans.first.attributes['result']).must_equal 'passed'
+      _(spans.first.attributes['rspec.example.result']).must_equal 'passed'
       _(spans.first.start_timestamp).wont_equal 0
       _(spans.first.start_timestamp / 1_000_000_000).must_be_close_to(current_time.to_i)
       _(spans.first.end_timestamp / 1_000_000_000).must_be_close_to(current_time.to_i)
@@ -124,15 +124,15 @@ describe OpenTelemetry::Instrumentation::RSpec::Formatter do
       end
 
       it 'has a description attribute matches the full example description' do
-        _(subject.attributes['full_description']).must_equal 'group one example one'
+        _(subject.attributes['rspec.example.full_description']).must_equal 'group one example one'
       end
 
       it 'has a description attribute matches the full example description' do
-        _(subject.attributes['location']).must_match %r{\./test/opentelemetry/instrumentation/rspec/formatter_test.rb:\d+}
+        _(subject.attributes['rspec.example.location']).must_match %r{\./test/opentelemetry/instrumentation/rspec/formatter_test.rb:\d+}
       end
 
       it 'records when the example passes' do
-        _(subject.attributes['result']).must_equal 'passed'
+        _(subject.attributes['rspec.example.result']).must_equal 'passed'
       end
     end
 
@@ -161,7 +161,7 @@ describe OpenTelemetry::Instrumentation::RSpec::Formatter do
       end
 
       it 'records when the example fails' do
-        _(subject.attributes['result']).must_equal 'failed'
+        _(subject.attributes['rspec.example.result']).must_equal 'failed'
       end
 
       it 'records the failure message' do
@@ -178,7 +178,8 @@ describe OpenTelemetry::Instrumentation::RSpec::Formatter do
           \e[0m\e[32m+true
           \e[0m
         MESSAGE
-        _(subject.attributes['message']).must_equal message
+        _(subject.attributes['rspec.example.failure_message']).must_equal message
+        _(subject.events.first.attributes['exception.message']).must_equal message
       end
 
       it 'records the exception' do
@@ -194,7 +195,7 @@ describe OpenTelemetry::Instrumentation::RSpec::Formatter do
       end
 
       it 'records when the example fails' do
-        _(subject.attributes['result']).must_equal 'failed'
+        _(subject.attributes['rspec.example.result']).must_equal 'failed'
       end
 
       it 'records the exception' do

--- a/instrumentation/rspec/test/opentelemetry/instrumentation/rspec/formatter_test.rb
+++ b/instrumentation/rspec/test/opentelemetry/instrumentation/rspec/formatter_test.rb
@@ -183,7 +183,7 @@ describe OpenTelemetry::Instrumentation::RSpec::Formatter do
       end
 
       it 'records the exception' do
-        assert_nil(subject.attributes['exception.type'])
+        _(subject.events.first.attributes['exception.type']).must_equal 'RSpec::Expectations::ExpectationNotMetError'
       end
     end
 

--- a/instrumentation/rspec/test/opentelemetry/instrumentation/rspec/formatter_test.rb
+++ b/instrumentation/rspec/test/opentelemetry/instrumentation/rspec/formatter_test.rb
@@ -164,6 +164,11 @@ describe OpenTelemetry::Instrumentation::RSpec::Formatter do
         _(subject.attributes['rspec.example.result']).must_equal 'failed'
       end
 
+      it 'records the span status as error' do
+        _(subject.status.ok?).must_equal false
+        _(subject.status.code).must_equal OpenTelemetry::Trace::Status::ERROR
+      end
+
       it 'records the failure message' do
         message = <<~MESSAGE.rstrip
 
@@ -196,6 +201,11 @@ describe OpenTelemetry::Instrumentation::RSpec::Formatter do
 
       it 'records when the example fails' do
         _(subject.attributes['rspec.example.result']).must_equal 'failed'
+      end
+
+      it 'records the span status as error' do
+        _(subject.status.ok?).must_equal false
+        _(subject.status.code).must_equal OpenTelemetry::Trace::Status::ERROR
       end
 
       it 'records the exception' do

--- a/instrumentation/rspec/test/opentelemetry/instrumentation/rspec/instrumentation_test.rb
+++ b/instrumentation/rspec/test/opentelemetry/instrumentation/rspec/instrumentation_test.rb
@@ -8,11 +8,11 @@ require 'test_helper'
 
 require_relative '../../../../lib/opentelemetry/instrumentation/rspec'
 
-describe OpenTelemetry::Instrumentation::Rspec do
-  let(:instrumentation) { OpenTelemetry::Instrumentation::Rspec::Instrumentation.instance }
+describe OpenTelemetry::Instrumentation::RSpec do
+  let(:instrumentation) { OpenTelemetry::Instrumentation::RSpec::Instrumentation.instance }
 
   it 'has #name' do
-    _(instrumentation.name).must_equal 'OpenTelemetry::Instrumentation::Rspec'
+    _(instrumentation.name).must_equal 'OpenTelemetry::Instrumentation::RSpec'
   end
 
   it 'has #version' do
@@ -24,6 +24,11 @@ describe OpenTelemetry::Instrumentation::Rspec do
     it 'accepts argument' do
       _(instrumentation.install({})).must_equal(true)
       instrumentation.instance_variable_set(:@installed, false)
+    end
+
+    it 'adds the formatter to RSpec configuration' do
+      _(instrumentation.install({})).must_equal(true)
+      _(RSpec.configuration.formatters.map(&:class)).must_include OpenTelemetry::Instrumentation::RSpec::Formatter
     end
   end
 end

--- a/instrumentation/rspec/test/opentelemetry/instrumentation/rspec/instrumentation_test.rb
+++ b/instrumentation/rspec/test/opentelemetry/instrumentation/rspec/instrumentation_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+require_relative '../../../../lib/opentelemetry/instrumentation/rspec'
+
+describe OpenTelemetry::Instrumentation::Rspec do
+  let(:instrumentation) { OpenTelemetry::Instrumentation::Rspec::Instrumentation.instance }
+
+  it 'has #name' do
+    _(instrumentation.name).must_equal 'OpenTelemetry::Instrumentation::Rspec'
+  end
+
+  it 'has #version' do
+    _(instrumentation.version).wont_be_nil
+    _(instrumentation.version).wont_be_empty
+  end
+
+  describe '#install' do
+    it 'accepts argument' do
+      _(instrumentation.install({})).must_equal(true)
+      instrumentation.instance_variable_set(:@installed, false)
+    end
+  end
+end

--- a/instrumentation/rspec/test/rspec_patches.rb
+++ b/instrumentation/rspec/test/rspec_patches.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# patch `RSpec::Core::DSL::change_global_dsl to reliably prevent
+# RSpec overriding minitest's global `::describe` method
+require 'rspec/core/dsl'
+module RSpec
+  module Core
+    module DSL
+      def self.change_global_dsl(&blk)
+        nil
+      end
+    end
+  end
+end

--- a/instrumentation/rspec/test/test_helper.rb
+++ b/instrumentation/rspec/test/test_helper.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry/sdk'
+
+require 'minitest/autorun'
+require 'webmock/minitest'
+
+# global opentelemetry-sdk setup:
+EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
+span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
+
+OpenTelemetry::SDK.configure do |c|
+  c.add_span_processor span_processor
+end

--- a/instrumentation/rspec/test/test_helper.rb
+++ b/instrumentation/rspec/test/test_helper.rb
@@ -3,8 +3,19 @@
 # Copyright The OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
-
 require 'opentelemetry/sdk'
+
+require 'rspec/core/dsl'
+module RSpec
+  module Core
+    module DSL
+      def self.change_global_dsl(&blk)
+        nil
+      end
+    end
+  end
+end
+require 'rspec/core'
 
 require 'minitest/autorun'
 require 'webmock/minitest'

--- a/instrumentation/rspec/test/test_helper.rb
+++ b/instrumentation/rspec/test/test_helper.rb
@@ -5,16 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 require 'opentelemetry/sdk'
 
-require 'rspec/core/dsl'
-module RSpec
-  module Core
-    module DSL
-      def self.change_global_dsl(&blk)
-        nil
-      end
-    end
-  end
-end
+require_relative 'rspec_patches'
 require 'rspec/core'
 
 require 'minitest/autorun'


### PR DESCRIPTION
This PR covers adding instrumentation for RSpec using a RSpec formatter. It could then be used as part of a CI/CD pipeline that is configured to emit traces. At this point, parent context would need to passed manually from other processes, but I understand this being discussed as [an addition to the spec](https://github.com/open-telemetry/opentelemetry-specification/issues/740).

There are two ways to enable instrumentation either by configured Otel to use the instrumentation or by adding the formatter to RSpec. You can see examples of this in `examples/`.

Some things :
- The formatter is using `::attach` and `::detach` and a stack to add and remove span context. I think this is appropriate considering how example and example groups are currently executed, but I'm assuming this might break if a later RSpec version offers multi-threaded execution.
- Should test framework instrumentation be auto-instrumented? 
- I've had to add a monkey patch at the `test/rspec_patches.rb` so that RSpec doesn't clobber minitest's `#describe` method. This might not be needed if specs were written in RSpec, but I don't think this is a good idea as there would then be multiple test frameworks used in this repo.

Also, the README is still a WIP