### PR TITLE
fix: resolve Dalli::Server deprecation in 3.0+

### DIFF
--- a/instrumentation/dalli/Appraisals
+++ b/instrumentation/dalli/Appraisals
@@ -3,3 +3,7 @@
 appraise 'dalli-2.7' do
   gem 'dalli', '~> 2.7'
 end
+
+appraise 'dalli-3.0' do
+  gem 'dalli', '~> 3.0'
+end

--- a/instrumentation/dalli/gemfiles/dalli_3.0.gemfile
+++ b/instrumentation/dalli/gemfiles/dalli_3.0.gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gem "opentelemetry-api", path: "../../../api"
 gem "opentelemetry-instrumentation-base", path: "../../base"
-gem "dalli", "~> 2.7"
+gem "dalli", "~> 3.0"
 
 group :test do
   gem "opentelemetry-common", path: "../../../common"

--- a/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/instrumentation.rb
+++ b/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/instrumentation.rb
@@ -30,7 +30,11 @@ module OpenTelemetry
         end
 
         def add_patches
-          ::Dalli::Server.prepend(Patches::Server)
+          if Gem::Version.new(::Dalli::VERSION) < Gem::Version.new('3.0.0')
+            ::Dalli::Server.prepend(Patches::Server)
+          else
+            ::Dalli::Protocol::Binary.prepend(Patches::Server)
+          end
         end
       end
     end

--- a/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/patches/server.rb
+++ b/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/patches/server.rb
@@ -8,7 +8,7 @@ module OpenTelemetry
   module Instrumentation
     module Dalli
       module Patches
-        # Module to prepend to Dalli::Server for instrumentation
+        # Module to prepend to Dalli::Server (or Dalli::Protocol::Binary in 3.0+) for instrumentation
         module Server
           def request(op, *args)
             operation = Utils.opname(op, multi?)

--- a/instrumentation/dalli/opentelemetry-instrumentation-dalli.gemspec
+++ b/instrumentation/dalli/opentelemetry-instrumentation-dalli.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '>= 1.17'
-  spec.add_development_dependency 'dalli', '~> 2.7'
+  spec.add_development_dependency 'dalli', '>= 2.7'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.0'
   spec.add_development_dependency 'rubocop', '~> 0.73.0'

--- a/instrumentation/dalli/test/opentelemetry/instrumentation/dalli/instrumentation_test.rb
+++ b/instrumentation/dalli/test/opentelemetry/instrumentation/dalli/instrumentation_test.rb
@@ -80,7 +80,7 @@ describe OpenTelemetry::Instrumentation::Dalli::Instrumentation do
       dalli.set('foo', 'bar')
       exporter.reset
 
-      dalli.instance_variable_get(:@ring).servers.first.stub(:write, ->(_bytes) { raise Dalli::NetworkError }) do
+      dalli.instance_variable_get(:@ring).servers.first.stub(:write, ->(_bytes) { raise Dalli::DalliError }) do
         dalli.get_multi('foo', 'bar')
       end
 
@@ -93,8 +93,8 @@ describe OpenTelemetry::Instrumentation::Dalli::Instrumentation do
 
       span_event = span.events.first
       _(span_event.name).must_equal 'exception'
-      _(span_event.attributes['exception.type']).must_equal 'Dalli::NetworkError'
-      _(span_event.attributes['exception.message']).must_equal 'Dalli::NetworkError'
+      _(span_event.attributes['exception.type']).must_equal 'Dalli::DalliError'
+      _(span_event.attributes['exception.message']).must_equal 'Dalli::DalliError'
     end
 
     it 'omits db.statement' do


### PR DESCRIPTION
Dalli 3.0 has deprecated `Dalli::Server` in petergoldstein/dalli#760

I believe the fix is simply to use `Dalli::Protocol::Binary` instead, when Dalli >=3.0 is detected (while still using `Dalli::Server` in <3.0).

I've created a new Appraisal config to test this with Dalli 3.0, while still also testing 2.7.

Related: [Dalli 3.0 Upgrade Guide](https://github.com/petergoldstein/dalli/blob/master/3.0-Upgrade.md)