### PR TITLE
chore: update dalli instrumentation to support v3.1 pipeline_get method

### DIFF
--- a/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/utils.rb
+++ b/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/utils.rb
@@ -26,6 +26,13 @@ module OpenTelemetry
         'write_noop' => 'noop',
         'version' => 'version',
         'send_multiget' => 'getkq',
+        # TODO: add better support for PipelinedGetter
+        # In dalli 3.1, multiget has been refactored to use a more robust PipelinedGetter class.
+        # The `pipelined_get` method has been introduced to the Dalli::Server to support this new class.
+        # If PipelinedGetter makes instrumentation of multi operations easier, we should then migrate 
+        # instrumentation to Dalli::Client, since it seems to be a more stable chokepoint.
+        # For now we're just ensuring we support this new Dalli::Server method.
+        'pipelined_get' => 'getkq',
         'append' => 'append',
         'prepend' => 'prepend',
         'stats' => 'stat',

--- a/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/utils.rb
+++ b/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/utils.rb
@@ -29,7 +29,7 @@ module OpenTelemetry
         # TODO: add better support for PipelinedGetter
         # In dalli 3.1, multiget has been refactored to use a more robust PipelinedGetter class.
         # The `pipelined_get` method has been introduced to the Dalli::Server to support this new class.
-        # If PipelinedGetter makes instrumentation of multi operations easier, we should then migrate 
+        # If PipelinedGetter makes instrumentation of multi operations easier, we should then migrate
         # instrumentation to Dalli::Client, since it seems to be a more stable chokepoint.
         # For now we're just ensuring we support this new Dalli::Server method.
         'pipelined_get' => 'getkq',


### PR DESCRIPTION
### Summary

Dalli v3.1 was released a few days ago (see: https://github.com/petergoldstein/dalli/releases/tag/v3.1.0) and contains some refactoring for `multi` methods, by adding a [PipelinedGetter Class to handle the multi behavior](
https://github.com/petergoldstein/dalli/blob/76acdbd841ce41c24bdb7a8c24c32d1afb8c2b03/lib/dalli/pipelined_getter.rb#L48-L55) instead of having it as part o the `Dalli::Client` code. This also means adding a new method to `Dalli::Server` which we didn't have mappings to `opcode` for. This PR updates our mapping to includes an opcode mapping for this new `Dalli::Server` method.

Long term, we would like to re-write this instrumentation to patch the Dalli::Client method, which in practice seems a bit more stable. Previously we'd looked into this but found the extra work around handling `multi` methods  to be too brittle as opposed to simply instrumenting `Dalli::Server`, but now that much of that `multi` code has been refactored, it's worth investigating whether `Dalli::Client` / `PipelinedGetter` patching is more reasonable.

For now this should fix our tests and unblock CI
