### PR TITLE
fix: Bump public version

### DIFF
--- a/instrumentation/trilogy/CHANGELOG.md
+++ b/instrumentation/trilogy/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Release History: opentelemetry-instrumentation-trilogy
 
-### v0.1.0 / 2021-12-31
+### v0.50.0 / 2021-12-31
 
-* Initial release.
+* Initial public release.

--- a/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/version.rb
+++ b/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/version.rb
@@ -7,7 +7,7 @@
 module OpenTelemetry
   module Instrumentation
     module Trilogy
-      VERSION = '0.1.0'
+      VERSION = '0.50.0'
     end
   end
 end


### PR DESCRIPTION
Earlier versions of this intrumentation were developed at GitHub and released privately.

Starting with 0.50.0 gives us enough buffer to address any issues that may come up with earlier versions of this gem.