### PR TITLE
Add protocol env var

### DIFF
--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -43,7 +43,7 @@ module OpenTelemetry
           end
         end
 
-        def initialize(endpoint: config_opt('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', 'OTEL_EXPORTER_OTLP_ENDPOINT', default: 'http://localhost:4318/v1/traces'), # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        def initialize(endpoint: config_opt('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', 'OTEL_EXPORTER_OTLP_ENDPOINT', default: 'http://localhost:4318/v1/traces'), # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity,  Metrics/AbcSize
                        certificate_file: config_opt('OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE', 'OTEL_EXPORTER_OTLP_CERTIFICATE'),
                        ssl_verify_mode: Exporter.ssl_verify_mode,
                        headers: config_opt('OTEL_EXPORTER_OTLP_TRACES_HEADERS', 'OTEL_EXPORTER_OTLP_HEADERS', default: {}),
@@ -52,6 +52,9 @@ module OpenTelemetry
                        metrics_reporter: nil)
           raise ArgumentError, "invalid url for OTLP::Exporter #{endpoint}" if invalid_url?(endpoint)
           raise ArgumentError, "unsupported compression key #{compression}" unless compression.nil? || %w[gzip none].include?(compression)
+
+          @protocol = config_opt('OTEL_EXPORTER_OTLP_TRACES_PROTOCOL', 'OTEL_EXPORTER_OTLP_PROTOCOL', default: 'http/protobuf')
+          raise ArgumentError, "unsupported protocol for OTLP::Exporter #{@protocol}" if @protocol != 'http/protobuf'
 
           @uri = if endpoint == ENV['OTEL_EXPORTER_OTLP_ENDPOINT']
                    URI("#{endpoint}/v1/traces")

--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -61,6 +61,28 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       end
     end
 
+    it 'only allows http/protobuf protocol via environment variable and defaults to http/protobuf' do
+      with_env('OTEL_EXPORTER_OTLP_TRACES_PROTOCOL' => 'grpc') do
+        assert_raises ArgumentError do
+          OpenTelemetry::Exporter::OTLP::Exporter.new
+        end
+      end
+
+      with_env('OTEL_EXPORTER_OTLP_PROTOCOL' => 'http/json') do
+        assert_raises ArgumentError do
+          OpenTelemetry::Exporter::OTLP::Exporter.new
+        end
+      end
+
+      with_env('OTEL_EXPORTER_OTLP_TRACES_PROTOCOL' => 'http/protobuf') do
+        exp = OpenTelemetry::Exporter::OTLP::Exporter.new
+        _(exp.instance_variable_get(:@protocol)).must_equal('http/protobuf')
+      end
+
+      exp = OpenTelemetry::Exporter::OTLP::Exporter.new
+      _(exp.instance_variable_get(:@protocol)).must_equal('http/protobuf')
+    end
+
     it 'sets parameters from the environment' do
       exp = with_env('OTEL_EXPORTER_OTLP_ENDPOINT' => 'https://localhost:1234',
                      'OTEL_EXPORTER_OTLP_CERTIFICATE' => '/foo/bar',


### PR DESCRIPTION
trying this again...

Addresses https://github.com/open-telemetry/opentelemetry-ruby/issues/1088, by adding `'OTEL_EXPORTER_OTLP_TRACES_PROTOCOL', 'OTEL_EXPORTER_OTLP_PROTOCOL'` environment variable support for the otlp exporter (and defaulting+only supporting `http/protobuf`)

I think this is the last remaining open item before we can 1.0 the exporter.

The implementation here is kinda of pointless beside for specification purposes, since afaik our plan of action is to have multiple exporter gems for http/protobuf, grpc, http/json, (should we choose to implement those down the line), and there's really no need to expose `protocol` as an instance variable on the exporter at the moment, but it's possible it could be useful in the future, and it keeps the approach in line with the other configuration options.

At the very least what this does is it will loudly raise if the user tries to use a different protocol, which I think is useful, since we should make sure the user's knows what is/isn't possible as an export option for otlp at the moment.