### PR TITLE
Fix: Don't error on non-string/utf8 kafka message keys

### DIFF
--- a/instrumentation/ruby_kafka/lib/opentelemetry/instrumentation/ruby_kafka/patches/client.rb
+++ b/instrumentation/ruby_kafka/lib/opentelemetry/instrumentation/ruby_kafka/patches/client.rb
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require_relative '../utils'
+
 module OpenTelemetry
   module Instrumentation
     module RubyKafka
@@ -17,7 +19,7 @@ module OpenTelemetry
               'messaging.destination_kind' => 'topic'
             }
 
-            attributes['messaging.kafka.message_key'] = key if key
+            attributes['messaging.kafka.message_key'] = Utils.encode_message_key(key) if key
             attributes['messaging.kafka.partition'] = partition if partition
 
             tracer.in_span("#{topic} send", attributes: attributes, kind: :producer) do
@@ -35,7 +37,7 @@ module OpenTelemetry
                 'messaging.kafka.partition' => message.partition
               }
 
-              attributes['messaging.kafka.message_key'] = message.key if message.key
+              attributes['messaging.kafka.message_key'] = Utils.encode_message_key(message.key) if message.key
 
               parent_context = OpenTelemetry.propagation.extract(message.headers)
               OpenTelemetry::Context.with_current(parent_context) do

--- a/instrumentation/ruby_kafka/lib/opentelemetry/instrumentation/ruby_kafka/patches/client.rb
+++ b/instrumentation/ruby_kafka/lib/opentelemetry/instrumentation/ruby_kafka/patches/client.rb
@@ -19,7 +19,9 @@ module OpenTelemetry
               'messaging.destination_kind' => 'topic'
             }
 
-            attributes['messaging.kafka.message_key'] = Utils.encode_message_key(key) if key
+            message_key = Utils.extract_message_key(key)
+            attributes['messaging.kafka.message_key'] = message_key if message_key
+
             attributes['messaging.kafka.partition'] = partition if partition
 
             tracer.in_span("#{topic} send", attributes: attributes, kind: :producer) do
@@ -37,7 +39,8 @@ module OpenTelemetry
                 'messaging.kafka.partition' => message.partition
               }
 
-              attributes['messaging.kafka.message_key'] = Utils.encode_message_key(message.key) if message.key
+              message_key = Utils.extract_message_key(message.key)
+              attributes['messaging.kafka.message_key'] = message_key if message_key
 
               parent_context = OpenTelemetry.propagation.extract(message.headers)
               OpenTelemetry::Context.with_current(parent_context) do

--- a/instrumentation/ruby_kafka/lib/opentelemetry/instrumentation/ruby_kafka/patches/consumer.rb
+++ b/instrumentation/ruby_kafka/lib/opentelemetry/instrumentation/ruby_kafka/patches/consumer.rb
@@ -20,7 +20,8 @@ module OpenTelemetry
                 'messaging.kafka.offset' => message.offset
               }
 
-              attributes['messaging.kafka.message_key'] = Utils.encode_message_key(message.key) if message.key
+              message_key = Utils.extract_message_key(message.key)
+              attributes['messaging.kafka.message_key'] = message_key if message_key
 
               parent_context = OpenTelemetry.propagation.extract(message.headers)
               span_context = OpenTelemetry::Trace.current_span(parent_context).context

--- a/instrumentation/ruby_kafka/lib/opentelemetry/instrumentation/ruby_kafka/patches/consumer.rb
+++ b/instrumentation/ruby_kafka/lib/opentelemetry/instrumentation/ruby_kafka/patches/consumer.rb
@@ -20,7 +20,7 @@ module OpenTelemetry
                 'messaging.kafka.offset' => message.offset
               }
 
-              attributes['messaging.kafka.message_key'] = message.key if message.key
+              attributes['messaging.kafka.message_key'] = Utils.encode_message_key(message.key) if message.key
 
               parent_context = OpenTelemetry.propagation.extract(message.headers)
               span_context = OpenTelemetry::Trace.current_span(parent_context).context

--- a/instrumentation/ruby_kafka/lib/opentelemetry/instrumentation/ruby_kafka/utils.rb
+++ b/instrumentation/ruby_kafka/lib/opentelemetry/instrumentation/ruby_kafka/utils.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Instrumentation
+    module RubyKafka
+      # Utilities to help with instrumenting kafka
+      module Utils
+        module_function
+
+        def encode_message_key(key)
+          return key if key.encoding == Encoding::UTF_8 && key.valid_encoding?
+
+          key.encode(Encoding::UTF_8)
+        rescue Encoding::UndefinedConversionError
+          key.unpack1('H*')
+        end
+      end
+    end
+  end
+end

--- a/instrumentation/ruby_kafka/lib/opentelemetry/instrumentation/ruby_kafka/utils.rb
+++ b/instrumentation/ruby_kafka/lib/opentelemetry/instrumentation/ruby_kafka/utils.rb
@@ -11,12 +11,13 @@ module OpenTelemetry
       module Utils
         module_function
 
-        def encode_message_key(key)
-          return key if key.encoding == Encoding::UTF_8 && key.valid_encoding?
+        def extract_message_key(key)
+          # skip encode if already valid utf8
+          return key if key.nil? || (key.encoding == Encoding::UTF_8 && key.valid_encoding?)
 
           key.encode(Encoding::UTF_8)
         rescue Encoding::UndefinedConversionError
-          key.unpack1('H*')
+          nil
         end
       end
     end

--- a/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/patches/client_test.rb
+++ b/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/patches/client_test.rb
@@ -46,4 +46,25 @@ describe OpenTelemetry::Instrumentation::RubyKafka::Patches::Client do
     _(spans[1].name).must_equal("#{topic} process")
     _(spans[1].kind).must_equal(:consumer)
   end
+
+  it 'encodes message keys' do
+    invalid_utf8_key = String.new("\xAF\x0F\xEF", encoding: 'ASCII-8BIT')
+    kafka.deliver_message('hello', key: invalid_utf8_key, topic: topic)
+    kafka.deliver_message('hello2', key: 'foobarbaz', topic: topic)
+    begin
+      counter = 0
+      kafka.each_message(topic: topic) do |_msg|
+        counter += 1
+        break if counter >= 2
+      end
+    end
+
+    send_spans = spans.select { |s| s.name == "#{topic} send" }
+    _(send_spans[0].attributes['messaging.kafka.message_key']).must_equal('af0fef')
+    _(send_spans[1].attributes['messaging.kafka.message_key']).must_equal('foobarbaz')
+
+    process_spans = spans.select { |s| s.name == "#{topic} process" }
+    _(process_spans[0].attributes['messaging.kafka.message_key']).must_equal('af0fef')
+    _(process_spans[1].attributes['messaging.kafka.message_key']).must_equal('foobarbaz')
+  end
 end unless ENV['OMIT_SERVICES']

--- a/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/patches/client_test.rb
+++ b/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/patches/client_test.rb
@@ -60,11 +60,11 @@ describe OpenTelemetry::Instrumentation::RubyKafka::Patches::Client do
     end
 
     send_spans = spans.select { |s| s.name == "#{topic} send" }
-    _(send_spans[0].attributes['messaging.kafka.message_key']).must_equal('af0fef')
+    _(send_spans[0].attributes).wont_include('messaging.kafka.message_key')
     _(send_spans[1].attributes['messaging.kafka.message_key']).must_equal('foobarbaz')
 
     process_spans = spans.select { |s| s.name == "#{topic} process" }
-    _(process_spans[0].attributes['messaging.kafka.message_key']).must_equal('af0fef')
+    _(process_spans[0].attributes).wont_include('messaging.kafka.message_key')
     _(process_spans[1].attributes['messaging.kafka.message_key']).must_equal('foobarbaz')
   end
 end unless ENV['OMIT_SERVICES']

--- a/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/patches/consumer_test.rb
+++ b/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/patches/consumer_test.rb
@@ -110,7 +110,7 @@ describe OpenTelemetry::Instrumentation::RubyKafka::Patches::Consumer do
 
       # First pair for send and process spans
       first_process_span = process_spans[0]
-      _(first_process_span.attributes['messaging.kafka.message_key']).must_equal('af0fef')
+      _(first_process_span.attributes).wont_include('messaging.kafka.message_key')
 
       second_process_span = process_spans[1]
       _(second_process_span.attributes['messaging.kafka.message_key']).must_equal('foobarbaz')

--- a/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/patches/consumer_test.rb
+++ b/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/patches/consumer_test.rb
@@ -93,6 +93,30 @@ describe OpenTelemetry::Instrumentation::RubyKafka::Patches::Consumer do
 
       _(spans.size).must_equal(4)
     end
+
+    it 'encodes messages keys depending on input format' do
+      kafka.deliver_message('hello', key: "\xAF\x0F\xEF", topic: topic)
+      kafka.deliver_message('hello2', key: 'foobarbaz', topic: topic)
+
+      begin
+        counter = 0
+        consumer.each_message do |_msg|
+          counter += 1
+          break if counter >= 2
+        end
+      end
+
+      process_spans = spans.select { |s| s.name == "#{topic} process" }
+
+      # First pair for send and process spans
+      first_process_span = process_spans[0]
+      _(first_process_span.attributes['messaging.kafka.message_key']).must_equal('af0fef')
+
+      second_process_span = process_spans[1]
+      _(second_process_span.attributes['messaging.kafka.message_key']).must_equal('foobarbaz')
+
+      _(spans.size).must_equal(4)
+    end
   end
 
   describe '#each_batch' do

--- a/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/utils_test.rb
+++ b/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/utils_test.rb
@@ -11,17 +11,17 @@ require_relative '../../../../lib/opentelemetry/instrumentation/ruby_kafka/utils
 describe OpenTelemetry::Instrumentation::RubyKafka::Utils do
   it 'returns input as itself if it is valid utf_8' do
     input = 'foobarbaz'
-    _(OpenTelemetry::Instrumentation::RubyKafka::Utils.encode_message_key(input).object_id).must_equal(input.object_id)
+    _(OpenTelemetry::Instrumentation::RubyKafka::Utils.extract_message_key(input).object_id).must_equal(input.object_id)
   end
 
   it 'returns input utf_8 encoded if it is encoded differently but not encoded' do
     input = String.new('foobarbaz', encoding: 'ASCII-8BIT')
-    _(OpenTelemetry::Instrumentation::RubyKafka::Utils.encode_message_key(input)).must_equal(input)
-    _(OpenTelemetry::Instrumentation::RubyKafka::Utils.encode_message_key(input).encoding).must_equal(Encoding::UTF_8)
+    _(OpenTelemetry::Instrumentation::RubyKafka::Utils.extract_message_key(input)).must_equal('foobarbaz')
+    _(OpenTelemetry::Instrumentation::RubyKafka::Utils.extract_message_key(input).encoding).must_equal(Encoding::UTF_8)
   end
 
   it 'returns input as a hexstring if it is not valid utf_8' do
     input = String.new("\x00\x00\x00\x00\x00\xAC\xBA\xC4", encoding: 'ASCII-8BIT')
-    _(OpenTelemetry::Instrumentation::RubyKafka::Utils.encode_message_key(input)).must_equal('0000000000acbac4')
+    _(OpenTelemetry::Instrumentation::RubyKafka::Utils.extract_message_key(input)).must_be_nil
   end
 end

--- a/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/utils_test.rb
+++ b/instrumentation/ruby_kafka/test/opentelemetry/instrumentation/ruby-kafka/utils_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require_relative '../../../test_helper'
+
+require_relative '../../../../lib/opentelemetry/instrumentation/ruby_kafka/utils'
+
+describe OpenTelemetry::Instrumentation::RubyKafka::Utils do
+  it 'returns input as itself if it is valid utf_8' do
+    input = 'foobarbaz'
+    _(OpenTelemetry::Instrumentation::RubyKafka::Utils.encode_message_key(input).object_id).must_equal(input.object_id)
+  end
+
+  it 'returns input utf_8 encoded if it is encoded differently but not encoded' do
+    input = String.new('foobarbaz', encoding: 'ASCII-8BIT')
+    _(OpenTelemetry::Instrumentation::RubyKafka::Utils.encode_message_key(input)).must_equal(input)
+    _(OpenTelemetry::Instrumentation::RubyKafka::Utils.encode_message_key(input).encoding).must_equal(Encoding::UTF_8)
+  end
+
+  it 'returns input as a hexstring if it is not valid utf_8' do
+    input = String.new("\x00\x00\x00\x00\x00\xAC\xBA\xC4", encoding: 'ASCII-8BIT')
+    _(OpenTelemetry::Instrumentation::RubyKafka::Utils.encode_message_key(input)).must_equal('0000000000acbac4')
+  end
+end


### PR DESCRIPTION
The instrumentation for Kafka was assuming that message keys are only
valid utf8 strings, but message keys can be any string of bytes. See:
https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-Responses

This was causing encoding errors in the exporters, and lost spans, as they were trying to encode string into utf8 before transport. These problems were originally described here: https://github.com/open-telemetry/opentelemetry-ruby/issues/751

This fix converts keys that aren't valid utf8 strings into hex strings, which seems to be consistent with how other byte strings are encoded such as with trace ids.

This change may need to be ported onto this PR: https://github.com/open-telemetry/opentelemetry-ruby/pull/978
