### PR TITLE
chore: fix dalli tests to account for upstream changes to `Dalli:DalliError` handling

### DIFF
--- a/instrumentation/dalli/test/opentelemetry/instrumentation/dalli/instrumentation_test.rb
+++ b/instrumentation/dalli/test/opentelemetry/instrumentation/dalli/instrumentation_test.rb
@@ -80,7 +80,7 @@ describe OpenTelemetry::Instrumentation::Dalli::Instrumentation do
       dalli.set('foo', 'bar')
       exporter.reset
 
-      dalli.instance_variable_get(:@ring).servers.first.stub(:write, ->(_bytes) { raise Dalli::DalliError }) do
+      dalli.instance_variable_get(:@ring).servers.first.stub(write: ->(_bytes) { raise Dalli::DalliError }, sock: ->(_bytes) { raise Dalli::DalliError }) do
         dalli.get_multi('foo', 'bar')
       end
 


### PR DESCRIPTION
Dalli tests are failing due to (i think?) changes upstream in `3.0.5` that change the behavior of certain errors we're raising via stubs in our specs, specifically `Dalli::DalliError`

```
opentelemetry-instrumentation-dalli: test

# Running:

......E.

Finished in 0.016433s, 486.8366 runs/s, 1643.0736 assertions/s.

  1) Error:
OpenTelemetry::Instrumentation::Dalli::Instrumentation::tracing#test_0006_after error:
NoMethodError: undefined method `options' for nil:NilClass
    /opt/hostedtoolcache/Ruby/2.6.9/x64/lib/ruby/gems/2.6.0/gems/dalli-3.0.5/lib/dalli/client.rb:437:in `block in get_multi_yielder'
    /opt/hostedtoolcache/Ruby/2.6.9/x64/lib/ruby/gems/2.6.0/gems/dalli-3.0.5/lib/dalli/ring.rb:76:in `lock'
    /opt/hostedtoolcache/Ruby/2.6.9/x64/lib/ruby/gems/2.6.0/gems/dalli-3.0.5/lib/dalli/client.rb:421:in `get_multi_yielder'
    /opt/hostedtoolcache/Ruby/2.6.9/x64/lib/ruby/gems/2.6.0/gems/dalli-3.0.5/lib/dalli/client.rb:95:in `block in get_multi'
    /opt/hostedtoolcache/Ruby/2.6.9/x64/lib/ruby/gems/2.6.0/gems/dalli-3.0.5/lib/dalli/client.rb:94:in `tap'
    /opt/hostedtoolcache/Ruby/2.6.9/x64/lib/ruby/gems/2.6.0/gems/dalli-3.0.5/lib/dalli/client.rb:94:in `get_multi'
    /home/runner/work/opentelemetry-ruby/opentelemetry-ruby/instrumentation/dalli/test/opentelemetry/instrumentation/dalli/instrumentation_test.rb:84:in `block (4 levels) in <top (required)>'
```

[This is the new Dalli code in question](https://github.com/petergoldstein/dalli/commit/8af0cade36e1be1d8018f0987c8858c876749e1f#diff-a326ee7acf56937d92cdeeb4b920547a89162170aab2ad32391200ad1b4c3638R429-R447).

The behavior around raising `Dalli::NetworkError` seems more deterministic. Previously we had stopped using this error in our stubs because there was a change in behavior for the actual library, which began retrying on `Dalli::NetworkError` for 2.x versions of Dalli. Rather than adding a helper to have the test behavior change depending on the version, we just used a different raised error in our stub. However, at this point it's easier to just test different behavior for different major version, and rely on `Dalli::NetworkError`