### PR TITLE
support truncating attributes in links and OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT env var

### DIFF
--- a/common/lib/opentelemetry/common/utilities.rb
+++ b/common/lib/opentelemetry/common/utilities.rb
@@ -69,7 +69,7 @@ module OpenTelemetry
       #
       # @return [String]
       def truncate(string, size)
-        string.size > size ? "#{string[0...size - 3]}..." : string
+        string.is_a?(String) && string.size > size ? "#{string[0...size - 3]}..." : string
       end
 
       def untraced

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History: opentelemetry-sdk
 
+### Unreleased
+
+* FIXED: Env var OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT is used to configure the
+  attribute length limit for attributes in an event
+* ADDED: Attributes in links will be truncated if
+  OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT env var is set
+
 ### v1.0.2 / 2021-12-01
 
 * FIXED: Default span kind 

--- a/sdk/lib/opentelemetry/sdk/internal.rb
+++ b/sdk/lib/opentelemetry/sdk/internal.rb
@@ -44,12 +44,12 @@ module OpenTelemetry
         valid_simple_value?(value) || valid_array_value?(value)
       end
 
-      def valid_attributes?(owner, kind, attrs)
+      def valid_attributes?(owner, kind, attrs, length_limit: nil)
         attrs.nil? || attrs.all? do |k, v|
           if !valid_key?(k)
             OpenTelemetry.handle_error(message: "invalid #{kind} attribute key type #{k.class} on span '#{owner}'")
             false
-          elsif !valid_value?(v)
+          elsif !valid_value?(v) || (!length_limit.nil? && v.is_a?(String) && v.length > length_limit)
             OpenTelemetry.handle_error(message: "invalid #{kind} attribute value type #{v.class} for key '#{k}' on span '#{owner}'")
             false
           else

--- a/sdk/lib/opentelemetry/sdk/internal.rb
+++ b/sdk/lib/opentelemetry/sdk/internal.rb
@@ -20,8 +20,8 @@ module OpenTelemetry
         key.instance_of?(String)
       end
 
-      def valid_simple_value?(value)
-        value.instance_of?(String) || value == false || value == true || value.is_a?(Numeric)
+      def valid_simple_value?(value, length_limit = nil)
+        (value.instance_of?(String) && (length_limit.nil? || value.length <= length_limit)) || value == false || value == true || value.is_a?(Numeric)
       end
 
       def valid_array_value?(value)
@@ -40,16 +40,16 @@ module OpenTelemetry
         end
       end
 
-      def valid_value?(value)
-        valid_simple_value?(value) || valid_array_value?(value)
+      def valid_value?(value, length_limit = nil)
+        valid_simple_value?(value, length_limit) || valid_array_value?(value)
       end
 
-      def valid_attributes?(owner, kind, attrs, length_limit: nil)
+      def valid_attributes?(owner, kind, attrs, length_limit = nil)
         attrs.nil? || attrs.all? do |k, v|
           if !valid_key?(k)
             OpenTelemetry.handle_error(message: "invalid #{kind} attribute key type #{k.class} on span '#{owner}'")
             false
-          elsif !valid_value?(v) || (!length_limit.nil? && v.is_a?(String) && v.length > length_limit)
+          elsif !valid_value?(v, length_limit)
             OpenTelemetry.handle_error(message: "invalid #{kind} attribute value type #{v.class} for key '#{k}' on span '#{owner}'")
             false
           else

--- a/sdk/lib/opentelemetry/sdk/trace/span_limits.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span_limits.rb
@@ -12,8 +12,11 @@ module OpenTelemetry
         # The global default max number of attributes per {Span}.
         attr_reader :attribute_count_limit
 
-        # The global default max length of attribute value per {Span}.
+        # The global default max length of attribute value per {Span}, {Event} and {Link}.
         attr_reader :attribute_length_limit
+
+        # The max length of attribute value per {Span}.
+        attr_reader :span_attribute_length_limit
 
         # The global default max number of {OpenTelemetry::SDK::Trace::Event}s per {Span}.
         attr_reader :event_count_limit
@@ -32,8 +35,9 @@ module OpenTelemetry
         # @return [SpanLimits] with the desired values.
         # @raise [ArgumentError] if any of the max numbers are not positive.
         def initialize(attribute_count_limit: Integer(ENV.fetch('OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT', 128)), # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-                       attribute_length_limit: ENV.fetch('OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT',
+                       attribute_length_limit: ENV.fetch('OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT',
                                                          ENV['OTEL_RUBY_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT']),
+                       span_attribute_length_limit: ENV['OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT'],
                        event_count_limit: Integer(ENV.fetch('OTEL_SPAN_EVENT_COUNT_LIMIT', 128)),
                        link_count_limit: Integer(ENV.fetch('OTEL_SPAN_LINK_COUNT_LIMIT', 128)),
                        event_attribute_count_limit: Integer(ENV.fetch('OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT', 128)),
@@ -47,6 +51,7 @@ module OpenTelemetry
 
           @attribute_count_limit = attribute_count_limit
           @attribute_length_limit = attribute_length_limit.nil? ? nil : Integer(attribute_length_limit)
+          @span_attribute_length_limit = span_attribute_length_limit.nil? ? @attribute_length_limit : Integer(span_attribute_length_limit)
           @event_count_limit = event_count_limit
           @link_count_limit = link_count_limit
           @event_attribute_count_limit = event_attribute_count_limit

--- a/sdk/test/opentelemetry/sdk/trace/span_limits_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/span_limits_test.rb
@@ -53,7 +53,7 @@ describe OpenTelemetry::SDK::Trace::SpanLimits do
         _(config.attribute_count_limit).must_equal 1
         _(config.event_count_limit).must_equal 2
         _(config.link_count_limit).must_equal 3
-        _(config.attribute_length_limit).must_equal nil
+        assert_nil config.attribute_length_limit
         _(config.span_attribute_length_limit).must_equal 32
         _(config.event_attribute_count_limit).must_equal 5
         _(config.link_attribute_count_limit).must_equal 6

--- a/sdk/test/opentelemetry/sdk/trace/span_limits_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/span_limits_test.rb
@@ -21,6 +21,28 @@ describe OpenTelemetry::SDK::Trace::SpanLimits do
 
     it 'reflects environment variables' do
       with_env('OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT' => '1',
+               'OTEL_ATTRIBUTE_COUNT_LIMIT' => '1',
+               'OTEL_SPAN_EVENT_COUNT_LIMIT' => '2',
+               'OTEL_SPAN_LINK_COUNT_LIMIT' => '3',
+               'OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '33',
+               'OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '32',
+               'OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT' => '5',
+               'OTEL_LINK_ATTRIBUTE_COUNT_LIMIT' => '6',
+               'OTEL_TRACES_SAMPLER' => 'always_on') do
+        config = subject.new
+        _(config.attribute_count_limit).must_equal 1
+        _(config.event_count_limit).must_equal 2
+        _(config.link_count_limit).must_equal 3
+        _(config.attribute_length_limit).must_equal 33
+        _(config.span_attribute_length_limit).must_equal 32
+        _(config.event_attribute_count_limit).must_equal 5
+        _(config.link_attribute_count_limit).must_equal 6
+      end
+    end
+
+    it 'attribute length limit is default if only span length limit is set' do
+      with_env('OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT' => '1',
+               'OTEL_ATTRIBUTE_COUNT_LIMIT' => '1',
                'OTEL_SPAN_EVENT_COUNT_LIMIT' => '2',
                'OTEL_SPAN_LINK_COUNT_LIMIT' => '3',
                'OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '32',
@@ -31,7 +53,28 @@ describe OpenTelemetry::SDK::Trace::SpanLimits do
         _(config.attribute_count_limit).must_equal 1
         _(config.event_count_limit).must_equal 2
         _(config.link_count_limit).must_equal 3
-        _(config.attribute_length_limit).must_equal 32
+        _(config.attribute_length_limit).must_equal nil
+        _(config.span_attribute_length_limit).must_equal 32
+        _(config.event_attribute_count_limit).must_equal 5
+        _(config.link_attribute_count_limit).must_equal 6
+      end
+    end
+
+    it 'span attribute value length limit uses global if not set' do
+      with_env('OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT' => '1',
+               'OTEL_ATTRIBUTE_COUNT_LIMIT' => '1',
+               'OTEL_SPAN_EVENT_COUNT_LIMIT' => '2',
+               'OTEL_SPAN_LINK_COUNT_LIMIT' => '3',
+               'OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '33',
+               'OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT' => '5',
+               'OTEL_LINK_ATTRIBUTE_COUNT_LIMIT' => '6',
+               'OTEL_TRACES_SAMPLER' => 'always_on') do
+        config = subject.new
+        _(config.attribute_count_limit).must_equal 1
+        _(config.event_count_limit).must_equal 2
+        _(config.link_count_limit).must_equal 3
+        _(config.attribute_length_limit).must_equal 33
+        _(config.span_attribute_length_limit).must_equal 33
         _(config.event_attribute_count_limit).must_equal 5
         _(config.link_attribute_count_limit).must_equal 6
       end
@@ -58,22 +101,25 @@ describe OpenTelemetry::SDK::Trace::SpanLimits do
       with_env('OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT' => '1',
                'OTEL_SPAN_EVENT_COUNT_LIMIT' => '2',
                'OTEL_SPAN_LINK_COUNT_LIMIT' => '3',
-               'OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '4',
-               'OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT' => '5',
-               'OTEL_LINK_ATTRIBUTE_COUNT_LIMIT' => '6',
+               'OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '4',
+               'OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '5',
+               'OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT' => '6',
+               'OTEL_LINK_ATTRIBUTE_COUNT_LIMIT' => '7',
                'OTEL_TRACES_SAMPLER' => 'always_on') do
         config = subject.new(attribute_count_limit: 10,
                              event_count_limit: 11,
                              link_count_limit: 12,
                              event_attribute_count_limit: 13,
                              link_attribute_count_limit: 14,
-                             attribute_length_limit: 32)
+                             attribute_length_limit: 32,
+                             span_attribute_length_limit: 33)
         _(config.attribute_count_limit).must_equal 10
         _(config.event_count_limit).must_equal 11
         _(config.link_count_limit).must_equal 12
         _(config.event_attribute_count_limit).must_equal 13
         _(config.link_attribute_count_limit).must_equal 14
         _(config.attribute_length_limit).must_equal 32
+        _(config.span_attribute_length_limit).must_equal 33
       end
     end
   end

--- a/sdk/test/opentelemetry/sdk/trace/span_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/span_test.rb
@@ -488,6 +488,12 @@ describe OpenTelemetry::SDK::Trace::Span do
       _(span.links.size).must_equal(1)
     end
 
+    it 'truncate link attributes' do
+      links = [OpenTelemetry::Trace::Link.new(context, { 'foo' => 'oldbaroldbaroldbaroldbaroldbaroldbar' })]
+      span = Span.new(context, Context.empty, OpenTelemetry::Trace::Span::INVALID, 'name', SpanKind::INTERNAL, nil, span_limits, [], nil, links, Time.now, nil, nil)
+      _(span.links.first.attributes['foo']).must_equal('oldbaroldbaroldbaroldbaroldba...')
+    end
+
     it 'honours an explicit timestamp' do
       timestamp = Time.now
       test_span = Span.new(context, Context.empty, OpenTelemetry::Trace::Span::INVALID, 'child span', SpanKind::INTERNAL, nil, span_limits, [], nil, [], timestamp, nil, nil)

--- a/sdk/test/opentelemetry/sdk/trace/tracer_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/tracer_test.rb
@@ -138,6 +138,15 @@ describe OpenTelemetry::SDK::Trace::Tracer do
       link = OpenTelemetry::Trace::Link.new(OpenTelemetry::Trace::SpanContext.new, '1' => 1, '2' => 2)
       span = tracer.start_root_span('root', links: [link])
       _(span.links.first.attributes.size).must_equal(1)
+      _(span.links.first.attributes['2']).must_equal(2)
+    end
+
+    it 'trims link attribute length' do
+      tracer_provider.span_limits = SpanLimits.new(link_attribute_count_limit: 1, attribute_length_limit: 32)
+      link = OpenTelemetry::Trace::Link.new(OpenTelemetry::Trace::SpanContext.new, '1' => 1, '2' => 'oldbaroldbaroldbaroldbaroldbaroldbar')
+      span = tracer.start_root_span('root', links: [link])
+      _(span.links.first.attributes.size).must_equal(1)
+      _(span.links.first.attributes['2']).must_equal('oldbaroldbaroldbaroldbaroldba...')
     end
 
     it 'trims links' do


### PR DESCRIPTION
This is a draft because the test in `span_test.rb` fails and I've given up on figuring out why and hoping someone sees what is wrong :). The testin `tracer_test.rb` works and basically does the same thing, but I felt I shouldn't just drop the other test in case it is finding an actual issue. Hopefully it is instead me just missing something.