### PR TITLE
fix: Allow HTTP method to be passed as string

### DIFF
--- a/instrumentation/excon/lib/opentelemetry/instrumentation/excon/middlewares/tracer_middleware.rb
+++ b/instrumentation/excon/lib/opentelemetry/instrumentation/excon/middlewares/tracer_middleware.rb
@@ -26,6 +26,7 @@ module OpenTelemetry
             begin
               unless datum.key?(:otel_span)
                 http_method = HTTP_METHODS_SYMBOL_TO_STRING[datum[:method]]
+                http_method = datum[:method] if http_method.nil?
                 attributes = span_creation_attributes(datum, http_method)
                 tracer.start_span(
                   "HTTP #{http_method}",

--- a/instrumentation/excon/test/opentelemetry/instrumentation/excon/instrumentation_test.rb
+++ b/instrumentation/excon/test/opentelemetry/instrumentation/excon/instrumentation_test.rb
@@ -143,5 +143,23 @@ describe OpenTelemetry::Instrumentation::Excon::Instrumentation do
 
       _(span.attributes['peer.service']).must_equal 'example:custom'
     end
+
+
+    it 'accepts string method' do
+      ::Excon.new('http://example.com').request(:path => '/success', :method => 'GET')
+
+      _(exporter.finished_spans.size).must_equal 1
+      _(span.name).must_equal 'HTTP GET'
+      _(span.attributes['http.method']).must_equal 'GET'
+      _(span.attributes['http.status_code']).must_equal 200
+      _(span.attributes['http.scheme']).must_equal 'http'
+      _(span.attributes['http.host']).must_equal 'example.com'
+      _(span.attributes['http.target']).must_equal '/success'
+      assert_requested(
+        :get,
+        'http://example.com/success',
+        headers: { 'Traceparent' => "00-#{span.hex_trace_id}-#{span.hex_span_id}-01" }
+      )
+    end
   end
 end


### PR DESCRIPTION
According to [Excon docs](https://www.rubydoc.info/gems/excon/0.79.0) is possible to set the HTTP Method with a string but when using excon instrumentation this fails with the following error `[2022-03-22T17:31:14.333447 #85108] ERROR -- : OpenTelemetry error: invalid span attribute value type NilClass for key 'http.method' on span 'HTTP '`

On this PR we add a test case for the described scenario and a fix to use the string if no symbol was provided.

Fixes #1158