### PR TITLE
update attribute length limit env var name to match spec

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/span_limits.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span_limits.rb
@@ -32,7 +32,8 @@ module OpenTelemetry
         # @return [SpanLimits] with the desired values.
         # @raise [ArgumentError] if any of the max numbers are not positive.
         def initialize(attribute_count_limit: Integer(ENV.fetch('OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT', 128)), # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-                       attribute_length_limit: ENV['OTEL_RUBY_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT'],
+                       attribute_length_limit: ENV.fetch('OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT',
+                                                         ENV['OTEL_RUBY_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT']),
                        event_count_limit: Integer(ENV.fetch('OTEL_SPAN_EVENT_COUNT_LIMIT', 128)),
                        link_count_limit: Integer(ENV.fetch('OTEL_SPAN_LINK_COUNT_LIMIT', 128)),
                        event_attribute_count_limit: Integer(ENV.fetch('OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT', 128)),

--- a/sdk/test/opentelemetry/sdk/trace/span_limits_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/span_limits_test.rb
@@ -23,7 +23,7 @@ describe OpenTelemetry::SDK::Trace::SpanLimits do
       with_env('OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT' => '1',
                'OTEL_SPAN_EVENT_COUNT_LIMIT' => '2',
                'OTEL_SPAN_LINK_COUNT_LIMIT' => '3',
-               'OTEL_RUBY_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '32',
+               'OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '32',
                'OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT' => '5',
                'OTEL_LINK_ATTRIBUTE_COUNT_LIMIT' => '6',
                'OTEL_TRACES_SAMPLER' => 'always_on') do
@@ -37,11 +37,28 @@ describe OpenTelemetry::SDK::Trace::SpanLimits do
       end
     end
 
+    it 'reflects old environment variable for attribute value length limit' do
+      with_env('OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT' => '1',
+               'OTEL_SPAN_EVENT_COUNT_LIMIT' => '2',
+               'OTEL_SPAN_LINK_COUNT_LIMIT' => '3',
+               'OTEL_RUBY_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '32',
+               'OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT' => '5',
+               'OTEL_LINK_ATTRIBUTE_COUNT_LIMIT' => '6',
+               'OTEL_TRACES_SAMPLER' => 'always_on') do
+        config = subject.new
+        _(config.attribute_count_limit).must_equal 1
+        _(config.event_count_limit).must_equal 2
+        _(config.link_count_limit).must_equal 3
+        _(config.attribute_length_limit).must_equal 32
+        _(config.event_attribute_count_limit).must_equal 5
+        _(config.link_attribute_count_limit).must_equal 6
+      end
+    end
     it 'reflects explicit overrides' do
       with_env('OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT' => '1',
                'OTEL_SPAN_EVENT_COUNT_LIMIT' => '2',
                'OTEL_SPAN_LINK_COUNT_LIMIT' => '3',
-               'OTEL_RUBY_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '4',
+               'OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '4',
                'OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT' => '5',
                'OTEL_LINK_ATTRIBUTE_COUNT_LIMIT' => '6',
                'OTEL_TRACES_SAMPLER' => 'always_on') do


### PR DESCRIPTION
This patch updates the attribute length limit environment variable name to match the spec: https://github.com/open-telemetry/opentelemetry-specification/blob/7b504383f53b02b10f62ef78fa008fdfd18c633e/specification/sdk-environment-variables.md#attribute-limits while also still falling back to the old environment variable since it was included in 1.0 (but only if the one that matches the specification is not set).