### PR TITLE
Fix deprecation warning from rack_env_getter

### DIFF
--- a/examples/http/server.rb
+++ b/examples/http/server.rb
@@ -29,7 +29,7 @@ class OpenTelemetryMiddleware
     # Extract context from request headers
     context = OpenTelemetry.propagation.extract(
       env,
-      getter: OpenTelemetry::Context::Propagation.rack_env_getter
+      getter: OpenTelemetry::Common::Propagation.rack_env_getter
     )
 
     status, headers, response_body = 200, {}, ''


### PR DESCRIPTION
I was running the example and saw this warning. So, fixing it to use the non-deprecated module.
