### PR TITLE
fix: Registry Release config

### DIFF
--- a/.toys/.data/releases.yml
+++ b/.toys/.data/releases.yml
@@ -103,7 +103,7 @@ gems:
 
   - name: opentelemetry-registry
     directory: registry
-    version_constant: [OpenTelemetry, Registry, VERSION]
+    version_constant: [OpenTelemetry, Instrumentation, Registry, VERSION]
 
   - name: opentelemetry-sdk
     directory: sdk


### PR DESCRIPTION
Fixes toys release error https://github.com/open-telemetry/opentelemetry-ruby/runs/5854957016?check_suite_focus=true

```console
Error: Missing version file /home/runner/work/opentelemetry-ruby/opentelemetry-ruby/registry/lib/opentelemetry/registry/version.rb for gem opentelemetry-registry
64
Version file /home/runner/work/opentelemetry-ruby/opentelemetry-ruby/registry/lib/opentelemetry/registry/version.rb for gem opentelemetry-registry didn't define OpenTelemetry::Registry::VERSION
65
```