### PR TITLE
fix: warn on unsupported otlp transport protocols

### DIFF
--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -175,10 +175,9 @@ module OpenTelemetry
           case exporter.strip
           when 'none' then nil
           when 'otlp'
-            otlp_protocol = ENV['OTEL_EXPORTER_OTLP_TRACES_PROTOCOL']
-            otlp_protocol ||= ENV['OTEL_EXPORTER_OTLP_PROTOCOL']
+            otlp_protocol = ENV['OTEL_EXPORTER_OTLP_TRACES_PROTOCOL'] || ENV['OTEL_EXPORTER_OTLP_PROTOCOL'] || 'http/protobuf'
 
-            if !otlp_protocol.nil? && otlp_protocol != 'http/protobuf'
+            if otlp_protocol != 'http/protobuf'
               OpenTelemetry.logger.warn "The #{otlp_protocol} transport protocol is not supported by the OTLP exporter, spans will not be exported."
               nil
             else

--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -169,12 +169,21 @@ module OpenTelemetry
         processors.each { |p| tracer_provider.add_span_processor(p) }
       end
 
-      def wrapped_exporters_from_env
+      def wrapped_exporters_from_env # rubocop:disable Metrics/CyclomaticComplexity, Metrics/AbcSize
         exporters = ENV.fetch('OTEL_TRACES_EXPORTER', 'otlp')
         exporters.split(',').map do |exporter|
           case exporter.strip
           when 'none' then nil
-          when 'otlp' then fetch_exporter(exporter, 'OpenTelemetry::Exporter::OTLP::Exporter')
+          when 'otlp'
+            otlp_protocol = ENV['OTEL_EXPORTER_OTLP_TRACES_PROTOCOL']
+            otlp_protocol ||= ENV['OTEL_EXPORTER_OTLP_PROTOCOL']
+
+            if !otlp_protocol.nil? && otlp_protocol != 'http/protobuf'
+              OpenTelemetry.logger.warn "The #{otlp_protocol} transport protocol is not supported by the OTLP exporter, spans will not be exported."
+              nil
+            else
+              fetch_exporter(exporter, 'OpenTelemetry::Exporter::OTLP::Exporter')
+            end
           when 'jaeger' then fetch_exporter(exporter, 'OpenTelemetry::Exporter::Jaeger::CollectorExporter')
           when 'zipkin' then fetch_exporter(exporter, 'OpenTelemetry::Exporter::Zipkin::Exporter')
           when 'console' then Trace::Export::SimpleSpanProcessor.new(Trace::Export::ConsoleSpanExporter.new)

--- a/sdk/test/opentelemetry/sdk/configurator_test.rb
+++ b/sdk/test/opentelemetry/sdk/configurator_test.rb
@@ -284,6 +284,26 @@ describe OpenTelemetry::SDK::Configurator do
           OpenTelemetry::SDK::Trace::Export::ConsoleSpanExporter
         )
       end
+
+      it 'warns on unsupported otlp transport protocol grpc' do
+        OpenTelemetry::TestHelpers.with_env('OTEL_TRACES_EXPORTER' => 'otlp', 'OTEL_EXPORTER_OTLP_TRACES_PROTOCOL' => 'grpc') do
+          OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
+            configurator.configure
+
+            _(log_stream.string).must_match(/The grpc transport protocol is not supported by the OTLP exporter/)
+          end
+        end
+      end
+
+      it 'warns on unsupported otlp transport protocol http/json' do
+        OpenTelemetry::TestHelpers.with_env('OTEL_TRACES_EXPORTER' => 'otlp', 'OTEL_EXPORTER_OTLP_TRACES_PROTOCOL' => 'http/json') do
+          OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
+            configurator.configure
+
+            _(log_stream.string).must_match(%r{The http/json transport protocol is not supported by the OTLP exporter})
+          end
+        end
+      end
     end
 
     describe 'instrumentation installation' do


### PR DESCRIPTION
Follow up from https://github.com/open-telemetry/opentelemetry-ruby/pull/1129

https://github.com/open-telemetry/opentelemetry-specification/blob/v1.10.0/specification/protocol/exporter.md#specify-protocol