### PR TITLE
fix: instrumentation of Rails 7

### DIFF
--- a/instrumentation/action_pack/Appraisals
+++ b/instrumentation/action_pack/Appraisals
@@ -19,6 +19,8 @@ appraise 'rails-6.1' do
   gem 'rails', '~> 6.1.0'
 end
 
-appraise 'rails-7.0' do
-  gem 'rails', '~> 7.0.0.alpha2'
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
+  appraise 'rails-7.0' do
+    gem 'rails', '~> 7.0.0.alpha2'
+  end
 end

--- a/instrumentation/action_pack/Appraisals
+++ b/instrumentation/action_pack/Appraisals
@@ -18,3 +18,7 @@ end
 appraise 'rails-6.1' do
   gem 'rails', '~> 6.1.0'
 end
+
+appraise 'rails-7.0' do
+  gem 'rails', '~> 7.0.0.alpha2'
+end

--- a/instrumentation/action_pack/gemfiles/rails_6.0.gemfile
+++ b/instrumentation/action_pack/gemfiles/rails_6.0.gemfile
@@ -8,6 +8,7 @@ gem "rails", "~> 6.0.0"
 group :test do
   gem "byebug"
   gem "opentelemetry-common", path: "../../../common"
+  gem "opentelemetry-instrumentation-base", path: "../../../instrumentation/base"
   gem "opentelemetry-instrumentation-rack", path: "../../../instrumentation/rack"
   gem "opentelemetry-sdk", path: "../../../sdk"
   gem "opentelemetry-semantic_conventions", path: "../../../semantic_conventions"

--- a/instrumentation/action_pack/gemfiles/rails_6.1.gemfile
+++ b/instrumentation/action_pack/gemfiles/rails_6.1.gemfile
@@ -8,6 +8,7 @@ gem "rails", "~> 6.1.0"
 group :test do
   gem "byebug"
   gem "opentelemetry-common", path: "../../../common"
+  gem "opentelemetry-instrumentation-base", path: "../../../instrumentation/base"
   gem "opentelemetry-instrumentation-rack", path: "../../../instrumentation/rack"
   gem "opentelemetry-sdk", path: "../../../sdk"
   gem "opentelemetry-semantic_conventions", path: "../../../semantic_conventions"

--- a/instrumentation/action_pack/gemfiles/rails_7.0.gemfile
+++ b/instrumentation/action_pack/gemfiles/rails_7.0.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "opentelemetry-api", path: "../../../api"
-gem "rails", "~> 5.2.0"
+gem "rails", "~> 7.0.0.alpha2"
 
 group :test do
   gem "byebug"

--- a/instrumentation/action_pack/test/test_helpers/app_config.rb
+++ b/instrumentation/action_pack/test/test_helpers/app_config.rb
@@ -28,6 +28,8 @@ module AppConfig
       apply_rails_6_0_configs(new_app)
     when /^6\.1/
       apply_rails_6_1_configs(new_app)
+    when /^7\./
+      apply_rails_7_configs(new_app)
     end
 
     remove_rack_middleware(new_app) if remove_rack_tracer_middleware
@@ -77,5 +79,16 @@ module AppConfig
   def apply_rails_6_1_configs(application)
     # Required in Rails 6
     application.config.hosts << 'example.org'
+  end
+
+  def apply_rails_7_configs(application)
+    # Required in Rails 7
+    application.config.hosts << 'example.org'
+
+    # Unfreeze values which may have been frozen on previous initializations.
+    ActiveSupport::Dependencies.autoload_paths =
+      ActiveSupport::Dependencies.autoload_paths.dup
+    ActiveSupport::Dependencies.autoload_once_paths =
+      ActiveSupport::Dependencies.autoload_once_paths.dup
   end
 end

--- a/instrumentation/action_view/Appraisals
+++ b/instrumentation/action_view/Appraisals
@@ -19,6 +19,8 @@ appraise 'rails-6.1' do
   gem 'rails', '~> 6.1.0'
 end
 
-appraise 'rails-7.0' do
-  gem 'rails', '~> 7.0.0.alpha2'
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
+  appraise 'rails-7.0' do
+    gem 'rails', '~> 7.0.0.alpha2'
+  end
 end

--- a/instrumentation/action_view/Appraisals
+++ b/instrumentation/action_view/Appraisals
@@ -18,3 +18,7 @@ end
 appraise 'rails-6.1' do
   gem 'rails', '~> 6.1.0'
 end
+
+appraise 'rails-7.0' do
+  gem 'rails', '~> 7.0.0.alpha2'
+end

--- a/instrumentation/action_view/gemfiles/rails_7.0.gemfile
+++ b/instrumentation/action_view/gemfiles/rails_7.0.gemfile
@@ -3,13 +3,12 @@
 source "https://rubygems.org"
 
 gem "opentelemetry-api", path: "../../../api"
-gem "rails", "~> 5.2.0"
+gem "opentelemetry-instrumentation-base", path: "../../base"
+gem "rails", "~> 7.0.0.alpha2"
 
 group :test do
   gem "byebug"
   gem "opentelemetry-common", path: "../../../common"
-  gem "opentelemetry-instrumentation-base", path: "../../../instrumentation/base"
-  gem "opentelemetry-instrumentation-rack", path: "../../../instrumentation/rack"
   gem "opentelemetry-sdk", path: "../../../sdk"
   gem "opentelemetry-semantic_conventions", path: "../../../semantic_conventions"
   gem "pry-byebug"

--- a/instrumentation/action_view/lib/opentelemetry/instrumentation/action_view/span_subscriber.rb
+++ b/instrumentation/action_view/lib/opentelemetry/instrumentation/action_view/span_subscriber.rb
@@ -17,7 +17,7 @@ module OpenTelemetry
       def self.subscribe(pattern = nil, callable = nil)
         ActiveSupport::Notifications.subscribe(pattern, callable)
         ::ActiveSupport::Notifications.notifier.synchronize do
-          if ::Rails::VERSION::MAJOR == 6
+          if ::Rails::VERSION::MAJOR >= 6
             s = ::ActiveSupport::Notifications.notifier.instance_variable_get(:@string_subscribers)[pattern].pop
             ::ActiveSupport::Notifications.notifier.instance_variable_get(:@string_subscribers)[pattern].unshift(s)
           else

--- a/instrumentation/rails/Appraisals
+++ b/instrumentation/rails/Appraisals
@@ -19,6 +19,8 @@ appraise 'rails-6.1' do
   gem 'rails', '~> 6.1.0'
 end
 
-appraise 'rails-7.0' do
-  gem 'rails', '~> 7.0.0.alpha2'
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
+  appraise 'rails-7.0' do
+    gem 'rails', '~> 7.0.0.alpha2'
+  end
 end

--- a/instrumentation/rails/Appraisals
+++ b/instrumentation/rails/Appraisals
@@ -18,3 +18,7 @@ end
 appraise 'rails-6.1' do
   gem 'rails', '~> 6.1.0'
 end
+
+appraise 'rails-7.0' do
+  gem 'rails', '~> 7.0.0.alpha2'
+end

--- a/instrumentation/rails/gemfiles/rails_5.2.gemfile
+++ b/instrumentation/rails/gemfiles/rails_5.2.gemfile
@@ -9,6 +9,8 @@ gem "rails", "~> 5.2.0"
 group :test do
   gem "byebug"
   gem "opentelemetry-common", path: "../../../common"
+  gem "opentelemetry-instrumentation-action_pack", path: "../../../instrumentation/action_pack"
+  gem "opentelemetry-instrumentation-action_view", path: "../../../instrumentation/action_view"
   gem "opentelemetry-instrumentation-active_record", path: "../../../instrumentation/active_record"
   gem "opentelemetry-instrumentation-rack", path: "../../../instrumentation/rack"
   gem "opentelemetry-sdk", path: "../../../sdk"

--- a/instrumentation/rails/gemfiles/rails_6.0.gemfile
+++ b/instrumentation/rails/gemfiles/rails_6.0.gemfile
@@ -9,6 +9,8 @@ gem "rails", "~> 6.0.0"
 group :test do
   gem "byebug"
   gem "opentelemetry-common", path: "../../../common"
+  gem "opentelemetry-instrumentation-action_pack", path: "../../../instrumentation/action_pack"
+  gem "opentelemetry-instrumentation-action_view", path: "../../../instrumentation/action_view"
   gem "opentelemetry-instrumentation-active_record", path: "../../../instrumentation/active_record"
   gem "opentelemetry-instrumentation-rack", path: "../../../instrumentation/rack"
   gem "opentelemetry-sdk", path: "../../../sdk"

--- a/instrumentation/rails/gemfiles/rails_6.1.gemfile
+++ b/instrumentation/rails/gemfiles/rails_6.1.gemfile
@@ -9,6 +9,8 @@ gem "rails", "~> 6.1.0"
 group :test do
   gem "byebug"
   gem "opentelemetry-common", path: "../../../common"
+  gem "opentelemetry-instrumentation-action_pack", path: "../../../instrumentation/action_pack"
+  gem "opentelemetry-instrumentation-action_view", path: "../../../instrumentation/action_view"
   gem "opentelemetry-instrumentation-active_record", path: "../../../instrumentation/active_record"
   gem "opentelemetry-instrumentation-rack", path: "../../../instrumentation/rack"
   gem "opentelemetry-sdk", path: "../../../sdk"

--- a/instrumentation/rails/gemfiles/rails_7.0.gemfile
+++ b/instrumentation/rails/gemfiles/rails_7.0.gemfile
@@ -3,12 +3,15 @@
 source "https://rubygems.org"
 
 gem "opentelemetry-api", path: "../../../api"
-gem "rails", "~> 5.2.0"
+gem "opentelemetry-instrumentation-base", path: "../../base"
+gem "rails", "~> 7.0.0.alpha2"
 
 group :test do
   gem "byebug"
   gem "opentelemetry-common", path: "../../../common"
-  gem "opentelemetry-instrumentation-base", path: "../../../instrumentation/base"
+  gem "opentelemetry-instrumentation-action_pack", path: "../../../instrumentation/action_pack"
+  gem "opentelemetry-instrumentation-action_view", path: "../../../instrumentation/action_view"
+  gem "opentelemetry-instrumentation-active_record", path: "../../../instrumentation/active_record"
   gem "opentelemetry-instrumentation-rack", path: "../../../instrumentation/rack"
   gem "opentelemetry-sdk", path: "../../../sdk"
   gem "opentelemetry-semantic_conventions", path: "../../../semantic_conventions"

--- a/instrumentation/rails/test/test_helpers/app_config.rb
+++ b/instrumentation/rails/test/test_helpers/app_config.rb
@@ -28,6 +28,8 @@ module AppConfig
       apply_rails_6_0_configs(new_app)
     when /^6\.1/
       apply_rails_6_1_configs(new_app)
+    when /^7\./
+      apply_rails_7_configs(new_app)
     end
 
     remove_rack_middleware(new_app) if remove_rack_tracer_middleware
@@ -77,5 +79,16 @@ module AppConfig
   def apply_rails_6_1_configs(application)
     # Required in Rails 6
     application.config.hosts << 'example.org'
+  end
+
+  def apply_rails_7_configs(application)
+    # Required in Rails 7
+    application.config.hosts << 'example.org'
+
+    # Unfreeze values which may have been frozen on previous initializations.
+    ActiveSupport::Dependencies.autoload_paths =
+      ActiveSupport::Dependencies.autoload_paths.dup
+    ActiveSupport::Dependencies.autoload_once_paths =
+      ActiveSupport::Dependencies.autoload_once_paths.dup
   end
 end


### PR DESCRIPTION
ActionView instrumentation no longer fails by having it use the same
subscriber logic as used for Rails 6.

Also add Rails 7 Appraisals to all relevant gems which has any Rails
Appraisals.