### PR TITLE
attribute length limit: only truncate strings and strings in arrays

### DIFF
--- a/common/CHANGELOG.md
+++ b/common/CHANGELOG.md
@@ -1,4 +1,6 @@
+### Unreleased
 
+* FIXED: Check that a variable is a string before truncating
 
 ### v0.19.3 / 2021-12-01
 

--- a/common/lib/opentelemetry/common/utilities.rb
+++ b/common/lib/opentelemetry/common/utilities.rb
@@ -72,6 +72,17 @@ module OpenTelemetry
         string.is_a?(String) && string.size > size ? "#{string[0...size - 3]}..." : string
       end
 
+      def truncate_attribute_value(value, limit)
+        case value
+        when Array
+          value.map { |x| truncate(x, limit) }
+        when String
+          truncate(value, limit)
+        else
+          value
+        end
+      end
+
       def untraced
         OpenTelemetry::Trace.with_span(OpenTelemetry::Trace.non_recording_span(OpenTelemetry::Trace::SpanContext.new)) { yield }
       end

--- a/common/lib/opentelemetry/common/utilities.rb
+++ b/common/lib/opentelemetry/common/utilities.rb
@@ -69,13 +69,13 @@ module OpenTelemetry
       #
       # @return [String]
       def truncate(string, size)
-        string.is_a?(String) && string.size > size ? "#{string[0...size - 3]}..." : string
+        string.size > size ? "#{string[0...size - 3]}..." : string
       end
 
       def truncate_attribute_value(value, limit)
         case value
         when Array
-          value.map { |x| truncate(x, limit) }
+          value.map { |x| truncate_attribute_value(x, limit) }
         when String
           truncate(value, limit)
         else

--- a/common/lib/opentelemetry/common/utilities.rb
+++ b/common/lib/opentelemetry/common/utilities.rb
@@ -69,7 +69,7 @@ module OpenTelemetry
       #
       # @return [String]
       def truncate(string, size)
-        string.size > size ? "#{string[0...size - 3]}..." : string
+        string.is_a?(String) && string.size > size ? "#{string[0...size - 3]}..." : string
       end
 
       def untraced

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History: opentelemetry-sdk
 
+### Unreleased
+
+* ADDED: Truncate the strings in an array attribute value if length_limit is configured
+
 ### v1.0.2 / 2021-12-01
 
 * FIXED: Default span kind 

--- a/sdk/lib/opentelemetry/sdk/trace/span.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span.rb
@@ -347,11 +347,22 @@ module OpenTelemetry
           nil
         end
 
+        def truncate(value, limit)
+          case value
+              when Array
+                value.map { |x| OpenTelemetry::Common::Utilities.truncate(x, limit) }
+              when String
+                OpenTelemetry::Common::Utilities.truncate(value, limit)
+              else
+                value
+          end
+        end
+
         def truncate_attribute_values(attrs)
           return EMPTY_ATTRIBUTES if attrs.nil?
 
           attribute_length_limit = @span_limits.attribute_length_limit
-          attrs.each { |key, value| attrs[key] = OpenTelemetry::Common::Utilities.truncate(value, attribute_length_limit) } if attribute_length_limit
+          attrs.each { |key, value| attrs[key] = truncate(value, attribute_length_limit) } if attribute_length_limit
           attrs
         end
 

--- a/sdk/lib/opentelemetry/sdk/trace/span.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span.rb
@@ -353,9 +353,7 @@ module OpenTelemetry
           attribute_length_limit = @span_limits.attribute_length_limit
           return attrs if attribute_length_limit.nil?
 
-          attrs.each do |key, value|
-            attrs[key] = OpenTelemetry::Common::Utilities.truncate_attribute_value(value, attribute_length_limit) if value.is_a?(String)
-          end
+          attrs.transform_values! { |value| OpenTelemetry::Common::Utilities.truncate_attribute_value(value, attribute_length_limit) }
           attrs
         end
 

--- a/sdk/lib/opentelemetry/sdk/trace/span.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span.rb
@@ -351,7 +351,11 @@ module OpenTelemetry
           return EMPTY_ATTRIBUTES if attrs.nil?
 
           attribute_length_limit = @span_limits.attribute_length_limit
-          attrs.each { |key, value| attrs[key] = OpenTelemetry::Common::Utilities.truncate_attribute_value(value, attribute_length_limit) if attribute_length_limit && value.is_a?(String) }
+          return attrs if attribute_length_limit.nil?
+
+          attrs.each do |key, value|
+            attrs[key] = OpenTelemetry::Common::Utilities.truncate_attribute_value(value, attribute_length_limit) if value.is_a?(String)
+          end
           attrs
         end
 

--- a/sdk/lib/opentelemetry/sdk/trace/span.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span.rb
@@ -351,7 +351,7 @@ module OpenTelemetry
           return EMPTY_ATTRIBUTES if attrs.nil?
 
           attribute_length_limit = @span_limits.attribute_length_limit
-          attrs.each { |key, value| attrs[key] = OpenTelemetry::Common::Utilities.truncate_attribute_value(value, attribute_length_limit) } if attribute_length_limit
+          attrs.each { |key, value| attrs[key] = OpenTelemetry::Common::Utilities.truncate_attribute_value(value, attribute_length_limit) if attribute_length_limit && value.is_a?(String) }
           attrs
         end
 

--- a/sdk/lib/opentelemetry/sdk/trace/span.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span.rb
@@ -347,22 +347,11 @@ module OpenTelemetry
           nil
         end
 
-        def truncate(value, limit)
-          case value
-              when Array
-                value.map { |x| OpenTelemetry::Common::Utilities.truncate(x, limit) }
-              when String
-                OpenTelemetry::Common::Utilities.truncate(value, limit)
-              else
-                value
-          end
-        end
-
         def truncate_attribute_values(attrs)
           return EMPTY_ATTRIBUTES if attrs.nil?
 
           attribute_length_limit = @span_limits.attribute_length_limit
-          attrs.each { |key, value| attrs[key] = truncate(value, attribute_length_limit) } if attribute_length_limit
+          attrs.each { |key, value| attrs[key] = OpenTelemetry::Common::Utilities.truncate_attribute_value(value, attribute_length_limit) } if attribute_length_limit
           attrs
         end
 

--- a/sdk/test/opentelemetry/sdk/trace/span_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/span_test.rb
@@ -102,6 +102,11 @@ describe OpenTelemetry::SDK::Trace::Span do
       _(span.attributes).must_equal('foo' => [1, 2, 3])
     end
 
+    it 'accepts floats even if attribute length limit is configured' do
+      span.set_attribute('foo', 1.23)
+      _(span.attributes).must_equal('foo' => 1.23)
+    end
+
     it 'reports an error for an invalid value' do
       span.set_attribute('foo', :bar)
       span.finish

--- a/sdk/test/opentelemetry/sdk/trace/span_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/span_test.rb
@@ -80,6 +80,11 @@ describe OpenTelemetry::SDK::Trace::Span do
       _(span.attributes).must_equal('foo' => 'oldbaroldbaroldbaroldbaroldba...')
     end
 
+    it 'truncates elements of attribute value array based if configured' do
+      span.set_attribute('foo', ['not too long', 'oldbaroldbaroldbaroldbaroldbaroldbar'])
+      _(span.attributes).must_equal('foo' => ['not too long', 'oldbaroldbaroldbaroldbaroldba...'])
+    end
+
     it 'does not set an attribute if span is ended' do
       span.finish
       span.set_attribute('no', 'set')


### PR DESCRIPTION
This set of patches both adds support for truncating strings in arrays but also tests that a variable is a string before checking its size and truncating. This fixes a bug that an attribute value of type float would crash if `attribute_length_limit` were configured.