### PR TITLE
docs: fix exporter port in Jaeger exporter readme

### DIFF
--- a/exporter/jaeger/README.md
+++ b/exporter/jaeger/README.md
@@ -37,7 +37,7 @@ ENV['OTEL_TRACES_EXPORTER'] = 'jaeger'
 ENV['OTEL_SERVICE_NAME'] = 'jaeger-example'
 ENV['OTEL_SERVICE_VERSION'] = '0.6.0'
 
-# The exporter will connect to localhost:6381 by default. To change:
+# The exporter will connect to localhost:6831 by default. To change:
 # ENV['OTEL_EXPORTER_JAEGER_AGENT_HOST'] = 'some.other.host'
 # ENV['OTEL_EXPORTER_JAEGER_AGENT_PORT'] = 12345
 


### PR DESCRIPTION
This fixes a simple transposition typo.  The correct port number is on line 51 of the very same file and is also documented here: https://www.jaegertracing.io/docs/1.30/getting-started/#all-in-one