### PR TITLE
fix:[Instrumentation Rack] Allow to log Content-Type HTTP header

### DIFF
--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
@@ -18,7 +18,13 @@ module OpenTelemetry
           class << self
             def allowed_rack_request_headers
               @allowed_rack_request_headers ||= Array(config[:allowed_request_headers]).each_with_object({}) do |header, memo|
-                memo["HTTP_#{header.to_s.upcase.gsub(/[-\s]/, '_')}"] = build_attribute_name('http.request.headers.', header)
+                key = header.to_s.upcase.gsub(/[-\s]/, '_')
+                case key
+                when 'CONTENT_TYPE', 'CONTENT_LENGTH'
+                  memo[key] = build_attribute_name('http.request.headers.', header)
+                else
+                  memo["HTTP_#{key}"] = build_attribute_name('http.request.headers.', header)
+                end
               end
             end
 

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/tracer_middleware_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/tracer_middleware_test.rb
@@ -162,7 +162,13 @@ describe OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware do
     end
 
     describe 'config[:allowed_request_headers]' do
-      let(:env) { Hash('HTTP_FOO_BAR' => 'http foo bar value') }
+      let(:env) do
+        Hash(
+          'CONTENT_LENGTH' => '123',
+          'CONTENT_TYPE' => 'application/json',
+          'HTTP_FOO_BAR' => 'http foo bar value'
+        )
+      end
 
       it 'defaults to nil' do
         _(first_span.attributes['http.request.headers.foo_bar']).must_be_nil
@@ -173,6 +179,22 @@ describe OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware do
 
         it 'returns attribute' do
           _(first_span.attributes['http.request.headers.foo_bar']).must_equal 'http foo bar value'
+        end
+      end
+
+      describe 'when content-type' do
+        let(:config) { default_config.merge(allowed_request_headers: ['CONTENT_TYPE']) }
+
+        it 'returns attribute' do
+          _(first_span.attributes['http.request.headers.content_type']).must_equal 'application/json'
+        end
+      end
+
+      describe 'when content-length' do
+        let(:config) { default_config.merge(allowed_request_headers: ['CONTENT_LENGTH']) }
+
+        it 'returns attribute' do
+          _(first_span.attributes['http.request.headers.content_length']).must_equal '123'
         end
       end
     end


### PR DESCRIPTION
Rack env uses `CONTENT_TYPE` key for HTTP Header `Content-Type`.
There is not common as for other headers.

https://github.com/rack/rack/blob/e0993d47096d36535dbe725091963a7e0f5aab52/lib/rack/content_type.rb#L24

Update allowed_request_headers to support `CONTENT_TYPE`.