### PR TITLE
fix: prevent redis instrumentation from mutating the command

### DIFF
--- a/instrumentation/redis/lib/opentelemetry/instrumentation/redis/patches/client.rb
+++ b/instrumentation/redis/lib/opentelemetry/instrumentation/redis/patches/client.rb
@@ -71,11 +71,10 @@ module OpenTelemetry
               # and return the obfuscated command
               return 'AUTH ?' if command[0] == :auth
 
-              command[0] = command[0].to_s.upcase
               if config[:db_statement] == :obfuscate
-                command[0] + ' ?' * (command.size - 1)
+                command[0].to_s.upcase + ' ?' * (command.size - 1)
               else
-                command.join(' ')
+                command[0].to_s.upcase + " " +  command[1..-1].join(' ')
               end
             end.join("\n")
           end

--- a/instrumentation/redis/lib/opentelemetry/instrumentation/redis/patches/client.rb
+++ b/instrumentation/redis/lib/opentelemetry/instrumentation/redis/patches/client.rb
@@ -74,7 +74,9 @@ module OpenTelemetry
               if config[:db_statement] == :obfuscate
                 command[0].to_s.upcase + ' ?' * (command.size - 1)
               else
-                command[0].to_s.upcase + " " +  command[1..-1].join(' ')
+                command_copy = command.dup
+                command_copy[0] = command_copy[0].to_s.upcase
+                command_copy.join(' ')
               end
             end.join("\n")
           end


### PR DESCRIPTION
The redis instrumentation has been mutating the command during the parse steps.  This appears to have no impact on redis itself as it parses the command all the same if it's `set` or `SET`. 