### PR TITLE
Sidekiq messaging operation

### DIFF
--- a/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/client/tracer_middleware.rb
+++ b/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/client/tracer_middleware.rb
@@ -18,7 +18,8 @@ module OpenTelemetry
                 'messaging.sidekiq.job_class' => job['wrapped']&.to_s || job['class'],
                 'messaging.message_id' => job['jid'],
                 'messaging.destination' => job['queue'],
-                'messaging.destination_kind' => 'queue'
+                'messaging.destination_kind' => 'queue',
+                'messaging.operation' => 'send'
               }
               attributes['peer.service'] = config[:peer_service] if config[:peer_service]
 

--- a/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/client/tracer_middleware.rb
+++ b/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/client/tracer_middleware.rb
@@ -18,8 +18,7 @@ module OpenTelemetry
                 'messaging.sidekiq.job_class' => job['wrapped']&.to_s || job['class'],
                 'messaging.message_id' => job['jid'],
                 'messaging.destination' => job['queue'],
-                'messaging.destination_kind' => 'queue',
-                'messaging.operation' => 'send'
+                'messaging.destination_kind' => 'queue'
               }
               attributes['peer.service'] = config[:peer_service] if config[:peer_service]
 

--- a/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware.rb
+++ b/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware.rb
@@ -18,7 +18,8 @@ module OpenTelemetry
                 'messaging.sidekiq.job_class' => msg['wrapped']&.to_s || msg['class'],
                 'messaging.message_id' => msg['jid'],
                 'messaging.destination' => msg['queue'],
-                'messaging.destination_kind' => 'queue'
+                'messaging.destination_kind' => 'queue',
+                'messaging.operation' => 'process'
               }
               attributes['peer.service'] = config[:peer_service] if config[:peer_service]
 

--- a/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware_test.rb
+++ b/instrumentation/sidekiq/test/opentelemetry/instrumentation/sidekiq/middlewares/server/tracer_middleware_test.rb
@@ -42,6 +42,7 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Server::TracerMid
       _(job_span.attributes['messaging.message_id']).must_equal job_id
       _(job_span.attributes['messaging.destination']).must_equal 'default'
       _(job_span.attributes['messaging.destination_kind']).must_equal 'queue'
+      _(job_span.attributes['messaging.operation']).must_equal 'process'
       _(job_span.attributes['peer.service']).must_be_nil
       _(job_span.events.size).must_equal(2)
       _(job_span.events[0].name).must_equal('created_at')
@@ -57,6 +58,7 @@ describe OpenTelemetry::Instrumentation::Sidekiq::Middlewares::Server::TracerMid
       _(job_span.attributes['messaging.sidekiq.job_class']).must_equal('SimpleJobWithActiveJob')
       _(job_span.attributes['messaging.destination']).must_equal('default')
       _(job_span.attributes['messaging.destination_kind']).must_equal('queue')
+      _(job_span.attributes['messaging.operation']).must_equal 'process'
     end
 
     it 'defaults to using links to the enqueing span but does not continue the trace' do


### PR DESCRIPTION
### What's added in this PR?
Adding `messaging.operation` attribute to sidekiq.
The [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md#messaging-attributes) doesn't require it but it could be helpful.

The value must be either `receive` or `process`, in sidekiq case, there isn't a receive span so I have added only for `process`.
For the specification:

"The values allowed for <operation name> are defined in the section Operation names below. If the format above is used, the operation name MUST match the messaging.operation attribute defined for message consumer spans below." 


About tests, I felt it is too small of a change to add test, let me know if you think otherwise

Thanks!
(BTW, my first contribution here. My apologies in advance if I missed some contribution rules.)