### PR TITLE
Fix Ethon for Typhoeus::Hydra support

### DIFF
--- a/instrumentation/ethon/lib/opentelemetry/instrumentation/ethon/patches/easy.rb
+++ b/instrumentation/ethon/lib/opentelemetry/instrumentation/ethon/patches/easy.rb
@@ -45,10 +45,8 @@ module OpenTelemetry
                 @otel_span.status = OpenTelemetry::Trace::Status.error unless (100..399).include?(response_code.to_i)
               end
             ensure
-              if otel_span_started?
-                @otel_span.finish
-                @otel_span = nil
-              end
+              @otel_span&.finish
+              @otel_span = nil
             end
             super
           end

--- a/instrumentation/ethon/lib/opentelemetry/instrumentation/ethon/patches/easy.rb
+++ b/instrumentation/ethon/lib/opentelemetry/instrumentation/ethon/patches/easy.rb
@@ -45,8 +45,10 @@ module OpenTelemetry
                 @otel_span.status = OpenTelemetry::Trace::Status.error unless (100..399).include?(response_code.to_i)
               end
             ensure
-              @otel_span.finish
-              @otel_span = nil
+              if otel_span_started?
+                @otel_span.finish
+                @otel_span = nil
+              end
             end
             super
           end

--- a/instrumentation/ethon/lib/opentelemetry/instrumentation/ethon/patches/multi.rb
+++ b/instrumentation/ethon/lib/opentelemetry/instrumentation/ethon/patches/multi.rb
@@ -17,6 +17,12 @@ module OpenTelemetry
 
             super
           end
+
+          def add(easy)
+            easy.otel_before_request unless easy.otel_span_started?
+
+            super
+          end
         end
       end
     end

--- a/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/instrumentation_test.rb
+++ b/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/instrumentation_test.rb
@@ -259,6 +259,26 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
             _(exporter.finished_spans.size).must_equal 2
           end
         end
+
+        describe 'with calls to add while running' do
+          it 'creates extra traces for each extra valid call to add' do
+            multi.add(easy)
+
+            # local variables for the closure
+            other = ::Ethon::Easy.new(url: 'http://username:password@example.com/test')
+            m = multi
+            easy.send(:define_singleton_method, :complete) do
+              m.add(other)
+              super()
+            end
+
+            multi.perform
+
+            _(exporter.finished_spans.size).must_equal 2
+            _(exporter.finished_spans[0].attributes['http.url']).must_equal nil
+            _(exporter.finished_spans[1].attributes['http.url']).must_equal 'http://example.com/test'
+          end
+        end
       end
     end
   end

--- a/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/instrumentation_test.rb
+++ b/instrumentation/ethon/test/opentelemetry/instrumentation/ethon/instrumentation_test.rb
@@ -265,7 +265,7 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
             multi.add(easy)
 
             # local variables for the closure
-            other = ::Ethon::Easy.new(url: 'http://username:password@example.com/test')
+            other = ::Ethon::Easy.new(url: 'test')
             m = multi
             easy.send(:define_singleton_method, :complete) do
               m.add(other)
@@ -276,7 +276,7 @@ describe OpenTelemetry::Instrumentation::Ethon::Instrumentation do
 
             _(exporter.finished_spans.size).must_equal 2
             _(exporter.finished_spans[0].attributes['http.url']).must_equal nil
-            _(exporter.finished_spans[1].attributes['http.url']).must_equal 'http://example.com/test'
+            _(exporter.finished_spans[1].attributes['http.url']).must_equal 'test'
           end
         end
       end


### PR DESCRIPTION
As probably you already now Typhoeus relay on Ethon and this repository is adding automatic instrumentation for it.

But the issue is that we found an issue when using Typhoeus::Hydra which is kind of difficult to explain but kind of easy to reproduce.

The main idea is that Typhoeus::Hydra stores on memory requests to be done but only pass to ethon in batches of `max_concurrency` and in only one call to `Ethon::Multi#perform` the batches after the first max_concurrency batch only call to `Ethon::Multi.#add` methods so we missed the `@otel_span` instance variable.

You can see a trace of the issue here

```sh
Caught a post-mortem exception: #<NoMethodError: undefined method `finish' for nil:NilClass>
versions/2.6.8/lib/ruby/gems/2.6.0/gems/opentelemetry-instrumentation-ethon-0.19.2/lib/opentelemetry/instrumentation/ethon/patches/easy.rb:48:in `ensure in complete': undefined method `finish' for nil:NilClass (NoMethodError)
	from versions/2.6.8/lib/ruby/gems/2.6.0/gems/opentelemetry-instrumentation-ethon-0.19.2/lib/opentelemetry/instrumentation/ethon/patches/easy.rb:49:in `complete'
	from versions/2.6.8/lib/ruby/gems/2.6.0/gems/ethon-0.15.0/lib/ethon/multi/operations.rb:189:in `check'
	from versions/2.6.8/lib/ruby/gems/2.6.0/gems/ethon-0.15.0/lib/ethon/multi/operations.rb:202:in `run'
	from versions/2.6.8/lib/ruby/gems/2.6.0/gems/ethon-0.15.0/lib/ethon/multi/operations.rb:50:in `perform'
	from versions/2.6.8/lib/ruby/gems/2.6.0/gems/opentelemetry-instrumentation-ethon-0.19.2/lib/opentelemetry/instrumentation/ethon/patches/multi.rb:18:in `perform'
	from versions/2.6.8/lib/ruby/gems/2.6.0/gems/typhoeus-1.4.0/lib/typhoeus/hydra/runnable.rb:15:in `run'
	from versions/2.6.8/lib/ruby/gems/2.6.0/gems/typhoeus-1.4.0/lib/typhoeus/hydra/memoizable.rb:52:in `run'
	from hydra.rb:23:in `run'
	from hydra.rb:28:in `block in <main>'
	from hydra.rb:9:in `block (2 levels) in within_span'
	from versions/2.6.8/lib/ruby/gems/2.6.0/gems/opentelemetry-api-1.0.0/lib/opentelemetry/trace/tracer.rb:29:in `block in in_span'
	from versions/2.6.8/lib/ruby/gems/2.6.0/gems/opentelemetry-api-1.0.0/lib/opentelemetry/trace.rb:82:in `block in with_span'
	from versions/2.6.8/lib/ruby/gems/2.6.0/gems/opentelemetry-api-1.0.0/lib/opentelemetry/context.rb:87:in `with_value'
	from versions/2.6.8/lib/ruby/gems/2.6.0/gems/opentelemetry-api-1.0.0/lib/opentelemetry/trace.rb:82:in `with_span'
	from versions/2.6.8/lib/ruby/gems/2.6.0/gems/opentelemetry-api-1.0.0/lib/opentelemetry/trace/tracer.rb:29:in `in_span'
	from hydra.rb:8:in `block in within_span'
	from versions/2.6.8/lib/ruby/gems/2.6.0/gems/opentelemetry-api-1.0.0/lib/opentelemetry/context.rb:71:in `with_current'
	from hydra.rb:7:in `within_span'
	from hydra.rb:28:in `<main>'
	from versions/2.6.8/lib/ruby/gems/2.6.0/gems/railties-5.2.5/lib/rails/commands/runner/runner_command.rb:38:in `load'
	from versions/2.6.8/lib/ruby/gems/2.6.0/gems/railties-5.2.5/lib/rails/commands/runner/runner_command.rb:38:in `perform'
	from versions/2.6.8/lib/ruby/gems/2.6.0/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
	from versions/2.6.8/lib/ruby/gems/2.6.0/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
	from versions/2.6.8/lib/ruby/gems/2.6.0/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
	from versions/2.6.8/lib/ruby/gems/2.6.0/gems/railties-5.2.5/lib/rails/command/base.rb:69:in `perform'
	from versions/2.6.8/lib/ruby/gems/2.6.0/gems/railties-5.2.5/lib/rails/command.rb:46:in `invoke'
	from versions/2.6.8/lib/ruby/gems/2.6.0/gems/railties-5.2.5/lib/rails/commands.rb:18:in `<main>'
	from bin/rails:4:in `require'
	from bin/rails:4:in `<main>'
```

It was reproduced with the following ruby script

```ruby
# Run some code with a new trace
def within_span
  tracer = OpenTelemetry::Instrumentation::Rack::Instrumentation.instance.tracer

  start_span = tracer.start_span("console", kind: :internal)
  context = OpenTelemetry::Trace.context_with_span(start_span)
  OpenTelemetry::Context.with_current(context) do
    tracer.in_span("console", kind: :internal) do
      yield
    end
  end
end

def run
  hydra = Typhoeus::Hydra.new(max_concurrency: 3)
  40.times.map do
    request = Typhoeus::Request.new("www.google.com", followlocation: true)
    request.on_complete do |response|
      puts "#{response.success?} | #{response.code}"
    end
    hydra.queue(request)
  end
  hydra.run
end


puts "within span"
within_span { run }
puts "Done"
```