### PR TITLE
chore: update server instrumentation to not reflect 400 status as error

### DIFF
--- a/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
+++ b/instrumentation/rack/lib/opentelemetry/instrumentation/rack/middlewares/tracer_middleware.rb
@@ -151,7 +151,7 @@ module OpenTelemetry
           end
 
           def set_attributes_after_request(span, status, headers, _response)
-            span.status = OpenTelemetry::Trace::Status.error unless (100..399).include?(status.to_i)
+            span.status = OpenTelemetry::Trace::Status.error unless (100..499).include?(status.to_i)
             span.set_attribute('http.status_code', status)
 
             # NOTE: if data is available, it would be good to do this:

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/tracer_middleware_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/tracer_middleware_test.rb
@@ -268,7 +268,7 @@ describe OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware do
       it 'leaves status code unset' do
         _(first_span.attributes['http.status_code']).must_equal 404
         _(first_span.kind).must_equal :server
-        _(first_span.status.code).must_equal OpenTelemetry::Trace::Status::ERROR
+        _(first_span.status.code).must_equal OpenTelemetry::Trace::Status::UNSET
       end
     end
   end

--- a/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/tracer_middleware_test.rb
+++ b/instrumentation/rack/test/opentelemetry/instrumentation/rack/middlewares/tracer_middleware_test.rb
@@ -259,6 +259,18 @@ describe OpenTelemetry::Instrumentation::Rack::Middlewares::TracerMiddleware do
         end
       end
     end
+
+    describe '#called with 400 level http status code' do
+      let(:app) do
+        ->(_env) { [404, { 'Foo-Bar' => 'foo bar response header' }, ['Not Found']] }
+      end
+
+      it 'leaves status code unset' do
+        _(first_span.attributes['http.status_code']).must_equal 404
+        _(first_span.kind).must_equal :server
+        _(first_span.status.code).must_equal OpenTelemetry::Trace::Status::ERROR
+      end
+    end
   end
 
   describe 'config[:quantization]' do

--- a/instrumentation/sinatra/lib/opentelemetry/instrumentation/sinatra/middlewares/tracer_middleware.rb
+++ b/instrumentation/sinatra/lib/opentelemetry/instrumentation/sinatra/middlewares/tracer_middleware.rb
@@ -43,7 +43,7 @@ module OpenTelemetry
             span.set_attribute('http.status_code', status)
             span.set_attribute('http.route', env['sinatra.route'].split.last) if env['sinatra.route']
             span.name = env['sinatra.route'] if env['sinatra.route']
-            span.status = OpenTelemetry::Trace::Status.error unless (100..399).include?(status.to_i)
+            span.status = OpenTelemetry::Trace::Status.error unless (100..499).include?(status.to_i)
           end
         end
       end

--- a/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_test.rb
+++ b/instrumentation/sinatra/test/opentelemetry/instrumentation/sinatra_test.rb
@@ -128,7 +128,7 @@ describe OpenTelemetry::Instrumentation::Sinatra do
     it 'does not create unhandled exceptions for missing routes' do
       get '/one/missing_example/not_present'
 
-      _(exporter.finished_spans.first.status.code).must_equal OpenTelemetry::Trace::Status::ERROR
+      _(exporter.finished_spans.first.status.code).must_equal OpenTelemetry::Trace::Status::UNSET
       _(exporter.finished_spans.first.attributes).must_equal(
         'http.method' => 'GET',
         'http.url' => '/missing_example/not_present',


### PR DESCRIPTION
### Summary

The specification as of late October/early November 2021 has been updated for http server spans so that 400 level responses should not create a span.status of `Error` but instead should leave span status unset. Two instrumentations, rack and sinatra, were off spec and need to be updated, this PR updates them.

see:

- https://github.com/open-telemetry/opentelemetry-specification/pull/1998
- https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#status