### PR TITLE
Remove TIMEOUT timeout status from OTLP exporter

### DIFF
--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -22,7 +22,6 @@ module OpenTelemetry
       class Exporter # rubocop:disable Metrics/ClassLength
         SUCCESS = OpenTelemetry::SDK::Trace::Export::SUCCESS
         FAILURE = OpenTelemetry::SDK::Trace::Export::FAILURE
-        TIMEOUT = OpenTelemetry::SDK::Trace::Export::TIMEOUT
         private_constant(:SUCCESS, :FAILURE, :TIMEOUT)
 
         # Default timeouts in seconds.
@@ -165,7 +164,7 @@ module OpenTelemetry
             @headers.each { |key, value| request.add_field(key, value) }
 
             remaining_timeout = OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time)
-            return TIMEOUT if remaining_timeout.zero?
+            return FAILURE if remaining_timeout.zero?
 
             @http.open_timeout = remaining_timeout
             @http.read_timeout = remaining_timeout

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -22,7 +22,7 @@ module OpenTelemetry
       class Exporter # rubocop:disable Metrics/ClassLength
         SUCCESS = OpenTelemetry::SDK::Trace::Export::SUCCESS
         FAILURE = OpenTelemetry::SDK::Trace::Export::FAILURE
-        private_constant(:SUCCESS, :FAILURE, :TIMEOUT)
+        private_constant(:SUCCESS, :FAILURE)
 
         # Default timeouts in seconds.
         KEEP_ALIVE_TIMEOUT = 30

--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -8,7 +8,6 @@ require 'test_helper'
 describe OpenTelemetry::Exporter::OTLP::Exporter do
   SUCCESS = OpenTelemetry::SDK::Trace::Export::SUCCESS
   FAILURE = OpenTelemetry::SDK::Trace::Export::FAILURE
-  TIMEOUT = OpenTelemetry::SDK::Trace::Export::TIMEOUT
 
   describe '#initialize' do
     it 'initializes with defaults' do
@@ -297,7 +296,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       stub_request(:post, 'http://localhost:4318/v1/traces').to_return(status: 200)
       span_data = create_span_data
       result = exporter.export([span_data], timeout: 0)
-      _(result).must_equal(TIMEOUT)
+      _(result).must_equal(FAILURE)
     end
 
     it 'returns FAILURE on unexpected exceptions' do

--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -348,7 +348,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       end
 
       exporter.stub(:backoff?, backoff_stubbed_call) do
-        _(exporter.export([span_data], timeout: 0.1)).must_equal(TIMEOUT)
+        _(exporter.export([span_data], timeout: 0.1)).must_equal(FAILURE)
       end
     ensure
       @retry_count = 0


### PR DESCRIPTION
In the effort of pushing the OTLP exporter to a 1.0, I'm going through the spec and trying to align the subtle inconsistencies. 

The TIMEOUT status is not explicitly stated, which leads me to believe it should probably be removed.
```
Returns: ExportResult:

ExportResult is one of:

* Success - The batch has been successfully exported. For protocol exporters this typically means that the data is sent over the wire and delivered to the destination server.
* Failure - exporting failed. The batch must be dropped. For example, this can happen when the batch contains bad data and cannot be serialized.
```
https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#interface-definition-1

However force flush does make reference to notify the caller that the call timed out.

```
ForceFlush SHOULD provide a way to let the caller know whether it succeeded, failed or timed out.
```
https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#forceflush-2

In either case, force flush is never going to return a timeout status code so I believe we can safely remove this.
https://github.com/open-telemetry/opentelemetry-ruby/blob/fd24a7b9b096c7a30021bfda1f3b7b1090d8cfce/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb#L90-L97