### PR TITLE
Be explicit about current span in manual instrumentation doc

### DIFF
--- a/website_docs/manual_instrumentation.md
+++ b/website_docs/manual_instrumentation.md
@@ -6,11 +6,11 @@ weight: 4
 Auto-instrumentation is the easiest way to get started with instrumenting your code, but in order to get the most insight into your system, you should add manual instrumentation where appropriate.
 To do this, use the OpenTelemetry SDK to access the currently executing span and add attributes to it, and/or to create new spans.
 
-### Adding Context to Exisiting Spans
+### Add information to the current span
 
-It's often beneficial to add context to a currently executing span in a trace.
+It's often beneficial to add information to the currently executing span in a trace.
 For example, you may have an application or service that handles extended warranties, and you want to associate it with the span when querying your tracing datastore.
-In order to do this, get the current span from the context and set an attribute with your application's domain specific data:
+In order to do this, get the current span and set [attributes](manual_instrumentation.md#attributes) with your application's domain specific data:
 
 ```ruby
 def track_extended_warranty(extended_warranty)

--- a/website_docs/manual_instrumentation.md
+++ b/website_docs/manual_instrumentation.md
@@ -10,7 +10,7 @@ To do this, use the OpenTelemetry SDK to access the currently executing span and
 
 It's often beneficial to add information to the currently executing span in a trace.
 For example, you may have an application or service that handles extended warranties, and you want to associate it with the span when querying your tracing datastore.
-In order to do this, get the current span and set [attributes](manual_instrumentation.md#attributes) with your application's domain specific data:
+In order to do this, get the current span and set [attributes](#attributes) with your application's domain specific data:
 
 ```ruby
 def track_extended_warranty(extended_warranty)


### PR DESCRIPTION
Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/973

Hello again!

I felt that some wording could change in this section. It's about adding some information to the current span, but the terminology of "context to existing spans" felt kind of confusing, since context has a pretty strong meaning in OTel, and it's not just any existing span that we're adding stuff to in the example.

I'm also happy to split out getting the existing span from adding attributes to it if folks would prefer. But I actually do sort of like how they're combined like this, since this feels like the most common use case for getting the current span.