### PR TITLE
fix: Trilogy Driver Options

### DIFF
--- a/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/client.rb
+++ b/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy/patches/client.rb
@@ -48,8 +48,8 @@ module OpenTelemetry
 
           FULL_SQL_REGEXP = Regexp.union(MYSQL_COMPONENTS.map { |component| COMPONENTS_REGEX_MAP[component] })
 
-          def initialize(**kwargs)
-            @_otel_net_peer_name = kwargs[:host]
+          def initialize(args)
+            @_otel_net_peer_name = args[:host]
             super
           end
 

--- a/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/instrumentation_test.rb
+++ b/instrumentation/trilogy/test/opentelemetry/instrumentation/trilogy/instrumentation_test.rb
@@ -14,14 +14,17 @@ describe OpenTelemetry::Instrumentation::Trilogy do
   let(:exporter) { EXPORTER }
   let(:span) { exporter.finished_spans.first }
   let(:config) { {} }
-  let(:client) do
-    ::Trilogy.new(
+  let(:driver_options) do
+    {
       host: host,
       port: port,
       username: username,
       password: password,
       ssl: false
-    )
+    }
+  end
+  let(:client) do
+    ::Trilogy.new(driver_options)
   end
 
   let(:host) { ENV.fetch('TEST_MYSQL_HOST', '127.0.0.1') }


### PR DESCRIPTION
The trilogy driver does not use keyword arguments in its initializer, which results in an ArgumentError to be raised when an options hash is used instead.

This change rolls back the overridden initializer to accept a hash.