### PR TITLE
fix: excessive hash creation on context attr merging

### DIFF
--- a/instrumentation/ethon/lib/opentelemetry/instrumentation/ethon/patches/easy.rb
+++ b/instrumentation/ethon/lib/opentelemetry/instrumentation/ethon/patches/easy.rb
@@ -89,7 +89,7 @@ module OpenTelemetry
             }
             config = Ethon::Instrumentation.instance.config
             instrumentation_attrs['peer.service'] = config[:peer_service] if config[:peer_service]
-            instrumentation_attrs.merge(
+            instrumentation_attrs.merge!(
               OpenTelemetry::Common::HTTP::ClientContext.attributes
             )
           end

--- a/instrumentation/excon/lib/opentelemetry/instrumentation/excon/middlewares/tracer_middleware.rb
+++ b/instrumentation/excon/lib/opentelemetry/instrumentation/excon/middlewares/tracer_middleware.rb
@@ -101,7 +101,7 @@ module OpenTelemetry
             }
             config = Excon::Instrumentation.instance.config
             instrumentation_attrs['peer.service'] = config[:peer_service] if config[:peer_service]
-            instrumentation_attrs.merge(
+            instrumentation_attrs.merge!(
               OpenTelemetry::Common::HTTP::ClientContext.attributes
             )
           end

--- a/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
+++ b/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
@@ -49,7 +49,7 @@ module OpenTelemetry
             }
             config = Faraday::Instrumentation.instance.config
             instrumentation_attrs['peer.service'] = config[:peer_service] if config[:peer_service]
-            instrumentation_attrs.merge(
+            instrumentation_attrs.merge!(
               OpenTelemetry::Common::HTTP::ClientContext.attributes
             )
           end

--- a/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/client.rb
+++ b/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/client.rb
@@ -21,7 +21,7 @@ module OpenTelemetry
               'http.url' => "#{uri.scheme}://#{uri.host}",
               'net.peer.name' => uri.host,
               'net.peer.port' => uri.port
-            }.merge(OpenTelemetry::Common::HTTP::ClientContext.attributes)
+            }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
 
             tracer.in_span("HTTP #{request_method}", attributes: attributes, kind: :client) do |span|
               OpenTelemetry.propagation.inject(req.headers)

--- a/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/connection.rb
+++ b/instrumentation/http/lib/opentelemetry/instrumentation/http/patches/connection.rb
@@ -11,10 +11,10 @@ module OpenTelemetry
         # Module to prepend to HTTP::Connection for instrumentation
         module Connection
           def initialize(req, options)
-            attributes = OpenTelemetry::Common::HTTP::ClientContext.attributes.merge(
+            attributes = {
               'net.peer.name' => req.uri.host,
               'net.peer.port' => req.uri.port
-            )
+            }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
 
             tracer.in_span('HTTP CONNECT', attributes: attributes) do
               super

--- a/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/patches/client.rb
+++ b/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/patches/client.rb
@@ -16,6 +16,7 @@ module OpenTelemetry
             uri = req.header.request_uri
             url = "#{uri.scheme}://#{uri.host}"
             request_method = req.header.request_method
+
             attributes = {
               'http.method' => request_method,
               'http.scheme' => uri.scheme,
@@ -23,7 +24,7 @@ module OpenTelemetry
               'http.url' => url,
               'net.peer.name' => uri.host,
               'net.peer.port' => uri.port
-            }.merge(OpenTelemetry::Common::HTTP::ClientContext.attributes)
+            }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
 
             tracer.in_span("HTTP #{request_method}", attributes: attributes, kind: :client) do |span|
               OpenTelemetry.propagation.inject(req.header)

--- a/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/patches/session.rb
+++ b/instrumentation/http_client/lib/opentelemetry/instrumentation/http_client/patches/session.rb
@@ -14,7 +14,7 @@ module OpenTelemetry
             site = @proxy || @dest
             url = site.addr
 
-            attributes = OpenTelemetry::Common::HTTP::ClientContext.attributes.merge('http.url' => url)
+            attributes = { 'http.url' => url }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
             tracer.in_span('HTTP CONNECT', attributes: attributes) do
               super
             end

--- a/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/patches/instrumentation.rb
+++ b/instrumentation/net_http/lib/opentelemetry/instrumentation/net/http/patches/instrumentation.rb
@@ -24,7 +24,7 @@ module OpenTelemetry
                 OpenTelemetry::SemanticConventions::Trace::HTTP_TARGET => req.path,
                 OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME => @address,
                 OpenTelemetry::SemanticConventions::Trace::NET_PEER_PORT => @port
-              }.merge(OpenTelemetry::Common::HTTP::ClientContext.attributes)
+              }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
 
               tracer.in_span(
                 HTTP_METHODS_TO_SPAN_NAMES[req.method],
@@ -50,11 +50,12 @@ module OpenTelemetry
                 conn_port    = port
               end
 
-              attributes = OpenTelemetry::Common::HTTP::ClientContext.attributes
-              tracer.in_span('HTTP CONNECT', attributes: attributes.merge(
+              attributes = {
                 OpenTelemetry::SemanticConventions::Trace::NET_PEER_NAME => conn_address,
                 OpenTelemetry::SemanticConventions::Trace::NET_PEER_PORT => conn_port
-              )) do
+              }.merge!(OpenTelemetry::Common::HTTP::ClientContext.attributes)
+
+              tracer.in_span('HTTP CONNECT', attributes: attributes) do
                 super
               end
             end


### PR DESCRIPTION
Fixes the ordering of attribute merging in some places, switches to using `merge!` to avoid creating an additional hash on merge.