### PR TITLE
feat: Validate Using Enums

### DIFF
--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/instrumentation.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/instrumentation.rb
@@ -52,9 +52,9 @@ module OpenTelemetry
         # spans will always be children of the enqueueing spans. This is due to the way
         # ActiveJob immediately executes jobs during the process of "enqueueing" jobs when
         # using the `:inline` adapter.
-        option :propagation_style, default: :link, validate: ->(opt) { %i[link child none].include?(opt) }
+        option :propagation_style, default: :link, validate: %i[link child none]
         option :force_flush, default: false, validate: :boolean
-        option :span_naming, default: :queue, validate: ->(opt) { %i[job_class queue].include?(opt) }
+        option :span_naming, default: :queue, validate: %i[job_class queue]
 
         private
 

--- a/instrumentation/base/lib/opentelemetry/instrumentation/registry.rb
+++ b/instrumentation/base/lib/opentelemetry/instrumentation/registry.rb
@@ -76,7 +76,7 @@ module OpenTelemetry
 
       def install_instrumentation(instrumentation, config)
         if instrumentation.install(config)
-          OpenTelemetry.logger.info "Instrumentation: #{instrumentation.name} was successfully installed"
+          OpenTelemetry.logger.info "Instrumentation: #{instrumentation.name} was successfully installed with the following options #{instrumentation.config}"
         else
           OpenTelemetry.logger.warn "Instrumentation: #{instrumentation.name} failed to install"
         end

--- a/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/instrumentation.rb
+++ b/instrumentation/dalli/lib/opentelemetry/instrumentation/dalli/instrumentation.rb
@@ -20,7 +20,7 @@ module OpenTelemetry
         end
 
         option :peer_service, default: nil, validate: :string
-        option :db_statement, default: :include, validate: ->(opt) { %I[omit obfuscate include].include?(opt) }
+        option :db_statement, default: :include, validate: %I[omit obfuscate include]
 
         private
 

--- a/instrumentation/lmdb/lib/opentelemetry/instrumentation/lmdb/instrumentation.rb
+++ b/instrumentation/lmdb/lib/opentelemetry/instrumentation/lmdb/instrumentation.rb
@@ -21,7 +21,7 @@ module OpenTelemetry
         end
 
         option :peer_service, default: nil, validate: :string
-        option :db_statement, default: :include, validate: ->(opt) { %I[omit include].include?(opt) }
+        option :db_statement, default: :include, validate: %I[omit include]
 
         private
 

--- a/instrumentation/mongo/lib/opentelemetry/instrumentation/mongo/instrumentation.rb
+++ b/instrumentation/mongo/lib/opentelemetry/instrumentation/mongo/instrumentation.rb
@@ -25,7 +25,7 @@ module OpenTelemetry
         end
 
         option :peer_service, default: nil, validate: :string
-        option :db_statement, default: :include, validate: ->(opt) { %I[omit include].include?(opt) }
+        option :db_statement, default: :include, validate: %I[omit include]
 
         private
 

--- a/instrumentation/pg/lib/opentelemetry/instrumentation/pg/instrumentation.rb
+++ b/instrumentation/pg/lib/opentelemetry/instrumentation/pg/instrumentation.rb
@@ -43,7 +43,7 @@ module OpenTelemetry
         option :peer_service, default: nil, validate: :string
         option :enable_sql_obfuscation, default: false, validate: :boolean
         option :enable_statement_attribute, default: true, validate: :boolean
-        option :db_statement, default: :include, validate: ->(opt) { %I[omit include obfuscate].include?(opt) }
+        option :db_statement, default: :include, validate: %I[omit include obfuscate]
 
         private
 

--- a/instrumentation/que/lib/opentelemetry/instrumentation/que/instrumentation.rb
+++ b/instrumentation/que/lib/opentelemetry/instrumentation/que/instrumentation.rb
@@ -45,7 +45,7 @@ module OpenTelemetry
         # `messaging.message_id` attribute, so out-of-band correlation may
         # still be possible depending on your backend system.
         #
-        option :propagation_style, default: :link, validate: ->(opt) { %i[link child none].include?(opt) }
+        option :propagation_style, default: :link, validate: %i[link child none]
         option :trace_poller,      default: false, validate: :boolean
 
         private

--- a/instrumentation/redis/lib/opentelemetry/instrumentation/redis/instrumentation.rb
+++ b/instrumentation/redis/lib/opentelemetry/instrumentation/redis/instrumentation.rb
@@ -21,7 +21,7 @@ module OpenTelemetry
 
         option :peer_service,                 default: nil,   validate: :string
         option :trace_root_spans,             default: true,  validate: :boolean
-        option :db_statement,                 default: :obfuscate, validate: ->(opt) { %I[omit include obfuscate].include?(opt) }
+        option :db_statement,                 default: :obfuscate, validate: %I[omit include obfuscate]
 
         private
 

--- a/instrumentation/resque/lib/opentelemetry/instrumentation/resque/instrumentation.rb
+++ b/instrumentation/resque/lib/opentelemetry/instrumentation/resque/instrumentation.rb
@@ -18,8 +18,8 @@ module OpenTelemetry
           defined?(::Resque)
         end
 
-        option :span_naming,       default: :queue, validate: ->(opt) { %I[job_class queue].include?(opt) }
-        option :propagation_style, default: :link,  validate: ->(opt) { %i[link child none].include?(opt) }
+        option :span_naming,       default: :queue, validate: %I[job_class queue]
+        option :propagation_style, default: :link,  validate: %i[link child none]
 
         private
 

--- a/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/instrumentation.rb
+++ b/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/instrumentation.rb
@@ -27,8 +27,8 @@ module OpenTelemetry
           gem_version >= MINIMUM_VERSION
         end
 
-        option :span_naming,                 default: :queue, validate: ->(opt) { %I[job_class queue].include?(opt) }
-        option :propagation_style,           default: :link,  validate: ->(opt) { %i[link child none].include?(opt) }
+        option :span_naming,                 default: :queue, validate: %I[job_class queue]
+        option :propagation_style,           default: :link,  validate: %i[link child none]
         option :trace_launcher_heartbeat,    default: false, validate: :boolean
         option :trace_poller_enqueue,        default: false, validate: :boolean
         option :trace_poller_wait,           default: false, validate: :boolean


### PR DESCRIPTION
Instrumentation options that use procs for validate do not support being overridden by environment variables,
which makes it difficult for operators to override default settings of many configuration options at runtime.

This change updates several instrumentation options that _should_ be using `enum` validators instead to make it possible to override settings using environment variables.