### PR TITLE
Bump semantic_conventions gem to 1.10.0

### DIFF
--- a/semantic_conventions/Rakefile
+++ b/semantic_conventions/Rakefile
@@ -47,7 +47,7 @@ task :generate do
         -v "#{tmpdir}/semantic_conventions/#{kind}":/source
         -v "#{cwd}/templates":/templates
         -v "#{cwd}/lib":/output
-        otel/semconvgen:0.4.1
+        otel/semconvgen:0.11.1
         -f /source code
         --template /templates/semantic_conventions.j2
         --output /output/opentelemetry/semantic_conventions/#{kind}.rb

--- a/semantic_conventions/Rakefile
+++ b/semantic_conventions/Rakefile
@@ -10,7 +10,7 @@ require 'yard'
 require 'rubocop/rake_task'
 require 'tmpdir'
 
-SPEC_VERSION = '1.8.0'
+SPEC_VERSION = '1.10.0'
 
 RuboCop::RakeTask.new
 

--- a/semantic_conventions/lib/opentelemetry/semantic_conventions/resource.rb
+++ b/semantic_conventions/lib/opentelemetry/semantic_conventions/resource.rb
@@ -91,6 +91,10 @@ module OpenTelemetry
       # @note It's recommended this value represents a human readable version of the device model rather than a machine readable alternative
       DEVICE_MODEL_NAME = 'device.model.name'
 
+      # The name of the device manufacturer
+      # @note The Android OS provides this field via [Build](https://developer.android.com/reference/android/os/Build#MANUFACTURER). iOS apps SHOULD hardcode the value `Apple`
+      DEVICE_MANUFACTURER = 'device.manufacturer'
+
       # The name of the single function that this runtime instance executes
       # @note This is the name of the function as configured/deployed on the FaaS platform and is usually different from the name of the callback function (which may be stored in the [`code.namespace`/`code.function`](../../trace/semantic_conventions/span-general.md#source-code-attributes) span attributes)
       FAAS_NAME = 'faas.name'

--- a/semantic_conventions/lib/opentelemetry/semantic_conventions/version.rb
+++ b/semantic_conventions/lib/opentelemetry/semantic_conventions/version.rb
@@ -6,6 +6,6 @@
 
 module OpenTelemetry
   module SemanticConventions
-    VERSION = '1.8.0'
+    VERSION = '1.10.0'
   end
 end


### PR DESCRIPTION
This PR bumps the semantic_conventions gem to the 1.10.0 semantic conventions [release](https://github.com/open-telemetry/opentelemetry-specification/releases/tag/v1.10.0).

It's fairly uninteresting overall; but the commit messages have the full details and are replayed here for your convenience.

---

feat!: update for semantic conventions @ v1.10.0

The most notable thing here is that the delta between 1.8.0 and 1.10.0
results in a few fields going away. This will be a breaking change for
anyone who happens to be depending upon these fields:

- `DB_CASSANDRA_KEYSPACE`
- `DB_HBASE_NAMESPACE`

Users should instead use `DB_NAME`, according to
[open-telemetry/opentelemetry-specification#1973](https://github.com/open-telemetry/opentelemetry-specification/pull/1973).

Otherwise, we get the standard deal:

- A plethora of new, exciting fields!
- Reworded explanatory text!

Overall, not a terribly exciting change, but we must often take joy in
the small things, and I choose to do so here!

---

chore: bump semconvgen from 0.4.1 -> 0.11.1

I couldn't find any huge changes from the release notes; it seems the
generated wording was improved in some cases. Regardless, let us not
drift too far behind.
