### PR TITLE
fix warning about Struct initialization in Ruby 3.2+

### DIFF
--- a/sdk/.rubocop.yml
+++ b/sdk/.rubocop.yml
@@ -16,3 +16,5 @@ Naming/FileName:
     - "lib/opentelemetry-sdk.rb"
 Style/ModuleFunction:
   Enabled: false
+Style/BracesAroundHashParameters:
+  Enabled: false

--- a/sdk/test/opentelemetry/sdk/trace/export/console_span_exporter_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/export/console_span_exporter_test.rb
@@ -10,8 +10,8 @@ describe OpenTelemetry::SDK::Trace::Export::ConsoleSpanExporter do
   export = OpenTelemetry::SDK::Trace::Export
 
   let(:captured_stdout) { StringIO.new }
-  let(:span_data1) { OpenTelemetry::SDK::Trace::SpanData.new(name: 'name1') }
-  let(:span_data2) { OpenTelemetry::SDK::Trace::SpanData.new(name: 'name2') }
+  let(:span_data1) { OpenTelemetry::SDK::Trace::SpanData.new({ name: 'name1' }) }
+  let(:span_data2) { OpenTelemetry::SDK::Trace::SpanData.new({ name: 'name2' }) }
   let(:spans)      { [span_data1, span_data2] }
   let(:exporter)   { export::ConsoleSpanExporter.new }
 

--- a/sdk/test/opentelemetry/sdk/trace/export/in_memory_span_exporter_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/export/in_memory_span_exporter_test.rb
@@ -9,8 +9,8 @@ require 'test_helper'
 describe OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter do
   export = OpenTelemetry::SDK::Trace::Export
 
-  let(:span_data1)   { OpenTelemetry::SDK::Trace::SpanData.new(name: 'name1') }
-  let(:span_data2)   { OpenTelemetry::SDK::Trace::SpanData.new(name: 'name2') }
+  let(:span_data1)   { OpenTelemetry::SDK::Trace::SpanData.new({ name: 'name1' }) }
+  let(:span_data2)   { OpenTelemetry::SDK::Trace::SpanData.new({ name: 'name2' }) }
 
   let(:exporter) { OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new }
 

--- a/sdk/test/opentelemetry/sdk/trace/export/span_exporter_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/export/span_exporter_test.rb
@@ -9,8 +9,8 @@ require 'test_helper'
 describe OpenTelemetry::SDK::Trace::Export::SpanExporter do
   export = OpenTelemetry::SDK::Trace::Export
 
-  let(:span_data1) { OpenTelemetry::SDK::Trace::SpanData.new(name: 'name1') }
-  let(:span_data2) { OpenTelemetry::SDK::Trace::SpanData.new(name: 'name2') }
+  let(:span_data1) { OpenTelemetry::SDK::Trace::SpanData.new({ name: 'name1' }) }
+  let(:span_data2) { OpenTelemetry::SDK::Trace::SpanData.new({ name: 'name2' }) }
   let(:spans)      { [span_data1, span_data2] }
   let(:exporter)   { export::SpanExporter.new }
 


### PR DESCRIPTION
I was seeing a lot of warnings like:

```
opentelemetry-ruby/sdk/test/opentelemetry/sdk/trace/export/console_span_exporter_test.rb:14: warning: Passing only keyword arguments to Struct#initialize will behave differently from Ruby 3.2. Please use a Hash literal like .new({k: v}) instead of .new(k: v).
```

on Ruby 3.1 and this patch clears them up.