### PR TITLE
feat: Version Compatibility Based on Gem Specs

### DIFF
--- a/.instrumentation_generator/templates/gemspec.tt
+++ b/.instrumentation_generator/templates/gemspec.tt
@@ -38,6 +38,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+  # TODO Add semantic version constraints
+  spec.add_development_dependency '<%= instrumentation_name %>'
 
   if spec.respond_to?(:metadata)
     spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-<%= instrumentation_name %>/v#{OpenTelemetry::Instrumentation::<%= pascal_cased_instrumentation_name %>::VERSION}/file.CHANGELOG.html"

--- a/.instrumentation_generator/templates/lib/instrumentation/instrumentation_name/instrumentation.rb.tt
+++ b/.instrumentation_generator/templates/lib/instrumentation/instrumentation_name/instrumentation.rb.tt
@@ -9,6 +9,8 @@ module OpenTelemetry
     module <%= pascal_cased_instrumentation_name %>
       # The Instrumentation class contains logic to detect and install the <%= pascal_cased_instrumentation_name %> instrumentation
       class Instrumentation < OpenTelemetry::Instrumentation::Base
+        instrumented_library_name '<%= instrumentation_name %>'
+
         install do |_config|
           require_dependencies
         end

--- a/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
@@ -308,7 +308,8 @@ module OpenTelemetry
 
           dependency = instrumentation_spec.development_dependencies.find { |spec| spec.name == library_spec.name }
           dependency&.requirement&.satisfied_by?(library_spec.version) == true
-        rescue Gem::MissingSpecError
+        rescue Gem::MissingSpecError => e
+          OpenTelemetry.handle_error(message: 'Instrumentation Compatibility Check Error', exception: e)
           return false
         end
       end

--- a/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
@@ -302,11 +302,15 @@ module OpenTelemetry
 
       # Checks compatability of `library_name` against the `development_dependency` declared in  instrumentations gemspec
       def compatible_version?
-        instrumentation_spec = Gem.loaded_specs[instrumentation_gem_name] || Gem::Specification.find_by_name(instrumentation_gem_name)
-        library_spec = Gem.loaded_specs[library_name] || Gem::Specification.find_by_name(library_name)
+        begin
+          instrumentation_spec = Gem.loaded_specs[instrumentation_gem_name] || Gem::Specification.find_by_name(instrumentation_gem_name)
+          library_spec = Gem.loaded_specs[library_name] || Gem::Specification.find_by_name(library_name)
 
-        dependency = instrumentation_spec&.development_dependencies&.find { |spec| spec.name == library_spec.name }
-        dependency&.requirement&.satisfied_by?(library_spec.version) == true
+          dependency = instrumentation_spec.development_dependencies.find { |spec| spec.name == library_spec.name }
+          dependency&.requirement&.satisfied_by?(library_spec.version) == true
+        rescue Gem::MissingSpecError
+          return false
+        end
       end
 
       # The config_options method is responsible for validating that the user supplied

--- a/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
@@ -134,7 +134,7 @@ module OpenTelemetry
         #
         # Set this value in lieu writing a custom compatible block.
         # @param [String] library_name must match the gem specification name of the instrumented library
-        def library_name(library_name=nil)
+        def library_name(library_name = nil)
           @library_name ||= library_name
         end
 
@@ -278,6 +278,7 @@ module OpenTelemetry
       # - a `library_name` use to compare gemspecs
       def compatible?
         return true unless @compatible_blk || library_name
+
         if @compatible_blk
           instance_exec(&@compatible_blk)
         else
@@ -304,10 +305,8 @@ module OpenTelemetry
         instrumentation_spec = Gem.loaded_specs[instrumentation_gem_name] || Gem::Specification.find_by_name(instrumentation_gem_name)
         library_spec = Gem.loaded_specs[library_name] || Gem::Specification.find_by_name(library_name)
 
-        return false if instrumentation_spec.nil? || library_spec.nil?
-
-        dependency = instrumentation_spec.development_dependencies.find { |spec| spec.name == library_spec.name }
-        dependency.requirement.satisfied_by?(library_spec.version)
+        dependency = instrumentation_spec&.development_dependencies&.find { |spec| spec.name == library_spec.name }
+        dependency&.requirement&.satisfied_by?(library_spec.version) == true
       end
 
       # The config_options method is responsible for validating that the user supplied

--- a/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/base.rb
@@ -310,8 +310,8 @@ module OpenTelemetry
       # See https://github.com/DataDog/dd-trace-rb/pull/1510
       # rubocop:disable Metrics/AbcSize
       def compatible_version?
-        instrumentation_spec = Gem.loaded_specs[instrumentation_gem_name] || Gem::Specification.find_by_name(instrumentation_gem_name)
-        library_spec = Gem.loaded_specs[library_name] || Gem::Specification.find_by_name(library_name)
+        instrumentation_spec = Gem.loaded_specs.fetch(instrumentation_gem_name) { Gem::Specification.find_by_name(instrumentation_gem_name) }
+        library_spec = Gem.loaded_specs.fetch(library_name) { Gem::Specification.find_by_name(library_name) }
 
         dependency = instrumentation_spec.development_dependencies.find { |spec| spec.name == library_name }
         dependency&.requirement&.satisfied_by?(library_spec&.version) == true

--- a/instrumentation/base/test/instrumentation/base_test.rb
+++ b/instrumentation/base/test/instrumentation/base_test.rb
@@ -146,10 +146,6 @@ describe OpenTelemetry::Instrumentation::Base do
       "opentelemetry-instrumentation-#{library_name}"
     end
 
-    def compatible_version?
-      instrumentation.instance.compatible_version?
-    end
-
     describe 'when comparing gemspecs' do
       let(:library_gem_spec) do
         Gem::Specification.new do |spec|
@@ -176,7 +172,7 @@ describe OpenTelemetry::Instrumentation::Base do
         describe 'with compatible versions' do
           it 'returns true' do
             Gem.stub(:loaded_specs, loaded_specs) do
-              _(compatible_version?).must_equal(true)
+              _(instrumentation.instance.compatible_version?).must_equal(true)
             end
           end
         end
@@ -188,7 +184,7 @@ describe OpenTelemetry::Instrumentation::Base do
 
           it 'returns false' do
             Gem.stub(:loaded_specs, loaded_specs) do
-             _(compatible_version?).must_equal(false)
+             _(instrumentation.instance.compatible_version?).must_equal(false)
             end
           end
         end
@@ -199,7 +195,7 @@ describe OpenTelemetry::Instrumentation::Base do
           it 'returns true' do
             Gem.stub(:loaded_specs, {}) do
               Gem::Specification.stub(:find_by_name, ->(name) { loaded_specs[name] } ) do
-                _(compatible_version?).must_equal(true)
+                _(instrumentation.instance.compatible_version?).must_equal(true)
               end
             end
           end
@@ -213,7 +209,7 @@ describe OpenTelemetry::Instrumentation::Base do
           it 'returns false' do
             Gem.stub(:loaded_specs, {}) do
               Gem::Specification.stub(:find_by_name, ->(name) { loaded_specs[name] } ) do
-               _(compatible_version?).must_equal(false)
+               _(instrumentation.instance.compatible_version?).must_equal(false)
               end
             end
           end

--- a/instrumentation/base/test/instrumentation/base_test.rb
+++ b/instrumentation/base/test/instrumentation/base_test.rb
@@ -124,15 +124,18 @@ describe OpenTelemetry::Instrumentation::Base do
       end
     end
 
-    describe 'when comparing gemspecs' do
-      # let(:instrumentation) do
-      #   Class.new(OpenTelemetry::Instrumentation::Base) do
-      #     library_name 'example'
-      #     instrumentation_name 'opentelemetry-instrumentation-example'
-      #     instrumentation_version '1.0.0'
-      #   end
-      # end
+    let(:library_name) do
+      'example'
+    end
 
+    def compatible_version?
+      instrumentation_spec = Gem.loaded_specs["opentelemetry-instrumentation-#{library_name}"]
+      library_spec = Gem.loaded_specs[library_name]
+      dependency = instrumentation_spec.development_dependencies.find { |spec| spec.name == library_spec.name }
+      compatible_version = dependency.requirement.satisfied_by?(library_gem_spec.version)
+    end
+
+    describe 'when comparing gemspecs' do
       let(:library_gem_spec_version) do
         '1.3.8.beta2'
       end
@@ -162,11 +165,7 @@ describe OpenTelemetry::Instrumentation::Base do
         describe 'with compatible versions' do
           it 'retruns true' do
             Gem.stub(:loaded_specs, loaded_specs) do
-              instrumentation_spec = Gem.loaded_specs['opentelemetry-instrumentation-example']
-              library_spec = Gem.loaded_specs['example']
-              dependency = instrumentation_spec.development_dependencies.find { |spec| spec.name == library_spec.name }
-              compatible_version = dependency.requirement.satisfied_by?(library_gem_spec.version)
-              _(compatible_version).must_equal(true)
+              _(compatible_version?).must_equal(true)
             end
           end
         end
@@ -178,11 +177,7 @@ describe OpenTelemetry::Instrumentation::Base do
 
           it 'returns false' do
             Gem.stub(:loaded_specs, loaded_specs) do
-              instrumentation_spec = Gem.loaded_specs['opentelemetry-instrumentation-example']
-              library_spec = Gem.loaded_specs['example']
-              dependency = instrumentation_spec.development_dependencies.find { |spec| spec.name == library_spec.name }
-              compatible_version = dependency.requirement.satisfied_by?(library_gem_spec.version)
-              _(compatible_version).must_equal(false)
+             _(compatible_version?).must_equal(false)
             end
           end
         end

--- a/instrumentation/base/test/instrumentation/base_test.rb
+++ b/instrumentation/base/test/instrumentation/base_test.rb
@@ -215,6 +215,16 @@ describe OpenTelemetry::Instrumentation::Base do
           end
         end
       end
+
+      describe 'when the library is not installed' do
+        it 'returns false' do
+          Gem.stub(:loaded_specs, {}) do
+            Gem::Specification.stub(:find_by_name, ->(name) { nil } ) do
+             _(instrumentation.instance.compatible?).must_equal(false)
+            end
+          end
+        end
+      end
     end
   end
 

--- a/instrumentation/base/test/instrumentation/base_test.rb
+++ b/instrumentation/base/test/instrumentation/base_test.rb
@@ -216,9 +216,18 @@ describe OpenTelemetry::Instrumentation::Base do
         end
 
         describe 'when the library is not installed' do
+          let(:loaded_specs) do
+            { instrumentation_gem_name => instrumentation_gem_spec }
+          end
+
           it 'returns false' do
             Gem.stub(:loaded_specs, {}) do
-              Gem::Specification.stub(:find_by_name, ->(_) { nil }) do
+              gem_finder = lambda do |name|
+                raise Gem::MissingSpecError.new(name, name) unless loaded_specs[name]
+                loaded_specs[name]
+              end
+
+              Gem::Specification.stub(:find_by_name, gem_finder) do
                 _(instrumentation.instance.compatible?).must_equal(false)
               end
             end

--- a/instrumentation/base/test/instrumentation/base_test.rb
+++ b/instrumentation/base/test/instrumentation/base_test.rb
@@ -183,7 +183,7 @@ describe OpenTelemetry::Instrumentation::Base do
 
             it 'returns false' do
               Gem.stub(:loaded_specs, loaded_specs) do
-              _(instrumentation.instance.compatible?).must_equal(false)
+                _(instrumentation.instance.compatible?).must_equal(false)
               end
             end
           end
@@ -193,7 +193,7 @@ describe OpenTelemetry::Instrumentation::Base do
           describe 'with compatible versions' do
             it 'returns true' do
               Gem.stub(:loaded_specs, {}) do
-                Gem::Specification.stub(:find_by_name, ->(name) { loaded_specs[name] } ) do
+                Gem::Specification.stub(:find_by_name, ->(name) { loaded_specs[name] }) do
                   _(instrumentation.instance.compatible?).must_equal(true)
                 end
               end
@@ -207,8 +207,8 @@ describe OpenTelemetry::Instrumentation::Base do
 
             it 'returns false' do
               Gem.stub(:loaded_specs, {}) do
-                Gem::Specification.stub(:find_by_name, ->(name) { loaded_specs[name] } ) do
-                _(instrumentation.instance.compatible?).must_equal(false)
+                Gem::Specification.stub(:find_by_name, ->(name) { loaded_specs[name] }) do
+                  _(instrumentation.instance.compatible?).must_equal(false)
                 end
               end
             end
@@ -218,9 +218,23 @@ describe OpenTelemetry::Instrumentation::Base do
         describe 'when the library is not installed' do
           it 'returns false' do
             Gem.stub(:loaded_specs, {}) do
-              Gem::Specification.stub(:find_by_name, ->(name) { nil } ) do
-              _(instrumentation.instance.compatible?).must_equal(false)
+              Gem::Specification.stub(:find_by_name, ->(_) { nil }) do
+                _(instrumentation.instance.compatible?).must_equal(false)
               end
+            end
+          end
+        end
+
+        describe 'when library is not declared as a development dependency' do
+          let(:instrumentation_gem_spec) do
+            Gem::Specification.new do |spec|
+              spec.name = instrumentation_gem_name
+            end
+          end
+
+          it 'returns false' do
+            Gem.stub(:loaded_specs, loaded_specs) do
+              _(instrumentation.instance.compatible?).must_equal(false)
             end
           end
         end

--- a/instrumentation/base/test/instrumentation/base_test.rb
+++ b/instrumentation/base/test/instrumentation/base_test.rb
@@ -224,6 +224,7 @@ describe OpenTelemetry::Instrumentation::Base do
             Gem.stub(:loaded_specs, {}) do
               gem_finder = lambda do |name|
                 raise Gem::MissingSpecError.new(name, name) unless loaded_specs[name]
+
                 loaded_specs[name]
               end
 

--- a/instrumentation/base/test/instrumentation/base_test.rb
+++ b/instrumentation/base/test/instrumentation/base_test.rb
@@ -123,104 +123,104 @@ describe OpenTelemetry::Instrumentation::Base do
         _(instance.compatible?).must_equal(true)
       end
     end
-  end
 
-  describe '#compatible_version?' do
-    let(:instrumentation) do
-      Class.new(OpenTelemetry::Instrumentation::Base) do
-        instrumentation_name 'OpenTelemetry::Instrumentation::Example::Instrumentation'
-        instrumentation_version '0.0.1'
-        library_name 'example'
-      end
-    end
-
-    let(:library_name) do
-      'example'
-    end
-
-    let(:library_gem_spec_version) do
-      '1.3.8.beta2'
-    end
-
-    let(:instrumentation_gem_name) do
-      "opentelemetry-instrumentation-#{library_name}"
-    end
-
-    describe 'when comparing gemspecs' do
-      let(:library_gem_spec) do
-        Gem::Specification.new do |spec|
-          spec.name = library_name
-          spec.version = library_gem_spec_version
+    describe 'with a library name' do
+      let(:instrumentation) do
+        Class.new(OpenTelemetry::Instrumentation::Base) do
+          instrumentation_name 'OpenTelemetry::Instrumentation::Example::Instrumentation'
+          instrumentation_version '0.0.1'
+          library_name 'example'
         end
       end
 
-      let(:instrumentation_gem_spec) do
-        Gem::Specification.new do |spec|
-          spec.name = instrumentation_gem_name
-          spec.add_development_dependency library_name, '~> 1.1', '< 1.3.9'
-        end
+      let(:library_name) do
+        'example'
       end
 
-      let(:loaded_specs) do
-        {
-          instrumentation_gem_name => instrumentation_gem_spec,
-          library_name => library_gem_spec
-        }
+      let(:library_gem_spec_version) do
+        '1.3.8.beta2'
       end
 
-      describe 'when gems are activated' do
-        describe 'with compatible versions' do
-          it 'returns true' do
-            Gem.stub(:loaded_specs, loaded_specs) do
-              _(instrumentation.instance.compatible?).must_equal(true)
-            end
+      let(:instrumentation_gem_name) do
+        "opentelemetry-instrumentation-#{library_name}"
+      end
+
+      describe 'when comparing gemspecs' do
+        let(:library_gem_spec) do
+          Gem::Specification.new do |spec|
+            spec.name = library_name
+            spec.version = library_gem_spec_version
           end
         end
 
-        describe 'with incompatible versions' do
-          let(:library_gem_spec_version) do
-            '1.3.9'
-          end
-
-          it 'returns false' do
-            Gem.stub(:loaded_specs, loaded_specs) do
-             _(instrumentation.instance.compatible?).must_equal(false)
-            end
+        let(:instrumentation_gem_spec) do
+          Gem::Specification.new do |spec|
+            spec.name = instrumentation_gem_name
+            spec.add_development_dependency library_name, '~> 1.1', '< 1.3.9'
           end
         end
-      end
 
-      describe 'when gems were not activated (e.g. without using bundler)' do
-        describe 'with compatible versions' do
-          it 'returns true' do
-            Gem.stub(:loaded_specs, {}) do
-              Gem::Specification.stub(:find_by_name, ->(name) { loaded_specs[name] } ) do
+        let(:loaded_specs) do
+          {
+            instrumentation_gem_name => instrumentation_gem_spec,
+            library_name => library_gem_spec
+          }
+        end
+
+        describe 'when gems are activated' do
+          describe 'with compatible versions' do
+            it 'returns true' do
+              Gem.stub(:loaded_specs, loaded_specs) do
                 _(instrumentation.instance.compatible?).must_equal(true)
               end
             end
           end
-        end
 
-        describe 'with incompatible versions' do
-          let(:library_gem_spec_version) do
-            '1.3.9'
-          end
+          describe 'with incompatible versions' do
+            let(:library_gem_spec_version) do
+              '1.3.9'
+            end
 
-          it 'returns false' do
-            Gem.stub(:loaded_specs, {}) do
-              Gem::Specification.stub(:find_by_name, ->(name) { loaded_specs[name] } ) do
-               _(instrumentation.instance.compatible?).must_equal(false)
+            it 'returns false' do
+              Gem.stub(:loaded_specs, loaded_specs) do
+              _(instrumentation.instance.compatible?).must_equal(false)
               end
             end
           end
         end
-      end
 
-      describe 'when the library is not installed' do
-        it 'returns false' do
-          Gem.stub(:loaded_specs, {}) do
-            Gem::Specification.stub(:find_by_name, ->(name) { nil } ) do
-             _(instrumentation.instance.compatible?).must_equal(false)
+        describe 'when gems were not activated (e.g. without using bundler)' do
+          describe 'with compatible versions' do
+            it 'returns true' do
+              Gem.stub(:loaded_specs, {}) do
+                Gem::Specification.stub(:find_by_name, ->(name) { loaded_specs[name] } ) do
+                  _(instrumentation.instance.compatible?).must_equal(true)
+                end
+              end
+            end
+          end
+
+          describe 'with incompatible versions' do
+            let(:library_gem_spec_version) do
+              '1.3.9'
+            end
+
+            it 'returns false' do
+              Gem.stub(:loaded_specs, {}) do
+                Gem::Specification.stub(:find_by_name, ->(name) { loaded_specs[name] } ) do
+                _(instrumentation.instance.compatible?).must_equal(false)
+                end
+              end
+            end
+          end
+        end
+
+        describe 'when the library is not installed' do
+          it 'returns false' do
+            Gem.stub(:loaded_specs, {}) do
+              Gem::Specification.stub(:find_by_name, ->(name) { nil } ) do
+              _(instrumentation.instance.compatible?).must_equal(false)
+              end
             end
           end
         end

--- a/instrumentation/base/test/instrumentation/base_test.rb
+++ b/instrumentation/base/test/instrumentation/base_test.rb
@@ -126,6 +126,14 @@ describe OpenTelemetry::Instrumentation::Base do
   end
 
   describe '#compatible_version?' do
+    let(:instrumentation) do
+      Class.new(OpenTelemetry::Instrumentation::Base) do
+        instrumentation_name 'OpenTelemetry::Instrumentation::Example::Instrumentation'
+        instrumentation_version '0.0.1'
+        library_name 'example'
+      end
+    end
+
     let(:library_name) do
       'example'
     end
@@ -139,10 +147,7 @@ describe OpenTelemetry::Instrumentation::Base do
     end
 
     def compatible_version?
-      instrumentation_spec = Gem.loaded_specs[instrumentation_gem_name] || Gem::Specification.find_by_name(instrumentation_gem_name)
-      library_spec = Gem.loaded_specs[library_name] || Gem::Specification.find_by_name(library_name)
-      dependency = instrumentation_spec.development_dependencies.find { |spec| spec.name == library_spec.name }
-      dependency.requirement.satisfied_by?(library_gem_spec.version)
+      instrumentation.instance.compatible_version?
     end
 
     describe 'when comparing gemspecs' do

--- a/instrumentation/base/test/instrumentation/base_test.rb
+++ b/instrumentation/base/test/instrumentation/base_test.rb
@@ -172,7 +172,7 @@ describe OpenTelemetry::Instrumentation::Base do
         describe 'with compatible versions' do
           it 'returns true' do
             Gem.stub(:loaded_specs, loaded_specs) do
-              _(instrumentation.instance.compatible_version?).must_equal(true)
+              _(instrumentation.instance.compatible?).must_equal(true)
             end
           end
         end
@@ -184,7 +184,7 @@ describe OpenTelemetry::Instrumentation::Base do
 
           it 'returns false' do
             Gem.stub(:loaded_specs, loaded_specs) do
-             _(instrumentation.instance.compatible_version?).must_equal(false)
+             _(instrumentation.instance.compatible?).must_equal(false)
             end
           end
         end
@@ -195,7 +195,7 @@ describe OpenTelemetry::Instrumentation::Base do
           it 'returns true' do
             Gem.stub(:loaded_specs, {}) do
               Gem::Specification.stub(:find_by_name, ->(name) { loaded_specs[name] } ) do
-                _(instrumentation.instance.compatible_version?).must_equal(true)
+                _(instrumentation.instance.compatible?).must_equal(true)
               end
             end
           end
@@ -209,7 +209,7 @@ describe OpenTelemetry::Instrumentation::Base do
           it 'returns false' do
             Gem.stub(:loaded_specs, {}) do
               Gem::Specification.stub(:find_by_name, ->(name) { loaded_specs[name] } ) do
-               _(instrumentation.instance.compatible_version?).must_equal(false)
+               _(instrumentation.instance.compatible?).must_equal(false)
               end
             end
           end

--- a/instrumentation/base/test/instrumentation/base_test.rb
+++ b/instrumentation/base/test/instrumentation/base_test.rb
@@ -129,11 +129,11 @@ describe OpenTelemetry::Instrumentation::Base do
         Class.new(OpenTelemetry::Instrumentation::Base) do
           instrumentation_name 'OpenTelemetry::Instrumentation::Example::Instrumentation'
           instrumentation_version '0.0.1'
-          library_name 'example'
+          instrumented_library_name 'example'
         end
       end
 
-      let(:library_name) do
+      let(:instrumented_library_name) do
         'example'
       end
 
@@ -142,13 +142,13 @@ describe OpenTelemetry::Instrumentation::Base do
       end
 
       let(:instrumentation_gem_name) do
-        "opentelemetry-instrumentation-#{library_name}"
+        "opentelemetry-instrumentation-#{instrumented_library_name}"
       end
 
       describe 'when comparing gemspecs' do
         let(:library_gem_spec) do
           Gem::Specification.new do |spec|
-            spec.name = library_name
+            spec.name = instrumented_library_name
             spec.version = library_gem_spec_version
           end
         end
@@ -156,14 +156,14 @@ describe OpenTelemetry::Instrumentation::Base do
         let(:instrumentation_gem_spec) do
           Gem::Specification.new do |spec|
             spec.name = instrumentation_gem_name
-            spec.add_development_dependency library_name, '~> 1.1', '< 1.3.9'
+            spec.add_development_dependency instrumented_library_name, '~> 1.1', '< 1.3.9'
           end
         end
 
         let(:loaded_specs) do
           {
             instrumentation_gem_name => instrumentation_gem_spec,
-            library_name => library_gem_spec
+            instrumented_library_name => library_gem_spec
           }
         end
 


### PR DESCRIPTION
This changes provides instrumentation authors the ability to use gem specifications for version compatibility checks instead of having to write a custom compatibility block.

In order to take advantage of this feature instrumentation authors must:

1. Declare the library and version constraints as a development dependency
2. Use instrumentation naming conventions e.g. `opentelemetry-instrumentation-ruby_kafka`

Related https://github.com/open-telemetry/opentelemetry-ruby/issues/988

Some Concerns:

- There are certainly many more test scenarios to take into consideration. E.g. When multiple versions of the gem are installed and not yet activated.  
- Naming is strict and requires that the instrumentation name suffix matches the target library. We currently have some cases where the instrumentation names do not match e.g. `ruby-kafka` and `activesupport`