### PR TITLE
fix: deprecate api rack env getter

### DIFF
--- a/api/lib/opentelemetry/context/propagation.rb
+++ b/api/lib/opentelemetry/context/propagation.rb
@@ -67,9 +67,13 @@ module OpenTelemetry
         TEXT_MAP_SETTER
       end
 
+      # @deprecated Use the rack env getter found in the
+      # opentelemetry-common gem instead.
       # Returns a {RackEnvGetter} instance suitable for reading values from a
       # Rack environment.
       def rack_env_getter
+        OpenTelemetry.logger.warn('OpenTelemetry::Context::Propagation.rack_env_getter has been deprecated \
+          use OpenTelemetry::Common::Propagation.rack_env_getter from the opentelemetry-common gem instead.')
         RACK_ENV_GETTER
       end
     end

--- a/api/lib/opentelemetry/context/propagation/rack_env_getter.rb
+++ b/api/lib/opentelemetry/context/propagation/rack_env_getter.rb
@@ -19,8 +19,6 @@ module OpenTelemetry
         # Converts key into a rack-normalized key and reads it from the carrier.
         # Useful for extract operations.
         def get(carrier, key)
-          OpenTelemetry.logger.warn('OpenTelemetry::Context::Propagation::RackEnvGetter has been deprecated \
-            use OpenTelemetry::Common::Propagation::RackEnvGetter from the opentelemetry-common gem instead.')
           carrier[to_rack_key(key)] || carrier[key]
         end
 
@@ -28,8 +26,6 @@ module OpenTelemetry
         # form to the original. The resulting keys will be lowercase and
         # underscores will be replaced with dashes.
         def keys(carrier)
-          OpenTelemetry.logger.warn('OpenTelemetry::Context::Propagation::RackEnvGetter has been deprecated \
-            use OpenTelemetry::Common::Propagation::RackEnvGetter from the opentelemetry-common gem instead.')
           carrier.keys.map(&method(:from_rack_key))
         end
 

--- a/api/lib/opentelemetry/context/propagation/rack_env_getter.rb
+++ b/api/lib/opentelemetry/context/propagation/rack_env_getter.rb
@@ -7,6 +7,9 @@
 module OpenTelemetry
   class Context
     module Propagation
+      # @deprecated Use the rack env getter found in the
+      # opentelemetry-common gem instead.
+
       # The RackEnvGetter class provides a common methods for reading
       # keys from a rack environment. It abstracts away the rack-normalization
       # process so that keys can be looked up without having to transform them
@@ -16,6 +19,8 @@ module OpenTelemetry
         # Converts key into a rack-normalized key and reads it from the carrier.
         # Useful for extract operations.
         def get(carrier, key)
+          OpenTelemetry.logger.warn('OpenTelemetry::Context::Propagation::RackEnvGetter has been deprecated \
+            use OpenTelemetry::Common::Propagation::RackEnvGetter from the opentelemetry-common gem instead.')
           carrier[to_rack_key(key)] || carrier[key]
         end
 
@@ -23,6 +28,8 @@ module OpenTelemetry
         # form to the original. The resulting keys will be lowercase and
         # underscores will be replaced with dashes.
         def keys(carrier)
+          OpenTelemetry.logger.warn('OpenTelemetry::Context::Propagation::RackEnvGetter has been deprecated \
+            use OpenTelemetry::Common::Propagation::RackEnvGetter from the opentelemetry-common gem instead.')
           carrier.keys.map(&method(:from_rack_key))
         end
 

--- a/propagator/jaeger/test/text_map_propagator_test.rb
+++ b/propagator/jaeger/test/text_map_propagator_test.rb
@@ -132,7 +132,7 @@ describe OpenTelemetry::Propagator::Jaeger::TextMapPropagator do
       context = propagator.extract(
         carrier,
         context: parent_context,
-        getter: OpenTelemetry::Context::Propagation.rack_env_getter
+        getter: OpenTelemetry::Common::Propagation.rack_env_getter
       )
       span_context = OpenTelemetry::Trace.current_span(context).context
       _(span_context.hex_trace_id).must_equal('80f198ee56343ba864fe8b2a57d3eff7')


### PR DESCRIPTION
Deprecates the api rack env getter, anyone retrieving the getter will receive a warning log message that this code path has been deprecated.