### PR TITLE
fix: `ActiveSupport` constant conflict in Active Model Serializers instrumentation

### DIFF
--- a/instrumentation/active_model_serializers/lib/opentelemetry/instrumentation/active_model_serializers/instrumentation.rb
+++ b/instrumentation/active_model_serializers/lib/opentelemetry/instrumentation/active_model_serializers/instrumentation.rb
@@ -35,7 +35,7 @@ module OpenTelemetry
         end
 
         def register_event_handler
-          ActiveSupport::Notifications.subscribe(event_name) do |_name, start, finish, _id, payload|
+          ::ActiveSupport::Notifications.subscribe(event_name) do |_name, start, finish, _id, payload|
             EventHandler.handle(start, finish, payload)
           end
         end

--- a/instrumentation/all/Gemfile
+++ b/instrumentation/all/Gemfile
@@ -46,6 +46,8 @@ gem 'opentelemetry-instrumentation-sinatra', path: '../sinatra'
 gem 'opentelemetry-instrumentation-trilogy', path: '../trilogy'
 
 group :test do
+  gem 'active_model_serializers'
+  gem 'activesupport'
   gem 'opentelemetry-sdk', path: '../../sdk'
   gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions'
 end

--- a/instrumentation/all/test/opentelemetry/instrumentation/all_test.rb
+++ b/instrumentation/all/test/opentelemetry/instrumentation/all_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require_relative '../../test_helper'
+
+require 'active_support/all'
+require 'active_model_serializers'
+
+# require Instrumentation so .install method is found:
+require_relative '../../../lib/opentelemetry/instrumentation/all'
+
+describe OpenTelemetry::Instrumentation::All do
+  describe 'ActiveModelSerializers instrumentation' do
+    it 'does not conflict with ActiveSupport instrumentation' do
+      # Expected behavior is that the exception is not raised.
+      OpenTelemetry::Instrumentation::ActiveSupport::Instrumentation.instance.install
+      OpenTelemetry::Instrumentation::ActiveModelSerializers::Instrumentation.instance.install
+    end
+  end
+end

--- a/instrumentation/all/test/test_helper.rb
+++ b/instrumentation/all/test/test_helper.rb
@@ -5,4 +5,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require 'minitest/autorun'
-require 'webmock/minitest'


### PR DESCRIPTION
When both `ActiveSupport` and `ActiveModelSerializers` instrumentations are loaded,
constant `ActiveSupport::Notifications` inside `ActiveModelSerializers` can be incorrectly
resolved to `OpenTelemetry::Instrumentation::ActiveSupport`.

```
ERROR -- : OpenTelemetry error: Instrumentation: OpenTelemetry::Instrumentation::ActiveModelSerializers unhandled exception during install
...
...
uninitialized constant OpenTelemetry::Instrumentation::ActiveSupport::Notifications
OR
undefined method `subscribe' for Notifications:Module
```