### PR TITLE
chore: fix tests for sidekiq to support inline lua changes

### DIFF
--- a/instrumentation/sidekiq/Appraisals
+++ b/instrumentation/sidekiq/Appraisals
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+appraise 'sidekiq-6.3' do
+  gem 'sidekiq', '~> 6.3'
+end
+
 appraise 'sidekiq-6.1' do
   gem 'sidekiq', '~> 6.1'
 end

--- a/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/patches/poller_test.rb
+++ b/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/patches/poller_test.rb
@@ -46,7 +46,8 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Patches::Poller do
         poller.enqueue
         span_names = spans.map(&:name)
         _(span_names).must_include('Sidekiq::Scheduled::Poller#enqueue')
-        _(span_names).must_include('ZRANGEBYSCORE')
+        # Inline Lua uses a different redis client method in 6.3+ https://github.com/mperham/sidekiq/pull/5044
+        _(span_names).must_include('ZRANGEBYSCORE') if Gem.loaded_specs['sidekiq'].version < Gem::Version.new('6.3')
       end
 
       describe 'when peer_service config is set' do


### PR DESCRIPTION
### Summary

Sidekiq cut a 6.3 release over the weekend, which has some fancy new and improved inline Lua https://github.com/mperham/sidekiq/pull/5044. While slick, it also happens to use a slightly different redis client method that ends up breaking some of our test assumptions about what gets traced in redis from our sidekiq poller instrumentation. Our CI is now failing as a result(failed run example here: https://github.com/open-telemetry/opentelemetry-ruby/runs/4144038824?check_suite_focus=true).

This PR updates the sidekiq instrumentation test suite to only expect that poller redis instrumentation when `sidekiq < 6.3x`.

Not exactly the prettiest solution but ought to work? long term i think further evidence that a canary build or some pessimistic version constraints can help us avoid this sort of brittleness https://github.com/open-telemetry/opentelemetry-ruby/issues/988