### PR TITLE
feat: deployment resource detector

### DIFF
--- a/resource_detectors/README.md
+++ b/resource_detectors/README.md
@@ -30,6 +30,7 @@ require 'opentelemetry/resource/detectors'
 # For a specific platform
 OpenTelemetry::SDK.configure do |c|
   c.resource = OpenTelemetry::Resource::Detectors::GoogleCloudPlatform.detect
+  c.resource = OpenTelemetry::Resource::Detectors::Deployment.detect
 end
 
 # Or if you would like for it to run all detectors available

--- a/resource_detectors/lib/opentelemetry/resource/detectors.rb
+++ b/resource_detectors/lib/opentelemetry/resource/detectors.rb
@@ -7,6 +7,7 @@
 require 'opentelemetry/sdk'
 require 'opentelemetry/resource/detectors/version'
 require 'opentelemetry/resource/detectors/google_cloud_platform'
+require 'opentelemetry/resource/detectors/deployment'
 require 'opentelemetry/resource/detectors/auto_detector'
 
 # OpenTelemetry is an open source observability framework, providing a

--- a/resource_detectors/lib/opentelemetry/resource/detectors/auto_detector.rb
+++ b/resource_detectors/lib/opentelemetry/resource/detectors/auto_detector.rb
@@ -13,7 +13,7 @@ module OpenTelemetry
 
         DETECTORS = [
           OpenTelemetry::Resource::Detectors::GoogleCloudPlatform,
-          OpenTelemetry::Resource::Detectors::Deployment,
+          OpenTelemetry::Resource::Detectors::Deployment
         ].freeze
 
         def detect

--- a/resource_detectors/lib/opentelemetry/resource/detectors/auto_detector.rb
+++ b/resource_detectors/lib/opentelemetry/resource/detectors/auto_detector.rb
@@ -12,7 +12,8 @@ module OpenTelemetry
         extend self
 
         DETECTORS = [
-          OpenTelemetry::Resource::Detectors::GoogleCloudPlatform
+          OpenTelemetry::Resource::Detectors::GoogleCloudPlatform,
+          OpenTelemetry::Resource::Detectors::Deployment,
         ].freeze
 
         def detect

--- a/resource_detectors/lib/opentelemetry/resource/detectors/deployment.rb
+++ b/resource_detectors/lib/opentelemetry/resource/detectors/deployment.rb
@@ -9,8 +9,8 @@ module OpenTelemetry
 
         def detect
           resource_attributes = {}
-          deployment_environment = rails_env || rack_env
-          resource_attributes[::OpenTelemetry::SemanticConventions::Resource::DEPLOYMENT_ENVIRONMENT] = deployment_environment.to_str if deployment_environment
+          deployment_environment = rails_env || sinatra_env || rack_env
+          resource_attributes[::OpenTelemetry::SemanticConventions::Resource::DEPLOYMENT_ENVIRONMENT] = deployment_environment if deployment_environment
           OpenTelemetry::SDK::Resources::Resource.create(resource_attributes)
         end
 
@@ -20,15 +20,27 @@ module OpenTelemetry
           # rails extract env like this:
           # https://github.com/rails/rails/blob/5647a9c1ced68d20338552d47a3b755e10a271c4/railties/lib/rails.rb#L74
           # ActiveSupport::EnvironmentInquirer.new(ENV["RAILS_ENV"].presence || ENV["RACK_ENV"].presence || "development")
-          ::Rails.env if defined?(::Rails.env)
+          ::Rails.env.to_str if defined?(::Rails.env)
         end
 
         def rack_env
           ENV['RACK_ENV']
         end
 
-        # TODO: add sinatra:
-        # https://github.com/sinatra/sinatra/blob/e69b6b9dee7165d3a583fc8a6af10ceee1ea687d/lib/sinatra/base.rb#L1801
+        def sinatra_env
+          # https://github.com/sinatra/sinatra/blob/e69b6b9dee7165d3a583fc8a6af10ceee1ea687d/lib/sinatra/base.rb#L1801
+          # cases:
+          #
+          # 1. if sinatra is "require"d before the detector, then we return the value from the library
+          # this case will return the default "development" fallback if not env variable is set which is good.
+          #
+          # 2. if sinatra is "require"d after the detector, then:
+          # 2.1 if user is setting environment via 'APP_ENV' or 'RACK_ENV' then those value will be picked up and reported
+          # 2.2 else, the sinatra environment will fallback to "development", but detector will return nil for it.
+          # this issue is not covered, as when detector initialize the immutable resource, it has no way
+          # of knowing if "sinatra" will be required later or not.
+          (::Sinatra::Base.environment.to_s if defined?(::Sinatra::Base.environment)) || ENV['APP_ENV']
+        end
       end
     end
   end

--- a/resource_detectors/lib/opentelemetry/resource/detectors/deployment.rb
+++ b/resource_detectors/lib/opentelemetry/resource/detectors/deployment.rb
@@ -20,7 +20,7 @@ module OpenTelemetry
           # rails extract env like this:
           # https://github.com/rails/rails/blob/5647a9c1ced68d20338552d47a3b755e10a271c4/railties/lib/rails.rb#L74
           # ActiveSupport::EnvironmentInquirer.new(ENV["RAILS_ENV"].presence || ENV["RACK_ENV"].presence || "development")
-          ::Rails.env.to_str if defined?(::Rails.env)
+          ::Rails.env.to_s if defined?(::Rails.env)
         end
 
         def rack_env

--- a/resource_detectors/lib/opentelemetry/resource/detectors/deployment.rb
+++ b/resource_detectors/lib/opentelemetry/resource/detectors/deployment.rb
@@ -1,38 +1,35 @@
+# frozen_string_literal: true
 
 module OpenTelemetry
-    module Resource
-      module Detectors
-            module Deployment
-                extend self
+  module Resource
+    module Detectors
+      # Deployment contains detect class method for determining deployment resource attributes
+      module Deployment
+        extend self
 
-                def detect
-                    resource_attributes = {}
-                    deployment_environment = get_rails_deployment_environment || get_rack_env
-                    if deployment_environment
-                        resource_attributes[::OpenTelemetry::SemanticConventions::Resource::DEPLOYMENT_ENVIRONMENT] = deployment_environment.to_str
-                    end
-                    OpenTelemetry::SDK::Resources::Resource.create(resource_attributes)
-                end
-
-                private
-
-                def get_rails_deployment_environment
-                    # rails extract env like this:
-                    # https://github.com/rails/rails/blob/5647a9c1ced68d20338552d47a3b755e10a271c4/railties/lib/rails.rb#L74
-                    # ActiveSupport::EnvironmentInquirer.new(ENV["RAILS_ENV"].presence || ENV["RACK_ENV"].presence || "development")
-                    if defined?(::Rails::env)
-                        ::Rails::env
-                    end
-                end
-
-                def get_rack_env
-                    ENV["RACK_ENV"]
-                end
-
-                # TODO: add sinatra:
-                # https://github.com/sinatra/sinatra/blob/e69b6b9dee7165d3a583fc8a6af10ceee1ea687d/lib/sinatra/base.rb#L1801
-                
-            end
+        def detect
+          resource_attributes = {}
+          deployment_environment = get_rails_deployment_environment || get_rack_env
+          resource_attributes[::OpenTelemetry::SemanticConventions::Resource::DEPLOYMENT_ENVIRONMENT] = deployment_environment.to_str if deployment_environment
+          OpenTelemetry::SDK::Resources::Resource.create(resource_attributes)
         end
+
+        private
+
+        def rails_deployment_environment
+          # rails extract env like this:
+          # https://github.com/rails/rails/blob/5647a9c1ced68d20338552d47a3b755e10a271c4/railties/lib/rails.rb#L74
+          # ActiveSupport::EnvironmentInquirer.new(ENV["RAILS_ENV"].presence || ENV["RACK_ENV"].presence || "development")
+          ::Rails.env if defined?(::Rails.env)
+        end
+
+        def rack_env
+          ENV['RACK_ENV']
+        end
+
+        # TODO: add sinatra:
+        # https://github.com/sinatra/sinatra/blob/e69b6b9dee7165d3a583fc8a6af10ceee1ea687d/lib/sinatra/base.rb#L1801
+      end
     end
+  end
 end

--- a/resource_detectors/lib/opentelemetry/resource/detectors/deployment.rb
+++ b/resource_detectors/lib/opentelemetry/resource/detectors/deployment.rb
@@ -1,0 +1,38 @@
+
+module OpenTelemetry
+    module Resource
+      module Detectors
+            module Deployment
+                extend self
+
+                def detect
+                    resource_attributes = {}
+                    deployment_environment = get_rails_deployment_environment || get_rack_env
+                    if deployment_environment
+                        resource_attributes[::OpenTelemetry::SemanticConventions::Resource::DEPLOYMENT_ENVIRONMENT] = deployment_environment.to_str
+                    end
+                    OpenTelemetry::SDK::Resources::Resource.create(resource_attributes)
+                end
+
+                private
+
+                def get_rails_deployment_environment
+                    # rails extrace env like this:
+                    # https://github.com/rails/rails/blob/5647a9c1ced68d20338552d47a3b755e10a271c4/railties/lib/rails.rb#L74
+                    # ActiveSupport::EnvironmentInquirer.new(ENV["RAILS_ENV"].presence || ENV["RACK_ENV"].presence || "development")
+                    if defined?(::Rails::env)
+                        ::Rails::env
+                    end
+                end
+
+                def get_rack_env
+                    ENV["RACK_ENV"]
+                end
+
+                # TODO: add sinatra:
+                # https://github.com/sinatra/sinatra/blob/e69b6b9dee7165d3a583fc8a6af10ceee1ea687d/lib/sinatra/base.rb#L1801
+                
+            end
+        end
+    end
+end

--- a/resource_detectors/lib/opentelemetry/resource/detectors/deployment.rb
+++ b/resource_detectors/lib/opentelemetry/resource/detectors/deployment.rb
@@ -17,7 +17,7 @@ module OpenTelemetry
                 private
 
                 def get_rails_deployment_environment
-                    # rails extrace env like this:
+                    # rails extract env like this:
                     # https://github.com/rails/rails/blob/5647a9c1ced68d20338552d47a3b755e10a271c4/railties/lib/rails.rb#L74
                     # ActiveSupport::EnvironmentInquirer.new(ENV["RAILS_ENV"].presence || ENV["RACK_ENV"].presence || "development")
                     if defined?(::Rails::env)

--- a/resource_detectors/lib/opentelemetry/resource/detectors/deployment.rb
+++ b/resource_detectors/lib/opentelemetry/resource/detectors/deployment.rb
@@ -9,14 +9,14 @@ module OpenTelemetry
 
         def detect
           resource_attributes = {}
-          deployment_environment = rails_deployment_environment || rack_env
+          deployment_environment = rails_env || rack_env
           resource_attributes[::OpenTelemetry::SemanticConventions::Resource::DEPLOYMENT_ENVIRONMENT] = deployment_environment.to_str if deployment_environment
           OpenTelemetry::SDK::Resources::Resource.create(resource_attributes)
         end
 
         private
 
-        def rails_deployment_environment
+        def rails_env
           # rails extract env like this:
           # https://github.com/rails/rails/blob/5647a9c1ced68d20338552d47a3b755e10a271c4/railties/lib/rails.rb#L74
           # ActiveSupport::EnvironmentInquirer.new(ENV["RAILS_ENV"].presence || ENV["RACK_ENV"].presence || "development")

--- a/resource_detectors/lib/opentelemetry/resource/detectors/deployment.rb
+++ b/resource_detectors/lib/opentelemetry/resource/detectors/deployment.rb
@@ -9,7 +9,7 @@ module OpenTelemetry
 
         def detect
           resource_attributes = {}
-          deployment_environment = get_rails_deployment_environment || get_rack_env
+          deployment_environment = rails_deployment_environment || rack_env
           resource_attributes[::OpenTelemetry::SemanticConventions::Resource::DEPLOYMENT_ENVIRONMENT] = deployment_environment.to_str if deployment_environment
           OpenTelemetry::SDK::Resources::Resource.create(resource_attributes)
         end

--- a/resource_detectors/opentelemetry-resource_detectors.gemspec
+++ b/resource_detectors/opentelemetry-resource_detectors.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 12.0'
+  spec.add_development_dependency 'rspec-mocks'
   spec.add_development_dependency 'rubocop', '~> 0.73.0'
   spec.add_development_dependency 'simplecov', '~> 0.17'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/resource_detectors/test/opentelemetry/detectors/deployment_test.rb
+++ b/resource_detectors/test/opentelemetry/detectors/deployment_test.rb
@@ -15,11 +15,21 @@ describe OpenTelemetry::Resource::Detectors::Deployment do
       _(detected_resource_attributes).must_equal(expected_resource_attributes)
     end
 
+    describe 'when rails is used' do
+      it 'return rails env when present' do
+        allow(::Rails).to receive(:env).and_return('env from rails')
+        with_env({}) do
+          _(detected_resource).must_be_instance_of(OpenTelemetry::SDK::Resources::Resource)
+          _(detected_resource_attributes).must_equal('deployment.environment' => 'env from rails')          
+        end
+      end
+    end
+
     describe 'when in a rack environment' do
       it 'returns a resource with rack environment' do
-        with_env('RACK_ENV' => 'env from test') do
+        with_env('RACK_ENV' => 'env from rack') do
           _(detected_resource).must_be_instance_of(OpenTelemetry::SDK::Resources::Resource)
-          _(detected_resource_attributes).must_equal('deployment.environment' => 'env from test')
+          _(detected_resource_attributes).must_equal('deployment.environment' => 'env from rack')
         end
       end
     end

--- a/resource_detectors/test/opentelemetry/detectors/deployment_test.rb
+++ b/resource_detectors/test/opentelemetry/detectors/deployment_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 require 'test_helper'
 
@@ -20,12 +21,11 @@ describe OpenTelemetry::Resource::Detectors::GoogleCloudPlatform do
         ENV['RACK_ENV'] = 'env from test'
         begin
           _(detected_resource).must_be_instance_of(OpenTelemetry::SDK::Resources::Resource)
-          _(detected_resource_attributes).must_equal({'deployment.environment' => 'env from test'})
+          _(detected_resource_attributes).must_equal({ 'deployment.environment' => 'env from test' })
         ensure
           ENV['RACK_ENV'] = old_env
         end
       end
     end
   end
-
 end

--- a/resource_detectors/test/opentelemetry/detectors/deployment_test.rb
+++ b/resource_detectors/test/opentelemetry/detectors/deployment_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-describe OpenTelemetry::Resource::Detectors::GoogleCloudPlatform do
+describe OpenTelemetry::Resource::Detectors::Deployment do
   let(:detector) { OpenTelemetry::Resource::Detectors::Deployment }
 
   describe '.detect' do

--- a/resource_detectors/test/opentelemetry/detectors/deployment_test.rb
+++ b/resource_detectors/test/opentelemetry/detectors/deployment_test.rb
@@ -17,13 +17,9 @@ describe OpenTelemetry::Resource::Detectors::Deployment do
 
     describe 'when in a rack environment' do
       it 'returns a resource with rack environment' do
-        old_env = ENV['RACK_ENV']
-        ENV['RACK_ENV'] = 'env from test'
-        begin
+        with_env('RACK_ENV' => 'env from test') do
           _(detected_resource).must_be_instance_of(OpenTelemetry::SDK::Resources::Resource)
           _(detected_resource_attributes).must_equal('deployment.environment' => 'env from test')
-        ensure
-          ENV['RACK_ENV'] = old_env
         end
       end
     end

--- a/resource_detectors/test/opentelemetry/detectors/deployment_test.rb
+++ b/resource_detectors/test/opentelemetry/detectors/deployment_test.rb
@@ -19,7 +19,7 @@ describe OpenTelemetry::Resource::Detectors::Deployment do
 
     describe 'when rails is used' do
       it 'return rails env when present' do
-        module MockRails # rubocop:disable Lint/ConstantDefinitionInBlock
+        module MockRails
           def self.env
             'env from rails'
           end
@@ -35,7 +35,7 @@ describe OpenTelemetry::Resource::Detectors::Deployment do
 
     describe 'when sinatra is used' do
       it 'return sinatra env if already required' do
-        module MockSinatraBase  # rubocop:disable Lint/ConstantDefinitionInBlock
+        module MockSinatraBase
           def self.environment
             'env from sinatra'
           end
@@ -49,7 +49,7 @@ describe OpenTelemetry::Resource::Detectors::Deployment do
       end
 
       it 'when sinatra not yet initialized, but environment set in ENV' do
-        with_env({ 'APP_ENV' => 'env from sinatra environment variables' }) do
+        with_env('APP_ENV' => 'env from sinatra environment variables') do
           _(detected_resource).must_be_instance_of(OpenTelemetry::SDK::Resources::Resource)
           _(detected_resource_attributes).must_equal('deployment.environment' => 'env from sinatra environment variables')
         end

--- a/resource_detectors/test/opentelemetry/detectors/deployment_test.rb
+++ b/resource_detectors/test/opentelemetry/detectors/deployment_test.rb
@@ -11,8 +11,10 @@ describe OpenTelemetry::Resource::Detectors::Deployment do
     let(:expected_resource_attributes) { {} }
 
     it 'returns an empty resource' do
-      _(detected_resource).must_be_instance_of(OpenTelemetry::SDK::Resources::Resource)
-      _(detected_resource_attributes).must_equal(expected_resource_attributes)
+      with_env({}) do
+        _(detected_resource).must_be_instance_of(OpenTelemetry::SDK::Resources::Resource)
+        _(detected_resource_attributes).must_equal(expected_resource_attributes)
+      end
     end
 
     describe 'when rails is used' do
@@ -20,7 +22,7 @@ describe OpenTelemetry::Resource::Detectors::Deployment do
         allow(::Rails).to receive(:env).and_return('env from rails')
         with_env({}) do
           _(detected_resource).must_be_instance_of(OpenTelemetry::SDK::Resources::Resource)
-          _(detected_resource_attributes).must_equal('deployment.environment' => 'env from rails')          
+          _(detected_resource_attributes).must_equal('deployment.environment' => 'env from rails')
         end
       end
     end

--- a/resource_detectors/test/opentelemetry/detectors/deployment_test.rb
+++ b/resource_detectors/test/opentelemetry/detectors/deployment_test.rb
@@ -21,7 +21,7 @@ describe OpenTelemetry::Resource::Detectors::Deployment do
         ENV['RACK_ENV'] = 'env from test'
         begin
           _(detected_resource).must_be_instance_of(OpenTelemetry::SDK::Resources::Resource)
-          _(detected_resource_attributes).must_equal({ 'deployment.environment' => 'env from test' })
+          _(detected_resource_attributes).must_equal('deployment.environment' => 'env from test')
         ensure
           ENV['RACK_ENV'] = old_env
         end

--- a/resource_detectors/test/opentelemetry/detectors/deployment_test.rb
+++ b/resource_detectors/test/opentelemetry/detectors/deployment_test.rb
@@ -19,7 +19,7 @@ describe OpenTelemetry::Resource::Detectors::Deployment do
 
     describe 'when rails is used' do
       it 'return rails env when present' do
-        module MockRails  # rubocop:disable Lint/ConstantDefinitionInBlock
+        module MockRails # rubocop:disable Lint/ConstantDefinitionInBlock
           def self.env
             'env from rails'
           end

--- a/resource_detectors/test/opentelemetry/detectors/deployment_test.rb
+++ b/resource_detectors/test/opentelemetry/detectors/deployment_test.rb
@@ -1,0 +1,31 @@
+
+require 'test_helper'
+
+describe OpenTelemetry::Resource::Detectors::GoogleCloudPlatform do
+  let(:detector) { OpenTelemetry::Resource::Detectors::Deployment }
+
+  describe '.detect' do
+    let(:detected_resource) { detector.detect }
+    let(:detected_resource_attributes) { detected_resource.attribute_enumerator.to_h }
+    let(:expected_resource_attributes) { {} }
+
+    it 'returns an empty resource' do
+      _(detected_resource).must_be_instance_of(OpenTelemetry::SDK::Resources::Resource)
+      _(detected_resource_attributes).must_equal(expected_resource_attributes)
+    end
+
+    describe 'when in a rack environment' do
+      it 'returns a resource with rack environment' do
+        old_env = ENV['RACK_ENV']
+        ENV['RACK_ENV'] = 'env from test'
+        begin
+          _(detected_resource).must_be_instance_of(OpenTelemetry::SDK::Resources::Resource)
+          _(detected_resource_attributes).must_equal({'deployment.environment' => 'env from test'})
+        ensure
+          ENV['RACK_ENV'] = old_env
+        end
+      end
+    end
+  end
+
+end

--- a/resource_detectors/test/test_helper.rb
+++ b/resource_detectors/test/test_helper.rb
@@ -7,6 +7,7 @@
 require 'simplecov'
 SimpleCov.start
 
+require 'opentelemetry/common/test_helpers'
 require 'opentelemetry/resource/detectors'
 require 'minitest/autorun'
 require 'pry'

--- a/resource_detectors/test/test_helper.rb
+++ b/resource_detectors/test/test_helper.rb
@@ -10,4 +10,5 @@ SimpleCov.start
 require 'opentelemetry/common/test_helpers'
 require 'opentelemetry/resource/detectors'
 require 'minitest/autorun'
+require 'rspec/mocks/minitest_integration'
 require 'pry'


### PR DESCRIPTION
automatic resource detector for [deployment](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/deployment_environment.md)

I am new to ruby, so please don't hesitate to point me on how to do things correctly if I implemented any anti-pattern.
Also, I am not sure how to write tests for extracting the env from `::Rails::env`. Will appreciate some guidance on this
