### PR TITLE
refactor: Extract Instrumentation Registry Gem

### DIFF
--- a/registry/.rubocop.yml
+++ b/registry/.rubocop.yml
@@ -1,0 +1,5 @@
+inherit_from: ../.rubocop-examples.yml
+
+Naming/FileName:
+  Exclude:
+    - "lib/opentelemetry-instrumentation-registry.rb"

--- a/registry/.yardopts
+++ b/registry/.yardopts
@@ -1,0 +1,9 @@
+--no-private
+--title=OpenTelemetry Registry Instrumentation
+--markup=markdown
+--main=README.md
+./lib/opentelemetry/instrumentation/**/*.rb
+./lib/opentelemetry/instrumentation.rb
+-
+README.md
+CHANGELOG.md

--- a/registry/Appraisals
+++ b/registry/Appraisals
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+## TODO: Include the supported version to be tested here.
+## Example:
+# appraise 'rack-2.1' do
+#   gem 'rack', '~> 2.1.2'
+# end
+
+# appraise 'rack-2.0' do
+#   gem 'rack', '2.0.8'
+# end
+

--- a/registry/CHANGELOG.md
+++ b/registry/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Release History: opentelemetry-instrumentation-registry

--- a/registry/Gemfile
+++ b/registry/Gemfile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source 'https://rubygems.org'
+
+gemspec
+
+gem 'opentelemetry-api', path: '../api'

--- a/registry/LICENSE
+++ b/registry/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright The OpenTelemetry Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/registry/README.md
+++ b/registry/README.md
@@ -1,0 +1,52 @@
+# OpenTelemetry Registry Instrumentation
+
+Todo: Add a description.
+
+## How do I get started?
+
+Install the gem using:
+
+```
+gem install opentelemetry-instrumentation-registry
+```
+
+Or, if you use [bundler][bundler-home], include `opentelemetry-instrumentation-registry` in your `Gemfile`.
+
+## Usage
+
+To use the instrumentation, call `use` with the name of the instrumentation:
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::Registry'
+end
+```
+
+Alternatively, you can also call `use_all` to install all the available instrumentation.
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use_all
+end
+```
+
+## Examples
+
+Example usage can be seen in the `./example/trace_demonstration.rb` file [here](https://github.com/open-telemetry/opentelemetry-ruby/blob/main/instrumentation/registry/example/trace_demonstration.rb)
+
+## How can I get involved?
+
+The `opentelemetry-instrumentation-registry` gem source is [on github][repo-github], along with related gems including `opentelemetry-api` and `opentelemetry-sdk`.
+
+The OpenTelemetry Ruby gems are maintained by the OpenTelemetry-Ruby special interest group (SIG). You can get involved by joining us in [GitHub Discussions][discussions-url] or attending our weekly meeting. See the [meeting calendar][community-meetings] for dates and times. For more information on this and other language SIGs, see the OpenTelemetry [community page][ruby-sig].
+
+## License
+
+The `opentelemetry-instrumentation-registry` gem is distributed under the Apache 2.0 license. See [LICENSE][license-github] for more information.
+
+[bundler-home]: https://bundler.io
+[repo-github]: https://github.com/open-telemetry/opentelemetry-ruby
+[license-github]: https://github.com/open-telemetry/opentelemetry-ruby/blob/main/LICENSE
+[ruby-sig]: https://github.com/open-telemetry/community#ruby-sig
+[community-meetings]: https://github.com/open-telemetry/community#community-meetings
+[discussions-url]: https://github.com/open-telemetry/opentelemetry-ruby/discussions

--- a/registry/Rakefile
+++ b/registry/Rakefile
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+require 'yard'
+require 'rubocop/rake_task'
+
+RuboCop::RakeTask.new
+
+Rake::TestTask.new :test do |t|
+  t.libs << 'test'
+  t.libs << 'lib'
+  t.test_files = FileList['test/**/*_test.rb']
+end
+
+YARD::Rake::YardocTask.new do |t|
+  t.stats_options = ['--list-undoc']
+end
+
+if RUBY_ENGINE == 'truffleruby'
+  task default: %i[test]
+else
+  task default: %i[test rubocop yard]
+end

--- a/registry/lib/opentelemetry-registry.rb
+++ b/registry/lib/opentelemetry-registry.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry'
+require_relative './opentelemetry/instrumentation'

--- a/registry/lib/opentelemetry/instrumentation.rb
+++ b/registry/lib/opentelemetry/instrumentation.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# OpenTelemetry is an open source observability framework, providing a
+# general-purpose API, SDK, and related tools required for the instrumentation
+# of cloud-native software, frameworks, and libraries.
+#
+# The OpenTelemetry module provides global accessors for telemetry objects.
+# See the documentation for the `opentelemetry-api` gem for details.
+require_relative './instrumentation/registry'
+
+module OpenTelemetry
+  # Instrumentation should be able to handle the case when the library is not installed on a user's system.
+  module Instrumentation
+    extend self
+    # @return [Registry] registry containing all known
+    #  instrumentation
+    def registry
+      @registry ||= Registry.new
+    end
+  end
+end

--- a/registry/lib/opentelemetry/instrumentation/registry.rb
+++ b/registry/lib/opentelemetry/instrumentation/registry.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Instrumentation
+    # The instrumentation Registry contains information about instrumentation
+    # available and facilitates discovery, installation and
+    # configuration. This functionality is primarily useful for SDK
+    # implementors.
+    class Registry
+      def initialize
+        @lock = Mutex.new
+        @instrumentation = []
+      end
+
+      # @api private
+      def register(instrumentation)
+        @lock.synchronize do
+          @instrumentation << instrumentation
+        end
+      end
+
+      # Lookup an instrumentation definition by name. Returns nil if +instrumentation_name+
+      # is not found.
+      #
+      # @param [String] instrumentation_name A stringified class name for an instrumentation
+      # @return [Instrumentation]
+      def lookup(instrumentation_name)
+        @lock.synchronize do
+          find_instrumentation(instrumentation_name)
+        end
+      end
+
+      # Install the specified instrumentation with optionally specified configuration.
+      #
+      # @param [Array<String>] instrumentation_names An array of instrumentation names to
+      #   install
+      # @param [optional Hash<String, Hash>] instrumentation_config_map A map of
+      #   instrumentation_name to config. This argument is optional and config can be
+      #   passed for as many or as few instrumentations as desired.
+      def install(instrumentation_names, instrumentation_config_map = {})
+        @lock.synchronize do
+          instrumentation_names.each do |instrumentation_name|
+            instrumentation = find_instrumentation(instrumentation_name)
+            if instrumentation.nil?
+              OpenTelemetry.logger.warn "Could not install #{instrumentation_name} because it was not found"
+            else
+              install_instrumentation(instrumentation, instrumentation_config_map[instrumentation.name])
+            end
+          end
+        end
+      end
+
+      # Install all instrumentation available and installable in this process.
+      #
+      # @param [optional Hash<String, Hash>] instrumentation_config_map A map of
+      #   instrumentation_name to config. This argument is optional and config can be
+      #   passed for as many or as few instrumentations as desired.
+      def install_all(instrumentation_config_map = {})
+        @lock.synchronize do
+          @instrumentation.map(&:instance).each do |instrumentation|
+            install_instrumentation(instrumentation, instrumentation_config_map[instrumentation.name])
+          end
+        end
+      end
+
+      private
+
+      def find_instrumentation(instrumentation_name)
+        @instrumentation.detect { |a| a.instance.name == instrumentation_name }
+                   &.instance
+      end
+
+      def install_instrumentation(instrumentation, config)
+        if instrumentation.install(config)
+          OpenTelemetry.logger.info "Instrumentation: #{instrumentation.name} was successfully installed with the following options #{instrumentation.config}"
+        else
+          OpenTelemetry.logger.warn "Instrumentation: #{instrumentation.name} failed to install"
+        end
+      rescue => e # rubocop:disable Style/RescueStandardError
+        OpenTelemetry.handle_error(exception: e, message: "Instrumentation: #{instrumentation.name} unhandled exception during install: #{e.backtrace}")
+      end
+    end
+  end
+end
+
+require_relative './registry/version'

--- a/registry/lib/opentelemetry/instrumentation/registry/version.rb
+++ b/registry/lib/opentelemetry/instrumentation/registry/version.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Instrumentation
+    class Registry
+      VERSION = '0.0.0'
+    end
+  end
+end

--- a/registry/opentelemetry-registry.gemspec
+++ b/registry/opentelemetry-registry.gemspec
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'opentelemetry/instrumentation/registry/version'
+
+Gem::Specification.new do |spec|
+  spec.name        = 'opentelemetry-registry'
+  spec.version     = OpenTelemetry::Instrumentation::Registry::VERSION
+  spec.authors     = ['OpenTelemetry Authors']
+  spec.email       = ['cncf-opentelemetry-contributors@lists.cncf.io']
+
+  spec.summary     = 'Registry for the OpenTelemetry Instrumentation Libraries'
+  spec.description = 'Registry for the OpenTelemetry Instrumentation Libraries'
+  spec.homepage    = 'https://github.com/open-telemetry/opentelemetry-ruby'
+  spec.license     = 'Apache-2.0'
+
+  spec.files = ::Dir.glob('lib/**/*.rb') +
+               ::Dir.glob('*.md') +
+               ['LICENSE', '.yardopts']
+  spec.require_paths = ['lib']
+  spec.required_ruby_version = '>= 2.5.0'
+
+  spec.add_dependency 'opentelemetry-api', '~> 1.0.1'
+
+  spec.add_development_dependency 'appraisal', '~> 2.2.0'
+  spec.add_development_dependency 'bundler', '>= 1.17'
+  spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'rake', '~> 12.3.3'
+  spec.add_development_dependency 'rspec-mocks'
+  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'simplecov', '~> 0.17.1'
+  spec.add_development_dependency 'yard', '~> 0.9'
+  spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-registry/v#{OpenTelemetry::Instrumentation::Registry::VERSION}/file.CHANGELOG.html"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/main/instrumentation/registry'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/issues'
+    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-instrumentation-registry/v#{OpenTelemetry::Instrumentation::Registry::VERSION}"
+  end
+end

--- a/registry/test/.rubocop.yml
+++ b/registry/test/.rubocop.yml
@@ -1,0 +1,4 @@
+inherit_from: ../.rubocop.yml
+
+Metrics/BlockLength:
+  Enabled: false

--- a/registry/test/opentelemetry/instrumentation/registry_test.rb
+++ b/registry/test/opentelemetry/instrumentation/registry_test.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+class FakeInstrumentation
+  attr_reader :name, :version, :config
+
+  def initialize(name, version)
+    @name = name
+    @version = version
+    @install = false
+    @config = nil
+  end
+
+  def instance
+    self
+  end
+
+  def installed?
+    @install == true
+  end
+
+  def install(config)
+    @install = true
+    @config = config
+  end
+end
+
+describe OpenTelemetry::Instrumentation::Registry do
+  before do
+    @_logger = OpenTelemetry.logger
+  end
+
+  after do
+    OpenTelemetry.instance_variable_set(:@registry, nil)
+    OpenTelemetry.logger = @_logger
+  end
+
+  let(:registry) do
+    OpenTelemetry::Instrumentation::Registry.new
+  end
+
+  let(:instrumentation_1) do
+    FakeInstrumentation.new('TestInstrumentation1', '0.1.1')
+  end
+
+  let(:instrumentation_2) do
+    FakeInstrumentation.new('TestInstrumentation2', '0.3.2')
+  end
+
+  let(:instrumentations) do
+    [instrumentation_1, instrumentation_2]
+  end
+
+  describe '#register, #lookup' do
+    it 'registers and looks up instrumentations' do
+      instrumentations.each { |i| registry.register(i) }
+
+      instrumentations.each do |i|
+        _(registry.lookup(i.name)).must_equal(i)
+      end
+    end
+  end
+
+  describe '#install_all' do
+    before do
+      instrumentations.each { |i| registry.register(i) }
+    end
+
+    describe 'when using defaults arguments' do
+      it 'installs all registered instrumentations' do
+        registry.install_all
+
+        instrumentations.each do |i|
+          _(i).must_be :installed?
+          _(i.config).must_be_nil
+        end
+      end
+    end
+
+    describe 'when using instrumentation specific configs' do
+      it 'installs all registered instrumentations' do
+        registry.install_all(
+          'TestInstrumentation1' => { a: 'a' },
+          'TestInstrumentation2' => { b: 'b' }
+        )
+
+        _(instrumentation_1).must_be :installed?
+        _(instrumentation_1.config).must_equal(a: 'a')
+
+        _(instrumentation_2).must_be :installed?
+        _(instrumentation_2.config).must_equal(b: 'b')
+      end
+    end
+  end
+
+  describe '#install' do
+    before do
+      instrumentations.each { |i| registry.register(i) }
+    end
+
+    describe 'when using defaults arguments' do
+      it 'installs a specific instrumentation' do
+        registry.install(%w[TestInstrumentation1])
+
+        _(instrumentation_1).must_be :installed?
+        _(instrumentation_1.config).must_be_nil
+
+        _(instrumentation_2).wont_be :installed?
+        _(instrumentation_2.config).must_be_nil
+      end
+    end
+
+    describe 'when using instrumentation specific configs' do
+      it 'installs a specific instrumentation' do
+        registry.install(
+          %w[TestInstrumentation1 TestInstrumentation2],
+          'TestInstrumentation1' => { a: 'a' },
+          'TestInstrumentation2' => { b: 'b' }
+        )
+
+        _(instrumentation_1).must_be :installed?
+        _(instrumentation_1.config).must_equal(a: 'a')
+
+        _(instrumentation_2).must_be :installed?
+        _(instrumentation_2.config).must_equal(b: 'b')
+      end
+    end
+
+    describe 'given an non-existent instrumentation' do
+      before do
+        @log_stream = StringIO.new
+        OpenTelemetry.logger = ::Logger.new(@log_stream)
+      end
+
+      it 'reports a warning' do
+        registry.install(%w[NotInstalled TestInstrumentation2],
+                         'NotInstalled' => {},
+                         'TestInstrumentation2' => { b: 'b' })
+
+        _(@log_stream.string).must_match(/Could not install NotInstalled because it was not found/)
+
+        _(instrumentation_2).must_be :installed?
+        _(instrumentation_2.config).must_equal(b: 'b')
+      end
+    end
+  end
+
+  describe 'buggy instrumentations' do
+    before do
+      instrumentations.each { |i| registry.register(i) }
+    end
+
+    describe 'install' do
+      it 'handles exceptions during installation' do
+        expect(instrumentation_1).to receive(:install).and_raise('oops')
+
+        registry.install(%w[TestInstrumentation1 TestInstrumentation2])
+
+        _(instrumentation_2).must_be :installed?
+      end
+    end
+
+    describe 'install_all' do
+      it 'handles exceptions during installation' do
+        expect(instrumentation_1).to receive(:install).and_raise('oops')
+
+        registry.install_all
+
+        _(instrumentation_2).must_be :installed?
+      end
+    end
+  end
+end

--- a/registry/test/test_helper.rb
+++ b/registry/test/test_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry-registry'
+require 'minitest/autorun'
+require 'rspec/mocks/minitest_integration'
+
+OpenTelemetry.logger = Logger.new(File::NULL)


### PR DESCRIPTION
This change is the first in many steps that will allow us to move instrumentation gems into the contrib repo.
It copies the existing `Registry` into its own gem and will allow us to release it without breaking the SDK
or Instrumentations.

Once published we can update existing dependencies to use the `opentelemetry-registry` gem.

See https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/1
See https://github.com/open-telemetry/opentelemetry-ruby/discussions/776