### PR TITLE
test: dont merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches:
       - main
-
 jobs:
   test:
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby' }}


### PR DESCRIPTION
dont merge want to test if bitnami/redis image is behaving as expected, or i guess, maybe the base image we use in ci?

```
>> BUNDLE_GEMFILE=/home/runner/work/opentelemetry-ruby/opentelemetry-ruby/instrumentation/sidekiq/gemfiles/sidekiq_6.1.gemfile bundle exec rake test
/home/runner/work/opentelemetry-ruby/opentelemetry-ruby/instrumentation/sidekiq/Rakefile:15:in `exec': No such file or directory - redis-server (Errno::ENOENT)
	from /home/runner/work/opentelemetry-ruby/opentelemetry-ruby/instrumentation/sidekiq/Rakefile:15:in `block (2 levels) in <top (required)>'
```