### PR TITLE
chore: add semconv gem to relevant gemspecs and require explicitly

### DIFF
--- a/instrumentation/aws_sdk/lib/opentelemetry/instrumentation/aws_sdk.rb
+++ b/instrumentation/aws_sdk/lib/opentelemetry/instrumentation/aws_sdk.rb
@@ -6,6 +6,7 @@
 
 require 'opentelemetry'
 require 'opentelemetry-instrumentation-base'
+require 'opentelemetry/semantic_conventions'
 
 module OpenTelemetry
   module Instrumentation

--- a/instrumentation/aws_sdk/opentelemetry-instrumentation-aws_sdk.gemspec
+++ b/instrumentation/aws_sdk/opentelemetry-instrumentation-aws_sdk.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.19.0'
+  spec.add_dependency 'opentelemetry-semantic_conventions'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'aws-sdk', '>= 2.0'

--- a/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http.rb
+++ b/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http.rb
@@ -7,6 +7,7 @@
 require 'opentelemetry'
 require 'opentelemetry/common'
 require 'opentelemetry-instrumentation-base'
+require 'opentelemetry/semantic_conventions'
 
 module OpenTelemetry
   module Instrumentation

--- a/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
+++ b/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.19.0'
+  spec.add_dependency 'opentelemetry-semantic_conventions'  
 
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'minitest', '~> 5.0'

--- a/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
+++ b/instrumentation/net_http/opentelemetry-instrumentation-net_http.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
   spec.add_dependency 'opentelemetry-instrumentation-base', '~> 0.19.0'
-  spec.add_dependency 'opentelemetry-semantic_conventions'  
+  spec.add_dependency 'opentelemetry-semantic_conventions'
 
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'minitest', '~> 5.0'

--- a/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy.rb
+++ b/instrumentation/trilogy/lib/opentelemetry/instrumentation/trilogy.rb
@@ -6,6 +6,7 @@
 
 require 'opentelemetry'
 require 'opentelemetry-instrumentation-base'
+require 'opentelemetry/semantic_conventions'
 
 module OpenTelemetry
   module Instrumentation


### PR DESCRIPTION
Followup for https://github.com/open-telemetry/opentelemetry-ruby/pull/1083

We should include a loose semconv gem dependency and explicitly require in the module during instrumentation loading, when it's being used in instrumentation.

Since the `-sdk` takes a loose semconv dependency this has not caused errors when the `SemanticConventions` constant gets used by instrumentations, but technically these instrumentations can be used outside the SDK and must not hold any hard SDK Dependency, so it's necessary that we add the semconv gem to their gemspec

Note: Trilogy already has a semconv gem dependancy in it's gemspec

(alternatively, should we just include this in `-base`?)