### PR TITLE
feat: add dalli obfuscation for db_statement

### DIFF
--- a/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/instrumentation.rb
+++ b/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/instrumentation.rb
@@ -20,7 +20,7 @@ module OpenTelemetry
         end
 
         option :peer_service, default: nil, validate: :string
-        option :db_statement, default: :include, validate: ->(opt) { %I[omit include].include?(opt) }
+        option :db_statement, default: :include, validate: ->(opt) { %I[omit obfuscate include].include?(opt) }
 
         private
 

--- a/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/patches/server.rb
+++ b/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/patches/server.rb
@@ -18,7 +18,7 @@ module OpenTelemetry
               'net.peer.port' => port
             }
             if config[:db_statement] == :include
-              attributes['db.statement'] = Utils.format_command(operation, args) 
+              attributes['db.statement'] = Utils.format_command(operation, args)
             elsif config[:db_statement] == :obfuscate
               attributes['db.statement'] = "#{operation} ?"
             end

--- a/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/patches/server.rb
+++ b/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/patches/server.rb
@@ -17,7 +17,12 @@ module OpenTelemetry
               'net.peer.name' => hostname,
               'net.peer.port' => port
             }
-            attributes['db.statement'] = Utils.format_command(operation, args) if config[:db_statement] == :include
+            if config[:db_statement] == :include
+              attributes['db.statement'] = Utils.format_command(operation, args) 
+            elsif config[:db_statement] == :obfuscate
+              attributes['db.statement'] = "#{operation} ?"
+            end
+
             attributes['peer.service'] = config[:peer_service] if config[:peer_service]
             tracer.in_span(operation, attributes: attributes, kind: :client) do
               super

--- a/instrumentation/dalli/test/opentelemetry/instrumentation/dalli/instrumentation_test.rb
+++ b/instrumentation/dalli/test/opentelemetry/instrumentation/dalli/instrumentation_test.rb
@@ -107,5 +107,16 @@ describe OpenTelemetry::Instrumentation::Dalli::Instrumentation do
       _(span.name).must_equal 'set'
       _(span.attributes).wont_include 'db.statement'
     end
+
+    it 'obfuscates db.statement' do
+      instrumentation.instance_variable_set(:@installed, false)
+      instrumentation.install(db_statement: :obfuscate)
+
+      dalli.set('foo', 'bar')
+
+      _(exporter.finished_spans.size).must_equal 1
+      _(span.name).must_equal 'set'
+      _(span.attributes['db.statement']).must_equal 'set ?'
+    end
   end
 end unless ENV['OMIT_SERVICES']


### PR DESCRIPTION
### Summary

In an attempt to standardize options around database instrumentation `db_statement` settings, this PR adds the `:obfuscate` value to dalli ( a memcached client)'s `db_statement` configuration option. When enabled, it will obfuscate the `db.statement` span attribute. In practice this simply means dropping the arguments and only including the command, which is relatively low value (since it's already available in the span name) but, for the sake of consistency with the other database instrumentations, this allows users to still capture some level of detail in their `db.statement` attribute without potentially exposing sensitive information.