### PR TITLE
fix: handle otlp exporter race condition gzip errors with retry

### DIFF
--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -206,6 +206,9 @@ module OpenTelemetry
           rescue EOFError
             retry if backoff?(retry_count: retry_count += 1, reason: 'eof_error')
             return FAILURE
+          rescue Zlib::DataError
+            retry if backoff?(retry_count: retry_count += 1, reason: 'zlib_error')
+            return FAILURE
           end
         ensure
           # Reset timeouts to defaults for the next call.


### PR DESCRIPTION
## Summary

We'd like to be able enable gzip compression by default with the otlp exporter, however internally we've noticed somewhat arbitrary `Zlib::DataError` exceptions as described in this comment https://github.com/open-telemetry/opentelemetry-ruby/pull/934#issuecomment-942399465. So, given this is likely a race condition that only occurs under specific and hard to reproduce scenarios, the least we can do is attempt to retry a few times. If we notice the errors become more consistent we can try to address in an alternate way. For now let's just handle the exception, emit a metric upon retry, and implement the usual backoff approach.