### PR TITLE
text map propagator extraction should use argument context

### DIFF
--- a/api/lib/opentelemetry/trace/propagation/trace_context/text_map_propagator.rb
+++ b/api/lib/opentelemetry/trace/propagation/trace_context/text_map_propagator.rb
@@ -54,7 +54,7 @@ module OpenTelemetry
                                                   tracestate: tracestate,
                                                   remote: true)
             span = OpenTelemetry::Trace.non_recording_span(span_context)
-            OpenTelemetry::Trace.context_with_span(span)
+            OpenTelemetry::Trace.context_with_span(span, parent_context: context)
           rescue OpenTelemetry::Error
             context
           end

--- a/api/test/opentelemetry/trace/propagation/trace_context/text_map_propagator_test.rb
+++ b/api/test/opentelemetry/trace/propagation/trace_context/text_map_propagator_test.rb
@@ -67,6 +67,14 @@ describe OpenTelemetry::Trace::Propagation::TraceContext::TextMapPropagator do
       ctx = propagator.extract({}, context: context) { invalid_traceparent_header }
       _(ctx).must_equal(context)
     end
+
+    it 'should apply current span on argument context' do
+      key = Context.create_key('key1')
+      ctx = Context::ROOT.set_value(key, 'value1')
+      extracted_ctx = propagator.extract(carrier, context: ctx) { |c, k| c[k] }
+
+      _(extracted_ctx.value(key)).must_equal('value1')
+    end
   end
 
   describe '#inject' do


### PR DESCRIPTION
For W3C text map propagator, the extraction should use the argument context and apply the current span on it.
Before this fix, when calling `context_with_span` the argument context is not used. It used the current context instead. 


From Propagators API specification:
> [Returns a new Context derived from the Context passed as argument](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/api-propagators.md#extract)

---- 

Thanks @blumamir for finding this issue.