### PR TITLE
fix: add max supported version for active record

### DIFF
--- a/instrumentation/active_record/gemfiles/activerecord_5.2.gemfile
+++ b/instrumentation/active_record/gemfiles/activerecord_5.2.gemfile
@@ -3,15 +3,16 @@
 source "https://rubygems.org"
 
 gem "opentelemetry-api", path: "../../../api"
+gem "opentelemetry-instrumentation-base", path: "../../base"
 gem "activerecord", "~> 5.2.0"
 
 group :test do
   gem "byebug"
-  gem "mysql2"
   gem "opentelemetry-common", path: "../../../common"
-  gem "opentelemetry-instrumentation-mysql2", path: "../../mysql2"
   gem "opentelemetry-sdk", path: "../../../sdk"
+  gem "opentelemetry-semantic_conventions", path: "../../../semantic_conventions"
   gem "pry-byebug"
+  gem "sqlite3-ruby"
 end
 
 gemspec path: "../"

--- a/instrumentation/active_record/gemfiles/activerecord_6.0.gemfile
+++ b/instrumentation/active_record/gemfiles/activerecord_6.0.gemfile
@@ -8,10 +8,11 @@ gem "activerecord", "~> 6.0.0"
 
 group :test do
   gem "byebug"
-  gem "sqlite3-ruby"
   gem "opentelemetry-common", path: "../../../common"
   gem "opentelemetry-sdk", path: "../../../sdk"
+  gem "opentelemetry-semantic_conventions", path: "../../../semantic_conventions"
   gem "pry-byebug"
+  gem "sqlite3-ruby"
 end
 
 gemspec path: "../"

--- a/instrumentation/active_record/gemfiles/activerecord_6.1.gemfile
+++ b/instrumentation/active_record/gemfiles/activerecord_6.1.gemfile
@@ -8,10 +8,11 @@ gem "activerecord", "~> 6.1.0"
 
 group :test do
   gem "byebug"
-  gem "sqlite3-ruby"
   gem "opentelemetry-common", path: "../../../common"
   gem "opentelemetry-sdk", path: "../../../sdk"
+  gem "opentelemetry-semantic_conventions", path: "../../../semantic_conventions"
   gem "pry-byebug"
+  gem "sqlite3-ruby"
 end
 
 gemspec path: "../"

--- a/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/instrumentation.rb
+++ b/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/instrumentation.rb
@@ -10,6 +10,7 @@ module OpenTelemetry
       # The Instrumentation class contains logic to detect and install the ActiveRecord instrumentation
       class Instrumentation < OpenTelemetry::Instrumentation::Base
         MINIMUM_VERSION = Gem::Version.new('5.2.0')
+        MAXIMUM_VERSION = Gem::Version.new('7.0.0')
 
         install do |_config|
           require_dependencies
@@ -21,7 +22,7 @@ module OpenTelemetry
         end
 
         compatible do
-          gem_version >= MINIMUM_VERSION
+          gem_version >= MINIMUM_VERSION && gem_version < MAXIMUM_VERSION
         end
 
         private

--- a/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/instrumentation.rb
+++ b/instrumentation/active_record/lib/opentelemetry/instrumentation/active_record/instrumentation.rb
@@ -10,7 +10,7 @@ module OpenTelemetry
       # The Instrumentation class contains logic to detect and install the ActiveRecord instrumentation
       class Instrumentation < OpenTelemetry::Instrumentation::Base
         MINIMUM_VERSION = Gem::Version.new('5.2.0')
-        MAXIMUM_VERSION = Gem::Version.new('7.0.0')
+        MAX_MAJOR_VERSION = 6
 
         install do |_config|
           require_dependencies
@@ -22,7 +22,11 @@ module OpenTelemetry
         end
 
         compatible do
-          gem_version >= MINIMUM_VERSION && gem_version < MAXIMUM_VERSION
+          # We know that releases after MAX_MAJOR_VERSION are unstable so we
+          # check the major version number of the gem installed to make sure we
+          # do not install on a pre-release or full release of the latest
+          # if it exceeds the MAX_MAJOR_VERSION version.
+          gem_version >= MINIMUM_VERSION && gem_version.segments[0] <= MAX_MAJOR_VERSION
         end
 
         private

--- a/instrumentation/active_record/test/instrumentation/active_record/instrumentation_test.rb
+++ b/instrumentation/active_record/test/instrumentation/active_record/instrumentation_test.rb
@@ -22,8 +22,14 @@ describe OpenTelemetry::Instrumentation::ActiveRecord do
   end
 
   describe 'compatible' do
-    it 'when unsupported gem version is installed' do
+    it 'when a version below the minimum supported gem version is installed' do
       Gem.stub(:loaded_specs, 'activerecord' => Gem::Specification.new { |s| s.version = '4.2.0' }) do
+        _(instrumentation.compatible?).must_equal false
+      end
+    end
+
+    it 'when a version above the maximum supported gem version is installed' do
+      Gem.stub(:loaded_specs, 'activerecord' => Gem::Specification.new { |s| s.version = '7.0.0' }) do
         _(instrumentation.compatible?).must_equal false
       end
     end

--- a/instrumentation/active_record/test/instrumentation/active_record/instrumentation_test.rb
+++ b/instrumentation/active_record/test/instrumentation/active_record/instrumentation_test.rb
@@ -34,6 +34,12 @@ describe OpenTelemetry::Instrumentation::ActiveRecord do
       end
     end
 
+    it 'it treats pre releases as being equivalent to a full release' do
+      Gem.stub(:loaded_specs, 'activerecord' => Gem::Specification.new { |s| s.version = '7.0.0.alpha' }) do
+        _(instrumentation.compatible?).must_equal false
+      end
+    end
+
     it 'when supported gem version installed' do
       Gem.stub(:loaded_specs, 'activerecord' => Gem::Specification.new { |s| s.version = minimum_version }) do
         _(instrumentation.compatible?).must_equal true


### PR DESCRIPTION
We've observed serious incompatibilities between this instrumentation and AR in the rails 7.X.X alpha releases.  We're going to err to the side of caution and disable the instrumentation patches if rails 7 is detected.

CC: @SomalianIvan 