### PR TITLE
fix: rack to stop using api env getter

### DIFF
--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
@@ -68,7 +68,7 @@ module OpenTelemetry
             original_env = env.dup
             extracted_context = OpenTelemetry.propagation.extract(
               env,
-              getter: OpenTelemetry::Context::Propagation.rack_env_getter
+              getter: OpenTelemetry::Common::Propagation.rack_env_getter
             )
             frontend_context = create_frontend_span(env, extracted_context)
 

--- a/instrumentation/rack/opentelemetry-instrumentation-rack.gemspec
+++ b/instrumentation/rack/opentelemetry-instrumentation-rack.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
+  spec.add_dependency 'opentelemetry-common', '~> 0.19.2'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.18.3'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'


### PR DESCRIPTION
Follow up from https://github.com/open-telemetry/opentelemetry-ruby/pull/1006