### PR TITLE
Update rubocop namespaces for 0.78.x

### DIFF
--- a/.instrumentation_generator/templates/gemspec.tt
+++ b/.instrumentation_generator/templates/gemspec.tt
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.0'
   spec.add_development_dependency 'rake', '~> 12.3.3'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 0.78.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/api/.rubocop.yml
+++ b/api/.rubocop.yml
@@ -5,7 +5,7 @@ Lint/UnusedMethodArgument:
   Enabled: false
 Metrics/AbcSize:
   Max: 18
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Max: 20

--- a/common/.rubocop.yml
+++ b/common/.rubocop.yml
@@ -8,7 +8,7 @@ Lint/UnusedMethodArgument:
   Enabled: false
 Metrics/AbcSize:
   Max: 18
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Max: 20

--- a/exporter/jaeger/.rubocop.yml
+++ b/exporter/jaeger/.rubocop.yml
@@ -8,7 +8,7 @@ Lint/UnusedMethodArgument:
   Enabled: false
 Metrics/AbcSize:
   Max: 18
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Max: 21

--- a/exporter/jaeger/test/.rubocop.yml
+++ b/exporter/jaeger/test/.rubocop.yml
@@ -2,5 +2,5 @@ inherit_from: ../.rubocop.yml
 
 Metrics/BlockLength:
   Enabled: false
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false

--- a/exporter/otlp/.rubocop.yml
+++ b/exporter/otlp/.rubocop.yml
@@ -8,7 +8,7 @@ Lint/UnusedMethodArgument:
   Enabled: false
 Metrics/AbcSize:
   Max: 18
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Max: 21

--- a/exporter/otlp/test/.rubocop.yml
+++ b/exporter/otlp/test/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_from: ../.rubocop.yml
 
 Metrics/BlockLength:
   Enabled: false
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 Style/MethodCallWithoutArgsParentheses:
   Exclude:

--- a/exporter/zipkin/.rubocop.yml
+++ b/exporter/zipkin/.rubocop.yml
@@ -8,7 +8,7 @@ Lint/UnusedMethodArgument:
   Enabled: false
 Metrics/AbcSize:
   Max: 29
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 Metrics/ModuleLength:
   Max: 130

--- a/exporter/zipkin/test/.rubocop.yml
+++ b/exporter/zipkin/test/.rubocop.yml
@@ -2,5 +2,5 @@ inherit_from: ../.rubocop.yml
 
 Metrics/BlockLength:
   Enabled: false
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false

--- a/instrumentation/.rubocop-examples.yml
+++ b/instrumentation/.rubocop-examples.yml
@@ -10,7 +10,7 @@ Metrics/AbcSize:
   Max: 18
   Exclude:
     - "**/test/**/*"
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Max: 20

--- a/instrumentation/active_job/.rubocop.yml
+++ b/instrumentation/active_job/.rubocop.yml
@@ -10,7 +10,7 @@ Lint/UnusedMethodArgument:
   Enabled: false
 Metrics/AbcSize:
   Max: 18
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Max: 20

--- a/instrumentation/active_record/test/.rubocop.yml
+++ b/instrumentation/active_record/test/.rubocop.yml
@@ -2,5 +2,3 @@ inherit_from: ../.rubocop.yml
 
 Metrics/BlockLength:
   Enabled: false
-Style/BracesAroundHashParameters:
-  Enabled: false

--- a/instrumentation/base/.rubocop.yml
+++ b/instrumentation/base/.rubocop.yml
@@ -8,7 +8,7 @@ Lint/UnusedMethodArgument:
   Enabled: false
 Metrics/AbcSize:
   Max: 18
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Max: 20

--- a/instrumentation/bunny/.rubocop.yml
+++ b/instrumentation/bunny/.rubocop.yml
@@ -8,7 +8,7 @@ Lint/UnusedMethodArgument:
   Enabled: false
 Metrics/AbcSize:
   Max: 18
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Max: 20

--- a/instrumentation/dalli/.rubocop.yml
+++ b/instrumentation/dalli/.rubocop.yml
@@ -3,5 +3,5 @@ inherit_from: ../.rubocop-examples.yml
 Naming/FileName:
   Exclude:
     - "lib/opentelemetry-instrumentation-dalli.rb"
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   Enabled: false

--- a/propagator/b3/.rubocop.yml
+++ b/propagator/b3/.rubocop.yml
@@ -4,7 +4,7 @@ Lint/UnusedMethodArgument:
   Enabled: false
 Metrics/AbcSize:
   Max: 18
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Max: 20

--- a/propagator/jaeger/.rubocop.yml
+++ b/propagator/jaeger/.rubocop.yml
@@ -8,7 +8,7 @@ Metrics/BlockLength:
   Exclude:
     - 'opentelemetry-propagator-jaeger.gemspec'
     - 'test/**/*_test.rb'
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Max: 20

--- a/propagator/ottrace/.rubocop.yml
+++ b/propagator/ottrace/.rubocop.yml
@@ -9,7 +9,7 @@ Metrics/BlockLength:
   Exclude:
     - 'test/opentelemetry/propagator/**/*_test.rb'
     - 'opentelemetry-propagator-ottrace.gemspec'
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Max: 20

--- a/propagator/xray/.rubocop.yml
+++ b/propagator/xray/.rubocop.yml
@@ -4,7 +4,7 @@ Lint/UnusedMethodArgument:
   Enabled: false
 Metrics/AbcSize:
   Max: 18
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Max: 20

--- a/resource_detectors/.rubocop.yml
+++ b/resource_detectors/.rubocop.yml
@@ -8,7 +8,7 @@ Lint/UnusedMethodArgument:
   Enabled: false
 Metrics/AbcSize:
   Max: 18
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Max: 20

--- a/sdk/.rubocop.yml
+++ b/sdk/.rubocop.yml
@@ -5,7 +5,7 @@ Lint/UnusedMethodArgument:
   Enabled: false
 Metrics/AbcSize:
   Max: 18
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Max: 21

--- a/sdk/test/.rubocop.yml
+++ b/sdk/test/.rubocop.yml
@@ -2,5 +2,5 @@ inherit_from: ../.rubocop.yml
 
 Metrics/BlockLength:
   Enabled: false
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false

--- a/semantic_conventions/.rubocop.yml
+++ b/semantic_conventions/.rubocop.yml
@@ -8,7 +8,7 @@ Lint/UnusedMethodArgument:
   Enabled: false
 Metrics/AbcSize:
   Max: 18
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Max: 20
@@ -33,5 +33,5 @@ Layout/EmptyLinesAroundModuleBody:
   Enabled: false
 Layout/TrailingWhitespace:
   Enabled: false
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: False


### PR DESCRIPTION
## Description

I was using VSCode and formatting with the `rubocop` extension when I got a warning for the namespace of the `instrumentation/.rubocop-examples.yml`.

I looked [at this issue comment](https://github.com/github/rubocop-github/issues/54#issuecomment-611406732) and found that it should be `Layout/LineLength` in that file. Updated it in this PR to make the warning go away.