### PR TITLE
Consistent CRLF in AWS SDK Instrumentation Changelog

### DIFF
--- a/instrumentation/aws_sdk/CHANGELOG.md
+++ b/instrumentation/aws_sdk/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### v0.2.0 / 2022-01-20
 
-* ADDED: SQS / SNS messaging attributes and context propagation 
+* ADDED: SQS / SNS messaging attributes and context propagation
 
 ### v0.1.0 / 2021-12-01
 


### PR DESCRIPTION
## Description

Follow up to #1099 which changed the lines breaks to be LF instead of CRLF like they were before. This breaks our regex of the CHANGELOG file that we need for the release:

https://github.com/open-telemetry/opentelemetry-ruby/blob/b7149fb72cad6c45956a6be80acfb2d062aab3a6/.toys/release/.lib/release_utils.rb#L228-L230