### PR TITLE
chore: add max faraday version to tests 

### DIFF
--- a/instrumentation/koala/Gemfile
+++ b/instrumentation/koala/Gemfile
@@ -13,6 +13,7 @@ gem 'opentelemetry-instrumentation-base', path: '../base'
 
 group :test do
   gem 'byebug'
+  gem 'faraday', '<2.0'
   gem 'opentelemetry-common', path: '../../common'
   gem 'opentelemetry-sdk', path: '../../sdk'
   gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions'


### PR DESCRIPTION
### Summary

Temp workaround for https://github.com/arsduo/koala/issues/659 to unblock CI until upstream Koala itself supports Faraday 2.0