### PR TITLE
Add `with_attributes` context propagation for mysql2 instrumentation

### DIFF
--- a/instrumentation/mysql2/CHANGELOG.md
+++ b/instrumentation/mysql2/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History: opentelemetry-instrumentation-mysql2
 
+### Unreleased
+
+* ADDED: `with_attributes` method for context propagation
+
 ### v0.20.0 / 2021-12-01
 
 * ADDED: Add default options config helper + env var config option support 

--- a/instrumentation/mysql2/README.md
+++ b/instrumentation/mysql2/README.md
@@ -46,9 +46,8 @@ end
 ```ruby
 OpenTelemetry::SDK.configure do |c|
   c.use 'OpenTelemetry::Instrumentation::Mysql2', {
-    # By default, this instrumentation includes the executed SQL as the `db.statement`
-    # semantic attribute. Optionally, you may disable the inclusion of this attribute entirely by
-    # setting this option to :omit or sanitize the attribute by setting to :obfuscate
+    # The obfuscation of SQL in the db.statement attribute is disabled by default.
+    # To enable, set db_statement to :obfuscate.
     db_statement: :obfuscate,
   }
 end

--- a/instrumentation/mysql2/README.md
+++ b/instrumentation/mysql2/README.md
@@ -30,13 +30,25 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
+The `mysql2` instrumentation allows the user to supply additional attributes via the `with_attributes` method. This makes it possible to supply additional attributes on mysql2 spans. Attributes supplied in `with_attributes` supersede those automatically generated within `mysql2`'s automatic instrumentation. If you supply a `db.statement` attribute in `with_attributes`, this library's `:db_statement` configuration will not be applied.
+
+```ruby
+require 'opentelemetry/instrumentation/mysql2'
+
+client = Mysql2::Client.new(:host => "localhost", :username => "root")
+OpenTelemetry::Instrumentation::Mysql2.with_attributes('pizzatoppings' => 'mushrooms') do
+  client.query("SELECT 1")
+end
+```
+
 ### Configuration options
 
 ```ruby
 OpenTelemetry::SDK.configure do |c|
   c.use 'OpenTelemetry::Instrumentation::Mysql2', {
-    # The obfuscation of SQL in the db.statement attribute is disabled by default.
-    # To enable, set db_statement to :obfuscate.
+    # By default, this instrumentation includes the executed SQL as the `db.statement`
+    # semantic attribute. Optionally, you may disable the inclusion of this attribute entirely by
+    # setting this option to :omit or sanitize the attribute by setting to :obfuscate
     db_statement: :obfuscate,
   }
 end

--- a/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2.rb
+++ b/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2.rb
@@ -11,6 +11,45 @@ module OpenTelemetry
   module Instrumentation
     # Contains the OpenTelemetry instrumentation for the Mysql2 gem
     module Mysql2
+      extend self
+
+      CURRENT_ATTRIBUTES_KEY = Context.create_key('mysql-attributes-hash')
+
+      private_constant :CURRENT_ATTRIBUTES_KEY
+
+      # Returns the attributes hash representing the Mysql2 context found
+      # in the optional context or the current context if none is provided.
+      #
+      # @param [optional Context] context The context to lookup the current
+      #   attributes hash. Defaults to Context.current
+      def attributes(context = nil)
+        context ||= Context.current
+        context.value(CURRENT_ATTRIBUTES_KEY) || {}
+      end
+
+      # Returns a context containing the merged attributes hash, derived from the
+      # optional parent context, or the current context if one was not provided.
+      #
+      # @param [optional Context] context The context to use as the parent for
+      #   the returned context
+      def context_with_attributes(attributes_hash, parent_context: Context.current)
+        attributes_hash = attributes(parent_context).merge(attributes_hash)
+        parent_context.set_value(CURRENT_ATTRIBUTES_KEY, attributes_hash)
+      end
+
+      # Activates/deactivates the merged attributes hash within the current Context,
+      # which makes the "current attributes hash" available implicitly.
+      #
+      # On exit, the attributes hash that was active before calling this method
+      # will be reactivated.
+      #
+      # @param [Span] span the span to activate
+      # @yield [Hash, Context] yields attributes hash and a context containing the
+      #   attributes hash to the block.
+      def with_attributes(attributes_hash)
+        attributes_hash = attributes.merge(attributes_hash)
+        Context.with_value(CURRENT_ATTRIBUTES_KEY, attributes_hash) { |c, h| yield h, c }
+      end
     end
   end
 end

--- a/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
+++ b/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
@@ -58,9 +58,10 @@ module OpenTelemetry
             when :obfuscate
               attributes['db.statement'] = obfuscate_sql(sql)
             end
+
             tracer.in_span(
               database_span_name(sql),
-              attributes: attributes,
+              attributes: attributes.merge(OpenTelemetry::Instrumentation::Mysql2.attributes),
               kind: :client
             ) do
               super(sql, options)

--- a/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
+++ b/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
@@ -58,7 +58,6 @@ module OpenTelemetry
             when :obfuscate
               attributes['db.statement'] = obfuscate_sql(sql)
             end
-
             tracer.in_span(
               database_span_name(sql),
               attributes: attributes.merge(OpenTelemetry::Instrumentation::Mysql2.attributes),

--- a/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
+++ b/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb
@@ -60,7 +60,7 @@ module OpenTelemetry
             end
             tracer.in_span(
               database_span_name(sql),
-              attributes: attributes.merge(OpenTelemetry::Instrumentation::Mysql2.attributes),
+              attributes: attributes.merge!(OpenTelemetry::Instrumentation::Mysql2.attributes),
               kind: :client
             ) do
               super(sql, options)

--- a/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
+++ b/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
@@ -79,7 +79,7 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
         end
       end
 
-      it 'sets span attribures according to with_attributes hash' do
+      it 'sets span attributes according to with_attributes hash' do
         OpenTelemetry::Instrumentation::Mysql2.with_attributes(attributes) do
           client.query("SELECT 1")
         end

--- a/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
+++ b/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
@@ -81,10 +81,10 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
 
       it 'sets span attributes according to with_attributes hash' do
         OpenTelemetry::Instrumentation::Mysql2.with_attributes(attributes) do
-          client.query("SELECT 1")
+          client.query('SELECT 1')
         end
 
-        _(span.attributes['db.statement']).must_equal "foobar" 
+        _(span.attributes['db.statement']).must_equal 'foobar'
       end
     end
 

--- a/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
+++ b/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
@@ -65,10 +65,10 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
 
       _(span.attributes['peer.service']).must_equal 'readonly:mysql'
     end
-  
+
     describe '.attributes' do
       let(:attributes) { { 'db.statement' => 'foobar' } }
-  
+
       it 'returns an empty hash by default' do
         _(OpenTelemetry::Instrumentation::Mysql2.attributes).must_equal({})
       end

--- a/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
+++ b/instrumentation/mysql2/test/opentelemetry/instrumentation/mysql2/instrumentation_test.rb
@@ -65,6 +65,28 @@ describe OpenTelemetry::Instrumentation::Mysql2::Instrumentation do
 
       _(span.attributes['peer.service']).must_equal 'readonly:mysql'
     end
+  
+    describe '.attributes' do
+      let(:attributes) { { 'db.statement' => 'foobar' } }
+  
+      it 'returns an empty hash by default' do
+        _(OpenTelemetry::Instrumentation::Mysql2.attributes).must_equal({})
+      end
+
+      it 'returns the current attributes hash' do
+        OpenTelemetry::Instrumentation::Mysql2.with_attributes(attributes) do
+          _(OpenTelemetry::Instrumentation::Mysql2.attributes).must_equal(attributes)
+        end
+      end
+
+      it 'sets span attribures according to with_attributes hash' do
+        OpenTelemetry::Instrumentation::Mysql2.with_attributes(attributes) do
+          client.query("SELECT 1")
+        end
+
+        _(span.attributes['db.statement']).must_equal "foobar" 
+      end
+    end
 
     it 'after requests' do
       client.query('SELECT 1')


### PR DESCRIPTION
As in `Redis` and `HTTP::ClientContext`, I'd like to use `with_attributes` to assign arbitrary attributes to spans generated within the `mysql2` instrumentation. Test coverage is light on the `*attributes` methods in `Mysql2` because it's a lightly modified copy/paste of [the redis instrumentation's implementation](https://github.com/open-telemetry/opentelemetry-ruby/blob/b7149fb72cad6c45956a6be80acfb2d062aab3a6/instrumentation/redis/lib/opentelemetry/instrumentation/redis.rb#L14). Happy to fill in test coverage if folks would prefer.