### PR TITLE
fix: handle missing job metadata

### DIFF
--- a/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/patches/base.rb
+++ b/instrumentation/active_job/lib/opentelemetry/instrumentation/active_job/patches/base.rb
@@ -27,7 +27,7 @@ module OpenTelemetry
           end
 
           def deserialize(job_data)
-            self.metadata = (deserialize_arguments(job_data['metadata']) || []).to_h
+            self.metadata = deserialize_arguments(job_data['metadata'] || []).to_h
             super
           end
         end

--- a/instrumentation/active_job/test/instrumentation/active_job/patches/base_test.rb
+++ b/instrumentation/active_job/test/instrumentation/active_job/patches/base_test.rb
@@ -30,5 +30,22 @@ describe OpenTelemetry::Instrumentation::ActiveJob::Patches::Base do
       job.deserialize(serialized_job)
       _(job.metadata).must_equal('foo' => 'bar')
     end
+
+    it 'must handle empty metadata' do
+      job = TestJob.new
+      serialized_job = job.serialize
+      job = TestJob.new
+      job.deserialize(serialized_job)
+      _(job.metadata).must_equal({})
+    end
+
+    it 'must handle missing metadata' do
+      job = TestJob.new
+      serialized_job = job.serialize
+      serialized_job.delete('metadata')
+      job = TestJob.new
+      job.deserialize(serialized_job)
+      _(job.metadata).must_equal({})
+    end
   end
 end


### PR DESCRIPTION
When jobs are enqueued before opentelemetry is enabled, they don't have `metadata` added to the serialized form. If the worker already has opentelemetry enabled, it assumes `metadata` is present and attempts to deserialize it, causing a crash:

```
ActiveJob::DeserializationError:
Error while trying to deserialize arguments: undefined method `map' for nil:NilClass
.../activejob-6.0.4.1/lib/active_job/arguments.rb:42:in `deserialize'
.../activejob-6.0.4.1/lib/active_job/core.rb:170:in `deserialize_arguments'
.../opentelemetry-instrumentation-active_job-0.1.5/lib/opentelemetry/instrumentation/active_job/patches/base.rb:30:in `deserialize'
.../activejob-6.0.4.1/lib/active_job/core.rb:52:in `deserialize'
.../activejob-6.0.4.1/lib/active_job/execution.rb:24:in `block in execute'
.../activesupport-6.0.4.1/lib/active_support/callbacks.rb:112:in `block in run_callbacks'
.../activejob-6.0.4.1/lib/active_job/railtie.rb:43:in `block (4 levels) in <class:Railtie>'
.../activesupport-6.0.4.1/lib/active_support/execution_wrapper.rb:88:in `wrap'
.../activesupport-6.0.4.1/lib/active_support/reloader.rb:72:in `block in wrap'
.../activesupport-6.0.4.1/lib/active_support/execution_wrapper.rb:88:in `wrap'
.../activesupport-6.0.4.1/lib/active_support/reloader.rb:71:in `wrap'
.../activejob-6.0.4.1/lib/active_job/railtie.rb:42:in `block (3 levels) in <class:Railtie>'
.../activesupport-6.0.4.1/lib/active_support/callbacks.rb:121:in `instance_exec'
.../activesupport-6.0.4.1/lib/active_support/callbacks.rb:121:in `block in run_callbacks'
.../activesupport-6.0.4.1/lib/active_support/callbacks.rb:139:in `run_callbacks'
.../activejob-6.0.4.1/lib/active_job/execution.rb:23:in `execute'
```

This happened to us due to some misconfiguration, where opentelemetry was enabled on the workers but disabled on the web servers. But this might also happen during a rolling restart if new workers with opentelemetry enabled come up before new web servers. Either way, we can handle this according to the [error handling principles](https://opentelemetry.io/docs/reference/specification/error-handling/#basic-error-handling-principles) by substituting the default value *before* deserializing.