### PR TITLE
use rails request's filtered path as http.target attribute

### DIFF
--- a/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/patches/action_controller/metal.rb
+++ b/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/patches/action_controller/metal.rb
@@ -18,7 +18,7 @@ module OpenTelemetry
 
                 add_rails_route(rack_span, request) if instrumentation_config[:enable_recognize_route]
 
-                rack_span.set_attribute('http.target', request.filtered_path)
+                rack_span.set_attribute('http.target', request.filtered_path) if request.filtered_path != request.fullpath
               end
 
               super(name, request, response)

--- a/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/patches/action_controller/metal.rb
+++ b/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/patches/action_controller/metal.rb
@@ -16,6 +16,9 @@ module OpenTelemetry
               rack_span.name = "#{self.class.name}##{name}" if rack_span.context.valid? && !request.env['action_dispatch.exception']
 
               add_rails_route(rack_span, request) if instrumentation_config[:enable_recognize_route]
+
+              rack_span.set_attribute('http.target', request.filtered_path)
+
               super(name, request, response)
             end
 

--- a/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/patches/action_controller/metal.rb
+++ b/instrumentation/action_pack/lib/opentelemetry/instrumentation/action_pack/patches/action_controller/metal.rb
@@ -13,11 +13,13 @@ module OpenTelemetry
           module Metal
             def dispatch(name, request, response)
               rack_span = OpenTelemetry::Instrumentation::Rack.current_span
-              rack_span.name = "#{self.class.name}##{name}" if rack_span.context.valid? && !request.env['action_dispatch.exception']
+              if rack_span.recording?
+                rack_span.name = "#{self.class.name}##{name}" unless request.env['action_dispatch.exception']
 
-              add_rails_route(rack_span, request) if instrumentation_config[:enable_recognize_route]
+                add_rails_route(rack_span, request) if instrumentation_config[:enable_recognize_route]
 
-              rack_span.set_attribute('http.target', request.filtered_path)
+                rack_span.set_attribute('http.target', request.filtered_path)
+              end
 
               super(name, request, response)
             end

--- a/instrumentation/action_pack/test/opentelemetry/instrumentation/action_pack/patches/action_controller/metal_test.rb
+++ b/instrumentation/action_pack/test/opentelemetry/instrumentation/action_pack/patches/action_controller/metal_test.rb
@@ -99,6 +99,13 @@ describe OpenTelemetry::Instrumentation::ActionPack::Patches::ActionController::
     end
   end
 
+  it 'sets filters `http.target`' do
+    get '/ok?param_to_be_filtered=bar&unfiltered_param=baz', {}
+    _(last_response.body).must_equal 'actually ok'
+    _(last_response.ok?).must_equal true
+    _(span.attributes['http.target']).must_equal '/ok?param_to_be_filtered=[FILTERED]&unfiltered_param=baz'
+  end
+
   describe 'when the application does not have the tracing rack middleware' do
     let(:rails_app) { AppConfig.initialize_app(remove_rack_tracer_middleware: true) }
 

--- a/instrumentation/action_pack/test/test_helpers/app_config.rb
+++ b/instrumentation/action_pack/test/test_helpers/app_config.rb
@@ -23,6 +23,8 @@ module AppConfig
     # Prevent tests from creating log/*.log
     new_app.config.logger = Logger.new(File::NULL)
 
+    new_app.config.filter_parameters = [:param_to_be_filtered]
+
     case Rails.version
     when /^6\.0/
       apply_rails_6_0_configs(new_app)


### PR DESCRIPTION
This change updates Rack spans so that their `http.target` attributes are consistent with [Rails' filter_parameter config](https://guides.rubyonrails.org/configuring.html#config-filter-parameters) when the ActionPack instrumentation is installed.

I have chosen to not make this optional as I feel it is important that the instrumentation follows the instruction set by Rails' configuration.