### PR TITLE
Add HTTP Status Code attribute to AWS SDK span

### DIFF
--- a/instrumentation/aws_sdk/Gemfile
+++ b/instrumentation/aws_sdk/Gemfile
@@ -12,7 +12,6 @@ gem 'opentelemetry-api', path: '../../api'
 gem 'opentelemetry-instrumentation-base', path: '../base'
 
 group :test do
-  gem 'httpclient'
   gem 'opentelemetry-common', path: '../../common'
   gem 'opentelemetry-sdk', path: '../../sdk'
   gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions'

--- a/instrumentation/aws_sdk/Gemfile
+++ b/instrumentation/aws_sdk/Gemfile
@@ -12,6 +12,7 @@ gem 'opentelemetry-api', path: '../../api'
 gem 'opentelemetry-instrumentation-base', path: '../base'
 
 group :test do
+  gem 'httpclient'
   gem 'opentelemetry-common', path: '../../common'
   gem 'opentelemetry-sdk', path: '../../sdk'
   gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions'

--- a/instrumentation/aws_sdk/lib/opentelemetry/instrumentation/aws_sdk/handler.rb
+++ b/instrumentation/aws_sdk/lib/opentelemetry/instrumentation/aws_sdk/handler.rb
@@ -37,6 +37,9 @@ module OpenTelemetry
             else
               super
             end.tap do |response|
+              span.set_attribute(OpenTelemetry::SemanticConventions::Trace::HTTP_STATUS_CODE,
+                                 context.http_response.status_code)
+
               if (err = response.error)
                 span.record_exception(err)
                 span.status = Trace::Status.error(err.to_s)

--- a/instrumentation/aws_sdk/test/opentelemetry/instrumentation_test.rb
+++ b/instrumentation/aws_sdk/test/opentelemetry/instrumentation_test.rb
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'httpclient'
 require 'test_helper'
 
 describe OpenTelemetry::Instrumentation::AwsSdk do
@@ -57,7 +56,7 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
         _(last_span.attributes['aws.region']).must_include 'stubbed'
         _(last_span.attributes['db.system']).must_be_nil
 
-        _(last_span.attributes[OpenTelemetry::SemanticConventions::Trace::HTTP_STATUS_CODE]).must_equal HTTP::Status::OK
+        _(last_span.attributes[OpenTelemetry::SemanticConventions::Trace::HTTP_STATUS_CODE]).must_equal 200
 
         _(last_span.status.code).must_equal OpenTelemetry::Trace::Status::UNSET
       end
@@ -75,7 +74,7 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
         _(last_span.attributes['aws.region']).must_include 'stubbed'
         _(last_span.attributes['db.system']).must_be_nil
 
-        _(last_span.attributes[OpenTelemetry::SemanticConventions::Trace::HTTP_STATUS_CODE]).must_equal HTTP::Status::OK
+        _(last_span.attributes[OpenTelemetry::SemanticConventions::Trace::HTTP_STATUS_CODE]).must_equal 200
 
         _(last_span.status.code).must_equal OpenTelemetry::Trace::Status::UNSET
       end
@@ -94,7 +93,7 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
           _(last_span.attributes['db.system']).must_be_nil
         end
 
-        _(last_span.attributes[OpenTelemetry::SemanticConventions::Trace::HTTP_STATUS_CODE]).must_equal HTTP::Status::BAD_REQUEST
+        _(last_span.attributes[OpenTelemetry::SemanticConventions::Trace::HTTP_STATUS_CODE]).must_equal 400
 
         _(last_span.status.code).must_equal OpenTelemetry::Trace::Status::ERROR
       end
@@ -109,7 +108,7 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
         _(last_span.attributes['rpc.system']).must_equal 'aws-api'
         _(last_span.attributes['db.system']).must_equal 'dynamodb'
 
-        _(last_span.attributes[OpenTelemetry::SemanticConventions::Trace::HTTP_STATUS_CODE]).must_equal HTTP::Status::OK
+        _(last_span.attributes[OpenTelemetry::SemanticConventions::Trace::HTTP_STATUS_CODE]).must_equal 200
       end
     end
 

--- a/instrumentation/aws_sdk/test/opentelemetry/instrumentation_test.rb
+++ b/instrumentation/aws_sdk/test/opentelemetry/instrumentation_test.rb
@@ -4,6 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require 'httpclient'
 require 'test_helper'
 
 describe OpenTelemetry::Instrumentation::AwsSdk do
@@ -55,6 +56,9 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
         _(last_span.attributes['rpc.method']).must_equal 'Publish'
         _(last_span.attributes['aws.region']).must_include 'stubbed'
         _(last_span.attributes['db.system']).must_be_nil
+
+        _(last_span.attributes[OpenTelemetry::SemanticConventions::Trace::HTTP_STATUS_CODE]).must_equal HTTP::Status::OK
+
         _(last_span.status.code).must_equal OpenTelemetry::Trace::Status::UNSET
       end
     end
@@ -70,6 +74,9 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
         _(last_span.attributes['rpc.method']).must_equal 'ListBuckets'
         _(last_span.attributes['aws.region']).must_include 'stubbed'
         _(last_span.attributes['db.system']).must_be_nil
+
+        _(last_span.attributes[OpenTelemetry::SemanticConventions::Trace::HTTP_STATUS_CODE]).must_equal HTTP::Status::OK
+
         _(last_span.status.code).must_equal OpenTelemetry::Trace::Status::UNSET
       end
 
@@ -87,6 +94,8 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
           _(last_span.attributes['db.system']).must_be_nil
         end
 
+        _(last_span.attributes[OpenTelemetry::SemanticConventions::Trace::HTTP_STATUS_CODE]).must_equal HTTP::Status::BAD_REQUEST
+
         _(last_span.status.code).must_equal OpenTelemetry::Trace::Status::ERROR
       end
     end
@@ -99,6 +108,8 @@ describe OpenTelemetry::Instrumentation::AwsSdk do
 
         _(last_span.attributes['rpc.system']).must_equal 'aws-api'
         _(last_span.attributes['db.system']).must_equal 'dynamodb'
+
+        _(last_span.attributes[OpenTelemetry::SemanticConventions::Trace::HTTP_STATUS_CODE]).must_equal HTTP::Status::OK
       end
     end
 


### PR DESCRIPTION
## Description

I looked at the documentation for the AWS Ruby SDK and found that [every `response` has a `successful?` method](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Seahorse/Client/Response.html#successful%3F-instance_method). It returns a boolean.

However, better than that, [the source code for `successful?`](https://github.com/aws/aws-sdk-ruby/blob/83ac0d4903a4c3f530b5f37c3e34e61cf54a1320/gems/aws-sdk-core/lib/seahorse/client/response.rb#L57-L61) reveals something useful:


```ruby
def successful?
    (200..299).cover?(@context.http_response.status_code) && @error.nil?
end
```

`@context.http_response.status_code` is appropriately populated when the `response` completes!

So I used that to set the `http.status_code` attribute on the span.

I also included the `httpclient` gem so that in the tests we can compare against constants.


Fixes #1094