### PR TITLE
fix: Allow OTLP Exporter compression value of `none`

### DIFF
--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -52,7 +52,7 @@ module OpenTelemetry
                        timeout: config_opt('OTEL_EXPORTER_OTLP_TRACES_TIMEOUT', 'OTEL_EXPORTER_OTLP_TIMEOUT', default: 10),
                        metrics_reporter: nil)
           raise ArgumentError, "invalid url for OTLP::Exporter #{endpoint}" if invalid_url?(endpoint)
-          raise ArgumentError, "unsupported compression key #{compression}" unless compression.nil? || compression == 'gzip'
+          raise ArgumentError, "unsupported compression key #{compression}" unless compression.nil? || %w[gzip none].include?(compression)
 
           @uri = if endpoint == ENV['OTEL_EXPORTER_OTLP_ENDPOINT']
                    URI("#{endpoint}/v1/traces")

--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -53,7 +53,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
         { envar: 'OTEL_EXPORTER_OTLP_COMPRESSION', value: 'gzip' },
         { envar: 'OTEL_EXPORTER_OTLP_COMPRESSION', value: 'none' },
         { envar: 'OTEL_EXPORTER_OTLP_TRACES_COMPRESSION', value: 'gzip' },
-        { envar: 'OTEL_EXPORTER_OTLP_TRACES_COMPRESSION', value: 'none' },
+        { envar: 'OTEL_EXPORTER_OTLP_TRACES_COMPRESSION', value: 'none' }
       ].each do |example|
         with_env(example[:envar] => example[:value]) do
           exp = OpenTelemetry::Exporter::OTLP::Exporter.new

--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -41,10 +41,25 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       assert_raises ArgumentError do
         OpenTelemetry::Exporter::OTLP::Exporter.new(compression: 'flate')
       end
-      exp = OpenTelemetry::Exporter::OTLP::Exporter.new(compression: 'gzip')
-      _(exp).wont_be_nil
       exp = OpenTelemetry::Exporter::OTLP::Exporter.new(compression: nil)
-      _(exp).wont_be_nil
+      _(exp.instance_variable_get(:@compression)).must_be_nil
+
+      %w[gzip none].each do |compression|
+        exp = OpenTelemetry::Exporter::OTLP::Exporter.new(compression: compression)
+        _(exp.instance_variable_get(:@compression)).must_equal(compression)
+      end
+
+      [
+        { envar: 'OTEL_EXPORTER_OTLP_COMPRESSION', value: 'gzip' },
+        { envar: 'OTEL_EXPORTER_OTLP_COMPRESSION', value: 'none' },
+        { envar: 'OTEL_EXPORTER_OTLP_TRACES_COMPRESSION', value: 'gzip' },
+        { envar: 'OTEL_EXPORTER_OTLP_TRACES_COMPRESSION', value: 'none' },
+      ].each do |example|
+        with_env(example[:envar] => example[:value]) do
+          exp = OpenTelemetry::Exporter::OTLP::Exporter.new
+          _(exp.instance_variable_get(:@compression)).must_equal(example[:value])
+        end
+      end
     end
 
     it 'sets parameters from the environment' do


### PR DESCRIPTION
> [2]: If no compression value is explicitly specified, SIGs can default to the value they deem most useful among the supported options.
>      This is especially important in the presence of technical constraints,
>      e.g. directly sending telemetry data from mobile devices to backend servers.
>
> Supported values for OTEL_EXPORTER_OTLP_*COMPRESSION options:
>
> * none if compression is disabled.
> * gzip is the only specified compression method for now.

https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options