### PR TITLE
fix: sinatra to stop using api env getter

### DIFF
--- a/instrumentation/sinatra/lib/opentelemetry/instrumentation/sinatra/middlewares/tracer_middleware.rb
+++ b/instrumentation/sinatra/lib/opentelemetry/instrumentation/sinatra/middlewares/tracer_middleware.rb
@@ -17,7 +17,7 @@ module OpenTelemetry
           def call(env)
             extracted_context = OpenTelemetry.propagation.extract(
               env,
-              getter: OpenTelemetry::Context::Propagation.rack_env_getter
+              getter: OpenTelemetry::Common::Propagation.rack_env_getter
             )
             OpenTelemetry::Context.with_current(extracted_context) do
               tracer.in_span(

--- a/instrumentation/sinatra/opentelemetry-instrumentation-sinatra.gemspec
+++ b/instrumentation/sinatra/opentelemetry-instrumentation-sinatra.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
+  spec.add_dependency 'opentelemetry-common', '~> 0.19.2'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.18.3'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'


### PR DESCRIPTION
Follow up from https://github.com/open-telemetry/opentelemetry-ruby/pull/1006