### PR TITLE
Add net.peer.name to Faraday instrumentation

### DIFF
--- a/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
+++ b/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
@@ -43,7 +43,9 @@ module OpenTelemetry
 
           def span_creation_attributes(http_method:, url:)
             instrumentation_attrs = {
-              'http.method' => http_method, 'http.url' => url.to_s
+              'http.method' => http_method,
+              'http.url' => url.to_s,
+              'net.peer.name' => url.host
             }
             config = Faraday::Instrumentation.instance.config
             instrumentation_attrs['peer.service'] = config[:peer_service] if config[:peer_service]

--- a/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
+++ b/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
@@ -50,6 +50,7 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
       _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.status_code']).must_equal 200
       _(span.attributes['http.url']).must_equal 'http://example.com/success'
+      _(span.attributes['net.peer.name']).must_equal 'example.com'
       _(response.env.request_headers['Traceparent']).must_equal(
         "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
       )
@@ -62,6 +63,7 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
       _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.status_code']).must_equal 404
       _(span.attributes['http.url']).must_equal 'http://example.com/not_found'
+      _(span.attributes['net.peer.name']).must_equal 'example.com'
       _(response.env.request_headers['Traceparent']).must_equal(
         "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
       )
@@ -74,6 +76,7 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
       _(span.attributes['http.method']).must_equal 'GET'
       _(span.attributes['http.status_code']).must_equal 500
       _(span.attributes['http.url']).must_equal 'http://example.com/failure'
+      _(span.attributes['net.peer.name']).must_equal 'example.com'
       _(response.env.request_headers['Traceparent']).must_equal(
         "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
       )
@@ -91,6 +94,7 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
       _(span.attributes['http.method']).must_equal 'OVERRIDE'
       _(span.attributes['http.status_code']).must_equal 200
       _(span.attributes['http.url']).must_equal 'http://example.com/success'
+      _(span.attributes['net.peer.name']).must_equal 'example.com'
       _(span.attributes['test.attribute']).must_equal 'test.value'
       _(response.env.request_headers['Traceparent']).must_equal(
         "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"


### PR DESCRIPTION
Adding `net.peer.name` attribute to Faraday instrumentation spans for parity with others similar libraries such as `Net::HTTP`.