### PR TITLE
Better: remove restrictions on koala.

### DIFF
--- a/instrumentation/koala/Appraisals
+++ b/instrumentation/koala/Appraisals
@@ -3,7 +3,6 @@
 # Copyright The OpenTelemetry Authors
 #
 # SPDX-License-Identifier: Apache-2.0
-appraise 'koala-3' do
-  gem 'koala', '~> 3.0.0'
-  gem 'faraday', '< 2.0'
+appraise 'koala' do
+  gem 'koala'
 end

--- a/instrumentation/koala/opentelemetry-instrumentation-koala.gemspec
+++ b/instrumentation/koala/opentelemetry-instrumentation-koala.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'bundler', '>= 1.17'
-  spec.add_development_dependency 'koala', '~> 3.0.0'
+  spec.add_development_dependency 'koala'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.0'
   spec.add_development_dependency 'rake', '~> 12.3.3'


### PR DESCRIPTION
Following https://github.com/arsduo/koala/issues/659 and the recent release of koala https://github.com/arsduo/koala/pull/663, restrictions on koala and faraday can be removed