### PR TITLE
[WIP] Fix authenticity token failure in Rails example

### DIFF
--- a/instrumentation/rails/example/trace_request_demonstration.ru
+++ b/instrumentation/rails/example/trace_request_demonstration.ru
@@ -25,8 +25,8 @@ class TraceRequestApp < Rails::Application
   config.hosts << 'example.org'
   secrets.secret_key_base = 'secret_key_base'
   config.eager_load = false
+  config.action_controller.default_protect_from_forgery = true
   config.logger = Logger.new($stdout)
-  Rails.logger  = config.logger
 end
 
 ENV['OTEL_TRACES_EXPORTER'] = 'console'

--- a/instrumentation/rails/gemfiles/rails_7.0.gemfile
+++ b/instrumentation/rails/gemfiles/rails_7.0.gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gem "opentelemetry-api", path: "../../../api"
 gem "opentelemetry-instrumentation-base", path: "../../base"
-gem "rails", "~> 7.0.0.alpha2"
+gem "rails", "~> 7.0.2"
 
 group :test do
   gem "byebug"


### PR DESCRIPTION
This pull request adds the following setting in the configuration of the example Rails application:

```
config.action_controller.default_protect_from_forgery = true
```

Before doing so, the application would not start and instead exited with the following error:

```
ArgumentError (Before process_action callback :verify_authenticity_token has not been defined):
```

The Rails 7 example Gemfile is also updated to reflect the current release on the Rails v7 line.