### PR TITLE
Only allow certain types of Numeric values as attribute values.

### DIFF
--- a/sdk/lib/opentelemetry/sdk/internal.rb
+++ b/sdk/lib/opentelemetry/sdk/internal.rb
@@ -21,7 +21,7 @@ module OpenTelemetry
       end
 
       def numeric?(value)
-        value.is_a?(Integer) || value.is_a?(Float)
+        value.instance_of?(Integer) || value.instance_of?(Float)
       end
 
       def valid_simple_value?(value)

--- a/sdk/lib/opentelemetry/sdk/internal.rb
+++ b/sdk/lib/opentelemetry/sdk/internal.rb
@@ -4,6 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require 'BigDecimal'
 module OpenTelemetry
   module SDK
     # @api private
@@ -20,8 +21,12 @@ module OpenTelemetry
         key.instance_of?(String)
       end
 
+      def valid_numeric?(value)
+        value.is_a?(Integer) || value.is_a?(Float) || value.is_a?(Rational) || value.is_a?(Complex) || value.is_a?(BigDecimal)
+      end
+
       def valid_simple_value?(value)
-        value.instance_of?(String) || value == false || value == true || value.is_a?(Numeric)
+        value.instance_of?(String) || value == false || value == true || valid_numeric?(value)
       end
 
       def valid_array_value?(value)
@@ -34,7 +39,7 @@ module OpenTelemetry
         when TrueClass, FalseClass
           value.all? { |v| boolean?(v) }
         when Numeric
-          value.all? { |v| v.is_a?(Numeric) }
+          value.all? { |v| valid_numeric?(v) }
         else
           false
         end

--- a/sdk/lib/opentelemetry/sdk/internal.rb
+++ b/sdk/lib/opentelemetry/sdk/internal.rb
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'BigDecimal'
 module OpenTelemetry
   module SDK
     # @api private
@@ -22,7 +21,7 @@ module OpenTelemetry
       end
 
       def valid_numeric?(value)
-        value.is_a?(Integer) || value.is_a?(Float) || value.is_a?(Rational) || value.is_a?(Complex) || value.is_a?(BigDecimal)
+        value.is_a?(Integer) || value.is_a?(Float)
       end
 
       def valid_simple_value?(value)

--- a/sdk/lib/opentelemetry/sdk/internal.rb
+++ b/sdk/lib/opentelemetry/sdk/internal.rb
@@ -20,12 +20,12 @@ module OpenTelemetry
         key.instance_of?(String)
       end
 
-      def valid_numeric?(value)
+      def numeric?(value)
         value.is_a?(Integer) || value.is_a?(Float)
       end
 
       def valid_simple_value?(value)
-        value.instance_of?(String) || value == false || value == true || valid_numeric?(value)
+        value.instance_of?(String) || value == false || value == true || numeric?(value)
       end
 
       def valid_array_value?(value)
@@ -38,7 +38,7 @@ module OpenTelemetry
         when TrueClass, FalseClass
           value.all? { |v| boolean?(v) }
         when Numeric
-          value.all? { |v| valid_numeric?(v) }
+          value.all? { |v| numeric?(v) }
         else
           false
         end

--- a/sdk/lib/opentelemetry/sdk/internal.rb
+++ b/sdk/lib/opentelemetry/sdk/internal.rb
@@ -13,7 +13,7 @@ module OpenTelemetry
       extend self
 
       def boolean?(value)
-        value.is_a?(TrueClass) || value.is_a?(FalseClass)
+        value.instance_of?(TrueClass) || value.instance_of?(FalseClass)
       end
 
       def valid_key?(key)
@@ -25,7 +25,7 @@ module OpenTelemetry
       end
 
       def valid_simple_value?(value)
-        value.instance_of?(String) || value == false || value == true || numeric?(value)
+        value.instance_of?(String) || boolean?(value) || numeric?(value)
       end
 
       def valid_array_value?(value)


### PR DESCRIPTION
We ran into a pretty odd failure mode, which this patch will hopefully help address (h/t @ericmustin for sussing this out):

In an app, we set a span attribute value to an `ActiveSupport::Duration` instance.  So imagine something like `.in_span("foobar", { "baz" => 1.minute }`. When we viewed the span in various destinations, it the attribute showed up with the value as `nil` (or `null` or what have you). We saw the symptom (null attribute value, which is not allowed per the otel spec) before we sussed out the problem.

Turns out that, when exporting, the otlp exporter checks for a whitelist of exportable value classes that are pretty basic (code [here](https://github.com/open-telemetry/opentelemetry-ruby/blob/main/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb#L382-L398)). As a result, a value with class `ActiveSupport::Duration` will be `nil`.

This patch should ensure that users will get a warning if they use an unsupported `Numeric` class, and that the invalid attribute k/v pair will not be exported.

I didn't see the need to do this, but we could also potentially:

* log a warning from the OTLP exporter about this
* allow other numeric classes (BigDecimal, etc.)