### PR TITLE
Fixing a minor typo in getting started.

### DIFF
--- a/website_docs/getting_started.md
+++ b/website_docs/getting_started.md
@@ -58,7 +58,7 @@ First, start up an example system:
 
 ```console
 $ git clone git@github.com:open-telemetry/opentelemetry-ruby.git; \
-    cd open-telemetry-ruby/examples/otel-collector; \
+    cd opentelemetry-ruby/examples/otel-collector; \
        docker-compose up -d
 ```
 


### PR DESCRIPTION
Just following the getting started and discovered that this was slightly wrong.

The git repo folder is opentelemetry-ruby instead of open-telemetry-ruby