### PR TITLE
feat: Otlp grpc

### DIFF
--- a/exporter/otlp-common/test/opentelemetry/exporter/otlp/common/common_test.rb
+++ b/exporter/otlp-common/test/opentelemetry/exporter/otlp/common/common_test.rb
@@ -10,7 +10,7 @@ describe OpenTelemetry::Exporter::OTLP::Common do
   describe '#as_encoded_etsr' do
     it 'handles encoding errors with poise and grace' do
       OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
-        span_data = create_span_data(
+        span_data = OpenTelemetry::TestHelpers.create_span_data(
           total_recorded_attributes: 1,
           attributes: { 'a' => "\xC2".dup.force_encoding(::Encoding::ASCII_8BIT) }
         )
@@ -27,11 +27,11 @@ describe OpenTelemetry::Exporter::OTLP::Common do
   describe '#as_etsr' do
     it 'batches per resource' do
       resource_one = OpenTelemetry::SDK::Resources::Resource.create('k1' => 'v1')
-      span_data1 = create_span_data(resource: resource_one)
+      span_data1 = OpenTelemetry::TestHelpers.create_span_data(resource: resource_one)
 
       resource_two = OpenTelemetry::SDK::Resources::Resource.create('k2' => 'v2')
-      span_data2 = create_span_data(resource: resource_two)
-      span_data3 = create_span_data(resource: resource_two)
+      span_data2 = OpenTelemetry::TestHelpers.create_span_data(resource: resource_two)
+      span_data3 = OpenTelemetry::TestHelpers.create_span_data(resource: resource_two)
 
       etsr = OpenTelemetry::Exporter::OTLP::Common.as_etsr([span_data1, span_data2, span_data3])
 
@@ -54,12 +54,12 @@ describe OpenTelemetry::Exporter::OTLP::Common do
       start_timestamp = Time.now
       end_timestamp = start_timestamp + 6
 
-      root = with_ids(trace_id, root_span_id) { tracer.start_root_span('root', kind: :internal, start_timestamp: start_timestamp) }
+      root = OpenTelemetry::TestHelpers.with_ids(trace_id, root_span_id) { tracer.start_root_span('root', kind: :internal, start_timestamp: start_timestamp) }
       root.status = OpenTelemetry::Trace::Status.ok
       root.finish(end_timestamp: end_timestamp)
       root_ctx = OpenTelemetry::Trace.context_with_span(root)
 
-      span = with_ids(trace_id, child_span_id) { tracer.start_span('child', with_parent: root_ctx, kind: :producer, start_timestamp: start_timestamp + 1, links: [OpenTelemetry::Trace::Link.new(root.context, 'attr' => 4)]) }
+      span = OpenTelemetry::TestHelpers.with_ids(trace_id, child_span_id) { tracer.start_span('child', with_parent: root_ctx, kind: :producer, start_timestamp: start_timestamp + 1, links: [OpenTelemetry::Trace::Link.new(root.context, 'attr' => 4)]) }
       span['b'] = true
       span['f'] = 1.1
       span['i'] = 2
@@ -68,12 +68,12 @@ describe OpenTelemetry::Exporter::OTLP::Common do
       span.status = OpenTelemetry::Trace::Status.error
       child_ctx = OpenTelemetry::Trace.context_with_span(span)
 
-      client = with_ids(trace_id, client_span_id) { tracer.start_span('client', with_parent: child_ctx, kind: :client, start_timestamp: start_timestamp + 2).finish(end_timestamp: end_timestamp) }
+      client = OpenTelemetry::TestHelpers.with_ids(trace_id, client_span_id) { tracer.start_span('client', with_parent: child_ctx, kind: :client, start_timestamp: start_timestamp + 2).finish(end_timestamp: end_timestamp) }
       client_ctx = OpenTelemetry::Trace.context_with_span(client)
 
-      server_span = with_ids(trace_id, server_span_id) { other_tracer.start_span('server', with_parent: client_ctx, kind: :server, start_timestamp: start_timestamp + 3).finish(end_timestamp: end_timestamp) }
+      server_span = OpenTelemetry::TestHelpers.with_ids(trace_id, server_span_id) { other_tracer.start_span('server', with_parent: client_ctx, kind: :server, start_timestamp: start_timestamp + 3).finish(end_timestamp: end_timestamp) }
       span.add_event('event', attributes: { 'attr' => 42 }, timestamp: start_timestamp + 4)
-      consumer_span = with_ids(trace_id, consumer_span_id) { tracer.start_span('consumer', with_parent: child_ctx, kind: :consumer, start_timestamp: start_timestamp + 5).finish(end_timestamp: end_timestamp) }
+      consumer_span = OpenTelemetry::TestHelpers.with_ids(trace_id, consumer_span_id) { tracer.start_span('consumer', with_parent: child_ctx, kind: :consumer, start_timestamp: start_timestamp + 5).finish(end_timestamp: end_timestamp) }
       span.finish(end_timestamp: end_timestamp)
 
       # Ordered by the first finished
@@ -217,25 +217,5 @@ describe OpenTelemetry::Exporter::OTLP::Common do
 
       _(encoded_etsr).must_equal(expected_encoded_etsr)
     end
-  end
-
-  def with_ids(trace_id, span_id)
-    OpenTelemetry::Trace.stub(:generate_trace_id, trace_id) do
-      OpenTelemetry::Trace.stub(:generate_span_id, span_id) do
-        yield
-      end
-    end
-  end
-
-  def create_span_data(name: '', kind: nil, status: nil, parent_span_id: OpenTelemetry::Trace::INVALID_SPAN_ID,
-                       total_recorded_attributes: 0, total_recorded_events: 0, total_recorded_links: 0, start_timestamp: OpenTelemetry::TestHelpers.exportable_timestamp,
-                       end_timestamp: OpenTelemetry::TestHelpers.exportable_timestamp, attributes: nil, links: nil, events: nil, resource: nil,
-                       instrumentation_library: OpenTelemetry::SDK::InstrumentationLibrary.new('', 'v0.0.1'),
-                       span_id: OpenTelemetry::Trace.generate_span_id, trace_id: OpenTelemetry::Trace.generate_trace_id,
-                       trace_flags: OpenTelemetry::Trace::TraceFlags::DEFAULT, tracestate: nil)
-    resource ||= OpenTelemetry::SDK::Resources::Resource.telemetry_sdk
-    OpenTelemetry::SDK::Trace::SpanData.new(name, kind, status, parent_span_id, total_recorded_attributes,
-                                            total_recorded_events, total_recorded_links, start_timestamp, end_timestamp,
-                                            attributes, links, events, resource, instrumentation_library, span_id, trace_id, trace_flags, tracestate)
   end
 end

--- a/exporter/otlp-grpc/.rubocop.yml
+++ b/exporter/otlp-grpc/.rubocop.yml
@@ -1,0 +1,18 @@
+AllCops:
+  TargetRubyVersion: "2.5.0"
+
+Lint/UnusedMethodArgument:
+  Enabled: false
+Metrics/AbcSize:
+  Max: 18
+Metrics/LineLength:
+  Enabled: false
+Metrics/MethodLength:
+  Max: 21
+Metrics/ParameterLists:
+  Enabled: false
+Naming/FileName:
+  Exclude:
+    - "lib/opentelemetry-exporter-otlp-grpc.rb"
+Style/ModuleFunction:
+  Enabled: false

--- a/exporter/otlp-grpc/.yardopts
+++ b/exporter/otlp-grpc/.yardopts
@@ -1,0 +1,9 @@
+--no-private
+--title=OpenTelemetry OTLP GRPC
+--markup=markdown
+--main=README.md
+./lib/opentelemetry/exporter/otlp/grpc/**/*.rb
+./lib/opentelemetry/exporter/otlp/grpc.rb
+-
+README.md
+CHANGELOG.md

--- a/exporter/otlp-grpc/CHANGELOG.md
+++ b/exporter/otlp-grpc/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Release History: opentelemetry-exporter-otlp-grpc

--- a/exporter/otlp-grpc/CHANGELOG.md
+++ b/exporter/otlp-grpc/CHANGELOG.md
@@ -1,1 +1,5 @@
 # Release History: opentelemetry-exporter-otlp-grpc
+
+### Unreleased
+
+* ADDED: Boiler plate for a OTLP GRPC exporter implementation. It is not in a production ready state and will not be published until further improvements are made to it.

--- a/exporter/otlp-grpc/Gemfile
+++ b/exporter/otlp-grpc/Gemfile
@@ -8,13 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
-# Use the opentelemetry-api gem from source
-gem 'opentelemetry-api', path: '../../api'
-gem 'opentelemetry-common', path: '../../common'
-gem 'opentelemetry-exporter-otlp-common', path: '../otlp-common'
-gem 'opentelemetry-instrumentation-base', path: '../../instrumentation/base'
-gem 'opentelemetry-sdk', path: '../../sdk'
-
 group :test, :development do
+  gem 'opentelemetry-api', path: '../../api'
+  gem 'opentelemetry-exporter-otlp-common', path: '../otlp-common'
+  gem 'opentelemetry-sdk', path: '../../sdk'
+  gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions'
   gem 'opentelemetry-test-helpers', path: '../../test_helpers'
 end

--- a/exporter/otlp-grpc/Gemfile
+++ b/exporter/otlp-grpc/Gemfile
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source 'https://rubygems.org'
+
+gemspec
+
+# Use the opentelemetry-api gem from source
+gem 'opentelemetry-api', path: '../../api'
+gem 'opentelemetry-common', path: '../../common'
+gem 'opentelemetry-exporter-otlp-common', path: '../otlp-common'
+gem 'opentelemetry-instrumentation-base', path: '../../instrumentation/base'
+gem 'opentelemetry-sdk', path: '../../sdk'
+
+group :test, :development do
+  gem 'opentelemetry-test-helpers', path: '../../test_helpers'
+end

--- a/exporter/otlp-grpc/LICENSE
+++ b/exporter/otlp-grpc/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright The OpenTelemetry Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/exporter/otlp-grpc/README.md
+++ b/exporter/otlp-grpc/README.md
@@ -1,0 +1,95 @@
+# opentelemetry-exporter-otlp-grpc
+
+The `opentelemetry-exporter-otlp-grpc` gem provides an [OTLP](https://github.com/open-telemetry/opentelemetry-proto) exporter over GRPC for OpenTelemetry for Ruby. Using `opentelemetry-exporter-otlp-grpc`, an application can configure OpenTelemetry to export collected tracing data to [the OpenTelemetry Collector][opentelemetry-collector-home].
+
+## What is OpenTelemetry?
+
+[OpenTelemetry][opentelemetry-home] is an open source observability framework, providing a general-purpose API, SDK, and related tools required for the instrumentation of cloud-native software, frameworks, and libraries.
+
+OpenTelemetry provides a single set of APIs, libraries, agents, and collector services to capture distributed traces and metrics from your application. You can analyze them using Prometheus, Jaeger, and other observability tools.
+
+## How does this gem fit in?
+
+The `opentelemetry-exporter-otlp-grpc` gem is a plugin that provides OTLP export. To export to the OpenTelemetry Collector, an application can include this gem along with `opentelemetry-sdk`, and configure the `SDK` to use the provided OTLP exporter as a span processor.
+
+Generally, *libraries* that produce telemetry data should avoid depending directly on specific exporter, deferring that choice to the application developer.
+
+### Supported protocol version
+
+This gem supports the [v0.4.0 release](https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v0.4.0) of OTLP.
+
+## How do I get started?
+
+Install the gem using:
+
+```
+gem install opentelemetry-sdk
+gem install opentelemetry-exporter-otlp-grpc
+```
+
+Or, if you use [bundler][bundler-home], include `opentelemetry-sdk` in your `Gemfile`.
+
+Then, configure the SDK to use the OTLP exporter as a span processor, and use the OpenTelemetry interfaces to produces traces and other information. Following is a basic example.
+
+```ruby
+require 'opentelemetry/sdk'
+require 'opentelemetry/exporter/otlp'
+
+# The OTLP exporter is the default, so no configuration is needed.
+# However, it could be manually selected via an environment variable if required:
+#
+# ENV['OTEL_TRACES_EXPORTER'] = 'otlp'
+#
+# You may also configure various settings via environment variables:
+# ENV['OTEL_EXPORTER_OTLP_COMPRESSION'] = 'gzip'
+
+OpenTelemetry::SDK.configure
+
+# To start a trace you need to get a Tracer from the TracerProvider
+tracer = OpenTelemetry.tracer_provider.tracer('my_app_or_gem', '0.1.0')
+
+# create a span
+tracer.in_span('foo') do |span|
+  # set an attribute
+  span.set_attribute('platform', 'osx')
+  # add an event
+  span.add_event('event in bar')
+  # create bar as child of foo
+  tracer.in_span('bar') do |child_span|
+    # inspect the span
+    pp child_span
+  end
+end
+```
+
+For additional examples, see the [examples on github][examples-github].
+
+## How can I configure the OTLP exporter?
+
+The collector exporter can be configured explicitly in code, or via environment variables as shown above. The configuration parameters, environment variables, and defaults are shown below.
+
+| Parameter           | Environment variable                         | Default                             |
+| ------------------- | -------------------------------------------- | ----------------------------------- |
+| `endpoint:`         | `OTEL_EXPORTER_OTLP_ENDPOINT`                | `"http://localhost:4318/v1/traces"` |
+
+
+## How can I get involved?
+
+The `opentelemetry-exporter-otlp-grpc` gem source is [on github][repo-github], along with related gems including `opentelemetry-sdk`.
+
+The OpenTelemetry Ruby gems are maintained by the OpenTelemetry-Ruby special interest group (SIG). You can get involved by joining us in [GitHub Discussions][discussions-url] or attending our weekly meeting. See the [meeting calendar][community-meetings] for dates and times. For more information on this and other language SIGs, see the OpenTelemetry [community page][ruby-sig].
+
+## License
+
+The `opentelemetry-exporter-otlp-grpc` gem is distributed under the Apache 2.0 license. See [LICENSE][license-github] for more information.
+
+
+[opentelemetry-collector-home]: https://opentelemetry.io/docs/collector/about/
+[opentelemetry-home]: https://opentelemetry.io
+[bundler-home]: https://bundler.io
+[repo-github]: https://github.com/open-telemetry/opentelemetry-ruby
+[license-github]: https://github.com/open-telemetry/opentelemetry-ruby/blob/main/LICENSE
+[examples-github]: https://github.com/open-telemetry/opentelemetry-ruby/tree/main/examples
+[ruby-sig]: https://github.com/open-telemetry/community#ruby-sig
+[community-meetings]: https://github.com/open-telemetry/community#community-meetings
+[discussions-url]: https://github.com/open-telemetry/opentelemetry-ruby/discussions

--- a/exporter/otlp-grpc/README.md
+++ b/exporter/otlp-grpc/README.md
@@ -16,7 +16,7 @@ Generally, *libraries* that produce telemetry data should avoid depending direct
 
 ### Supported protocol version
 
-This gem supports the [v0.4.0 release](https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v0.4.0) of OTLP.
+This gem supports the [v0.11.0 release](https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v0.11.0) of OTLP.
 
 ## How do I get started?
 
@@ -29,21 +29,18 @@ gem install opentelemetry-exporter-otlp-grpc
 
 Or, if you use [bundler][bundler-home], include `opentelemetry-sdk` in your `Gemfile`.
 
-Then, configure the SDK to use the OTLP exporter as a span processor, and use the OpenTelemetry interfaces to produces traces and other information. Following is a basic example.
+Then, configure the SDK to use the OTLP GRPC exporter as a span processor, and use the OpenTelemetry interfaces to produces traces and other information. Following is a basic example.
 
 ```ruby
 require 'opentelemetry/sdk'
-require 'opentelemetry/exporter/otlp'
+require 'opentelemetry/exporter/otlp/grpc'
 
-# The OTLP exporter is the default, so no configuration is needed.
-# However, it could be manually selected via an environment variable if required:
-#
-# ENV['OTEL_TRACES_EXPORTER'] = 'otlp'
-#
-# You may also configure various settings via environment variables:
-# ENV['OTEL_EXPORTER_OTLP_COMPRESSION'] = 'gzip'
+exporter = OpenTelemetry::Exporter::OTLP::GRPC::Exporter.new
+span_processor = OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(exporter)
 
-OpenTelemetry::SDK.configure
+OpenTelemetry::SDK.configure do |c|
+  c.add_span_processor(span_processor)
+end
 
 # To start a trace you need to get a Tracer from the TracerProvider
 tracer = OpenTelemetry.tracer_provider.tracer('my_app_or_gem', '0.1.0')
@@ -71,7 +68,6 @@ The collector exporter can be configured explicitly in code, or via environment 
 | Parameter           | Environment variable                         | Default                             |
 | ------------------- | -------------------------------------------- | ----------------------------------- |
 | `endpoint:`         | `OTEL_EXPORTER_OTLP_ENDPOINT`                | `"http://localhost:4318/v1/traces"` |
-
 
 ## How can I get involved?
 

--- a/exporter/otlp-grpc/Rakefile
+++ b/exporter/otlp-grpc/Rakefile
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+require 'yard'
+
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new
+
+Rake::TestTask.new :test do |t|
+  t.libs << 'test'
+  t.libs << 'lib'
+  t.libs << '../../api/lib'
+  t.libs << '../../sdk/lib'
+  t.test_files = FileList['test/**/*_test.rb']
+end
+
+YARD::Rake::YardocTask.new do |t|
+  t.stats_options = ['--list-undoc']
+end
+
+if RUBY_ENGINE == 'truffleruby'
+  task default: %i[test]
+else
+  task default: %i[test rubocop yard]
+end
+
+PROTOBUF_FILES = [
+  'common/v1/common.proto',
+  'resource/v1/resource.proto',
+  'trace/v1/trace.proto',
+  'collector/trace/v1/trace_service.proto'
+].freeze
+
+task :update_protobuf do
+  system('git clone https://github.com/open-telemetry/opentelemetry-proto')
+  PROTOBUF_FILES.each do |file|
+    system("protoc --ruby_out=lib/ --proto_path=opentelemetry-proto opentelemetry/proto/#{file}")
+  end
+  system('rm -rf opentelemetry-proto')
+end

--- a/exporter/otlp-grpc/Rakefile
+++ b/exporter/otlp-grpc/Rakefile
@@ -28,18 +28,3 @@ if RUBY_ENGINE == 'truffleruby'
 else
   task default: %i[test rubocop yard]
 end
-
-PROTOBUF_FILES = [
-  'common/v1/common.proto',
-  'resource/v1/resource.proto',
-  'trace/v1/trace.proto',
-  'collector/trace/v1/trace_service.proto'
-].freeze
-
-task :update_protobuf do
-  system('git clone https://github.com/open-telemetry/opentelemetry-proto')
-  PROTOBUF_FILES.each do |file|
-    system("protoc --ruby_out=lib/ --proto_path=opentelemetry-proto opentelemetry/proto/#{file}")
-  end
-  system('rm -rf opentelemetry-proto')
-end

--- a/exporter/otlp-grpc/lib/opentelemetry-exporter-otlp-grpc.rb
+++ b/exporter/otlp-grpc/lib/opentelemetry-exporter-otlp-grpc.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry/exporter/otlp/grpc'

--- a/exporter/otlp-grpc/lib/opentelemetry/exporter/otlp/grpc.rb
+++ b/exporter/otlp-grpc/lib/opentelemetry/exporter/otlp/grpc.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry/exporter/otlp/grpc/exporter'
+require 'opentelemetry/exporter/otlp/grpc/version'
+
+# OpenTelemetry is an open source observability framework, providing a
+# general-purpose API, SDK, and related tools required for the instrumentation
+# of cloud-native software, frameworks, and libraries.
+#
+# The OpenTelemetry module provides global accessors for telemetry objects.
+# See the documentation for the `opentelemetry-api` gem for details.
+module OpenTelemetry
+end

--- a/exporter/otlp-grpc/lib/opentelemetry/exporter/otlp/grpc.rb
+++ b/exporter/otlp-grpc/lib/opentelemetry/exporter/otlp/grpc.rb
@@ -4,9 +4,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'opentelemetry/exporter/otlp/grpc/exporter'
-require 'opentelemetry/exporter/otlp/grpc/version'
-
 # OpenTelemetry is an open source observability framework, providing a
 # general-purpose API, SDK, and related tools required for the instrumentation
 # of cloud-native software, frameworks, and libraries.
@@ -14,4 +11,14 @@ require 'opentelemetry/exporter/otlp/grpc/version'
 # The OpenTelemetry module provides global accessors for telemetry objects.
 # See the documentation for the `opentelemetry-api` gem for details.
 module OpenTelemetry
+  module Exporter
+    module OTLP
+      # GRPC contains the implementation for the OTLP over GRPC exporter
+      module GRPC
+      end
+    end
+  end
 end
+
+require 'opentelemetry/exporter/otlp/grpc/exporter'
+require 'opentelemetry/exporter/otlp/grpc/version'

--- a/exporter/otlp-grpc/lib/opentelemetry/exporter/otlp/grpc/exporter.rb
+++ b/exporter/otlp-grpc/lib/opentelemetry/exporter/otlp/grpc/exporter.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry/common'
+require 'opentelemetry/exporter/otlp/common'
+require 'opentelemetry/sdk'
+require 'grpc'
+
+require 'google/rpc/status_pb'
+require 'opentelemetry/proto/collector/trace/v1/trace_service_services_pb'
+
+module OpenTelemetry
+  module Exporter
+    module OTLP
+      module GRPC
+        # An OpenTelemetry trace exporter that sends spans over GRPC.
+        class Exporter
+          SUCCESS = OpenTelemetry::SDK::Trace::Export::SUCCESS
+          FAILURE = OpenTelemetry::SDK::Trace::Export::FAILURE
+          private_constant(:SUCCESS, :FAILURE)
+
+          def initialize(endpoint: config_opt('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', 'OTEL_EXPORTER_OTLP_ENDPOINT', default: 'http://localhost:4317/v1/traces'),
+                         timeout: config_opt('OTEL_EXPORTER_OTLP_TRACES_TIMEOUT', 'OTEL_EXPORTER_OTLP_TIMEOUT', default: 10),
+                         metrics_reporter: nil)
+            raise ArgumentError, "invalid url for OTLP::Exporter #{endpoint}" if invalid_url?(endpoint)
+
+            uri = URI(endpoint)
+
+            @client = Opentelemetry::Proto::Collector::Trace::V1::TraceService::Stub.new(
+              "#{uri.host}:#{uri.port}",
+              :this_channel_is_insecure
+            )
+
+            @timeout = timeout.to_f
+            @metrics_reporter = metrics_reporter || OpenTelemetry::SDK::Trace::Export::MetricsReporter
+            @shutdown = false
+          end
+
+          # Called to export sampled {OpenTelemetry::SDK::Trace::SpanData} structs.
+          #
+          # @param [Enumerable<OpenTelemetry::SDK::Trace::SpanData>] span_data the
+          #   list of recorded {OpenTelemetry::SDK::Trace::SpanData} structs to be
+          #   exported.
+          # @param [optional Numeric] timeout An optional timeout in seconds.
+          # @return [Integer] the result of the export.
+          def export(span_data, timeout: nil)
+            return FAILURE if @shutdown
+
+            @client.export(OpenTelemetry::Exporter::OTLP::Common.as_etsr(span_data))
+            SUCCESS
+          end
+
+          # Called when {OpenTelemetry::SDK::Trace::TracerProvider#force_flush} is called, if
+          # this exporter is registered to a {OpenTelemetry::SDK::Trace::TracerProvider}
+          # object.
+          #
+          # @param [optional Numeric] timeout An optional timeout in seconds.
+          def force_flush(timeout: nil)
+            SUCCESS
+          end
+
+          # Called when {OpenTelemetry::SDK::Trace::TracerProvider#shutdown} is called, if
+          # this exporter is registered to a {OpenTelemetry::SDK::Trace::TracerProvider}
+          # object.
+          #
+          # @param [optional Numeric] timeout An optional timeout in seconds.
+          def shutdown(timeout: nil)
+            @shutdown = true
+            SUCCESS
+          end
+
+          private
+
+          def config_opt(*env_vars, default: nil)
+            env_vars.each do |env_var|
+              val = ENV[env_var]
+              return val unless val.nil?
+            end
+            default
+          end
+
+          def invalid_url?(url)
+            return true if url.nil? || url.strip.empty?
+
+            URI(url)
+            false
+          rescue URI::InvalidURIError
+            true
+          end
+        end
+      end
+    end
+  end
+end

--- a/exporter/otlp-grpc/lib/opentelemetry/exporter/otlp/grpc/version.rb
+++ b/exporter/otlp-grpc/lib/opentelemetry/exporter/otlp/grpc/version.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Exporter
+    module OTLP
+      module GRPC
+        ## Current OpenTelemetry OTLP exporter grpc version
+        VERSION = '0.0.0'
+      end
+    end
+  end
+end

--- a/exporter/otlp-grpc/opentelemetry-exporter-otlp-grpc.gemspec
+++ b/exporter/otlp-grpc/opentelemetry-exporter-otlp-grpc.gemspec
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+lib = File.expand_path('lib', __dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'opentelemetry/exporter/otlp/version'
+
+Gem::Specification.new do |spec|
+  spec.name        = 'opentelemetry-exporter-otlp-grpc'
+  spec.version     = OpenTelemetry::Exporter::OTLP::VERSION
+  spec.authors     = ['OpenTelemetry Authors']
+  spec.email       = ['cncf-opentelemetry-contributors@lists.cncf.io']
+
+  spec.summary     = 'OTLP exporter for the OpenTelemetry framework'
+  spec.description = 'OTLP exporter for the OpenTelemetry framework'
+  spec.homepage    = 'https://github.com/open-telemetry/opentelemetry-ruby'
+  spec.license     = 'Apache-2.0'
+
+  spec.files = ::Dir.glob('lib/**/*.rb') +
+               ::Dir.glob('*.md') +
+               ['LICENSE', '.yardopts']
+  spec.require_paths = ['lib']
+  spec.required_ruby_version = '>= 2.5.0'
+
+  spec.add_dependency 'grpc'
+  spec.add_dependency 'opentelemetry-api', '~> 1.0'
+  spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
+  spec.add_dependency 'opentelemetry-exporter-otlp-common'
+  spec.add_dependency 'opentelemetry-sdk', '~> 1.0'
+
+  spec.add_development_dependency 'bundler', '>= 1.17'
+  spec.add_development_dependency 'faraday', '~> 0.13'
+  spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
+  spec.add_development_dependency 'rake', '~> 12.0'
+  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'simplecov', '~> 0.17'
+  spec.add_development_dependency 'webmock', '~> 3.7.6'
+  spec.add_development_dependency 'yard', '~> 0.9'
+  spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+
+  if spec.respond_to?(:metadata)
+    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-exporter-otlp-grpc/v#{OpenTelemetry::Exporter::OTLP::VERSION}/file.CHANGELOG.html"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/main/exporter/otlp'
+    spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/issues'
+    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-exporter-otlp-grpc/v#{OpenTelemetry::Exporter::OTLP::VERSION}"
+  end
+end

--- a/exporter/otlp-grpc/opentelemetry-exporter-otlp-grpc.gemspec
+++ b/exporter/otlp-grpc/opentelemetry-exporter-otlp-grpc.gemspec
@@ -6,11 +6,11 @@
 
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'opentelemetry/exporter/otlp/version'
+require 'opentelemetry/exporter/otlp/grpc/version'
 
 Gem::Specification.new do |spec|
   spec.name        = 'opentelemetry-exporter-otlp-grpc'
-  spec.version     = OpenTelemetry::Exporter::OTLP::VERSION
+  spec.version     = OpenTelemetry::Exporter::OTLP::GRPC::VERSION
   spec.authors     = ['OpenTelemetry Authors']
   spec.email       = ['cncf-opentelemetry-contributors@lists.cncf.io']
 
@@ -44,9 +44,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 
   if spec.respond_to?(:metadata)
-    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-exporter-otlp-grpc/v#{OpenTelemetry::Exporter::OTLP::VERSION}/file.CHANGELOG.html"
-    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/main/exporter/otlp'
+    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-exporter-otlp-grpc/v#{OpenTelemetry::Exporter::OTLP::GRPC::VERSION}/file.CHANGELOG.html"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/main/exporter/otlp-grpc'
     spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/issues'
-    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-exporter-otlp-grpc/v#{OpenTelemetry::Exporter::OTLP::VERSION}"
+    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-exporter-otlp-grpc/v#{OpenTelemetry::Exporter::OTLP::GRPC::VERSION}"
   end
 end

--- a/exporter/otlp-grpc/test/.rubocop.yml
+++ b/exporter/otlp-grpc/test/.rubocop.yml
@@ -1,0 +1,12 @@
+inherit_from: ../.rubocop.yml
+
+Metrics/BlockLength:
+  Enabled: false
+Metrics/LineLength:
+  Enabled: false
+Style/MethodCallWithoutArgsParentheses:
+  Exclude:
+    - 'opentelemetry/exporter/otlp/grpc/exporter_test.rb'
+Style/BlockDelimiters:
+  Exclude:
+   - 'opentelemetry/exporter/otlp/grpc/exporter_test.rb'

--- a/exporter/otlp-grpc/test/opentelemetry/exporter/otlp/grpc/exporter_test.rb
+++ b/exporter/otlp-grpc/test/opentelemetry/exporter/otlp/grpc/exporter_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+require 'test_helper'
+
+describe OpenTelemetry::Exporter::OTLP::GRPC::Exporter do
+  SUCCESS = OpenTelemetry::SDK::Trace::Export::SUCCESS
+  FAILURE = OpenTelemetry::SDK::Trace::Export::FAILURE
+
+  describe '#exporter' do
+    it 'integrates with collector' do
+      span_data = create_span_data
+      exporter = OpenTelemetry::Exporter::OTLP::GRPC::Exporter.new(endpoint: 'http://localhost:4317')
+      result = exporter.export([span_data])
+      _(result).must_equal(SUCCESS)
+    end
+  end
+
+  private
+
+  def create_span_data(name: '', kind: nil, status: nil, parent_span_id: OpenTelemetry::Trace::INVALID_SPAN_ID,
+                       total_recorded_attributes: 0, total_recorded_events: 0, total_recorded_links: 0, start_timestamp: OpenTelemetry::TestHelpers.exportable_timestamp,
+                       end_timestamp: OpenTelemetry::TestHelpers.exportable_timestamp, attributes: nil, links: nil, events: nil, resource: nil,
+                       instrumentation_library: OpenTelemetry::SDK::InstrumentationLibrary.new('', 'v0.0.1'),
+                       span_id: OpenTelemetry::Trace.generate_span_id, trace_id: OpenTelemetry::Trace.generate_trace_id,
+                       trace_flags: OpenTelemetry::Trace::TraceFlags::DEFAULT, tracestate: nil)
+    resource ||= OpenTelemetry::SDK::Resources::Resource.telemetry_sdk
+    OpenTelemetry::SDK::Trace::SpanData.new(name, kind, status, parent_span_id, total_recorded_attributes,
+                                            total_recorded_events, total_recorded_links, start_timestamp, end_timestamp,
+                                            attributes, links, events, resource, instrumentation_library, span_id, trace_id, trace_flags, tracestate)
+  end
+end

--- a/exporter/otlp-grpc/test/opentelemetry/exporter/otlp/grpc/exporter_test.rb
+++ b/exporter/otlp-grpc/test/opentelemetry/exporter/otlp/grpc/exporter_test.rb
@@ -11,6 +11,7 @@ describe OpenTelemetry::Exporter::OTLP::GRPC::Exporter do
 
   describe '#exporter' do
     it 'integrates with collector' do
+      skip unless ENV['TRACING_INTEGRATION_TEST']
       span_data = create_span_data
       exporter = OpenTelemetry::Exporter::OTLP::GRPC::Exporter.new(endpoint: 'http://localhost:4317')
       result = exporter.export([span_data])

--- a/exporter/otlp-grpc/test/opentelemetry/exporter/otlp/grpc/exporter_test.rb
+++ b/exporter/otlp-grpc/test/opentelemetry/exporter/otlp/grpc/exporter_test.rb
@@ -12,24 +12,10 @@ describe OpenTelemetry::Exporter::OTLP::GRPC::Exporter do
   describe '#exporter' do
     it 'integrates with collector' do
       skip unless ENV['TRACING_INTEGRATION_TEST']
-      span_data = create_span_data
+      span_data = OpenTelemetry::TestHelpers.create_span_data
       exporter = OpenTelemetry::Exporter::OTLP::GRPC::Exporter.new(endpoint: 'http://localhost:4317')
       result = exporter.export([span_data])
       _(result).must_equal(SUCCESS)
     end
-  end
-
-  private
-
-  def create_span_data(name: '', kind: nil, status: nil, parent_span_id: OpenTelemetry::Trace::INVALID_SPAN_ID,
-                       total_recorded_attributes: 0, total_recorded_events: 0, total_recorded_links: 0, start_timestamp: OpenTelemetry::TestHelpers.exportable_timestamp,
-                       end_timestamp: OpenTelemetry::TestHelpers.exportable_timestamp, attributes: nil, links: nil, events: nil, resource: nil,
-                       instrumentation_library: OpenTelemetry::SDK::InstrumentationLibrary.new('', 'v0.0.1'),
-                       span_id: OpenTelemetry::Trace.generate_span_id, trace_id: OpenTelemetry::Trace.generate_trace_id,
-                       trace_flags: OpenTelemetry::Trace::TraceFlags::DEFAULT, tracestate: nil)
-    resource ||= OpenTelemetry::SDK::Resources::Resource.telemetry_sdk
-    OpenTelemetry::SDK::Trace::SpanData.new(name, kind, status, parent_span_id, total_recorded_attributes,
-                                            total_recorded_events, total_recorded_links, start_timestamp, end_timestamp,
-                                            attributes, links, events, resource, instrumentation_library, span_id, trace_id, trace_flags, tracestate)
   end
 end

--- a/exporter/otlp-grpc/test/test_helper.rb
+++ b/exporter/otlp-grpc/test/test_helper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'simplecov'
+SimpleCov.start
+
+require 'pry'
+
+require 'opentelemetry-test-helpers'
+require 'opentelemetry/exporter/otlp/grpc'
+require 'minitest/autorun'
+require 'webmock/minitest'
+
+OpenTelemetry.logger = Logger.new(File::NULL)

--- a/exporter/otlp-http/test/opentelemetry/exporter/otlp/http/exporter_test.rb
+++ b/exporter/otlp-http/test/opentelemetry/exporter/otlp/http/exporter_test.rb
@@ -281,7 +281,7 @@ describe OpenTelemetry::Exporter::OTLP::HTTP::Exporter do
     it 'integrates with collector' do
       skip unless ENV['TRACING_INTEGRATION_TEST']
       WebMock.disable_net_connect!(allow: 'localhost')
-      span_data = create_span_data
+      span_data = OpenTelemetry::TestHelpers.create_span_data
       exporter = OpenTelemetry::Exporter::OTLP::HTTP::Exporter.new(endpoint: 'http://localhost:4318', compression: 'gzip')
       result = exporter.export([span_data])
       _(result).must_equal(SUCCESS)
@@ -289,14 +289,14 @@ describe OpenTelemetry::Exporter::OTLP::HTTP::Exporter do
 
     it 'retries on timeout' do
       stub_request(:post, 'http://localhost:4318/v1/traces').to_timeout.then.to_return(status: 200)
-      span_data = create_span_data
+      span_data = OpenTelemetry::TestHelpers.create_span_data
       result = exporter.export([span_data])
       _(result).must_equal(SUCCESS)
     end
 
     it 'returns TIMEOUT on timeout' do
       stub_request(:post, 'http://localhost:4318/v1/traces').to_return(status: 200)
-      span_data = create_span_data
+      span_data = OpenTelemetry::TestHelpers.create_span_data
       result = exporter.export([span_data], timeout: 0)
       _(result).must_equal(FAILURE)
     end
@@ -307,7 +307,7 @@ describe OpenTelemetry::Exporter::OTLP::HTTP::Exporter do
       OpenTelemetry.logger = ::Logger.new(log_stream)
 
       stub_request(:post, 'http://localhost:4318/v1/traces').to_raise('something unexpected')
-      span_data = create_span_data
+      span_data = OpenTelemetry::TestHelpers.create_span_data
       result = exporter.export([span_data], timeout: 1)
 
       _(log_stream.string).must_match(
@@ -325,7 +325,7 @@ describe OpenTelemetry::Exporter::OTLP::HTTP::Exporter do
       OpenTelemetry.logger = ::Logger.new(log_stream)
 
       stub_request(:post, 'http://localhost:4318/v1/traces').to_return(status: 200)
-      span_data = create_span_data
+      span_data = OpenTelemetry::TestHelpers.create_span_data
 
       Opentelemetry::Proto::Collector::Trace::V1::ExportTraceServiceRequest.stub(:encode, ->(_) { raise 'a little hell' }) do
         _(exporter.export([span_data], timeout: 1)).must_equal(FAILURE)
@@ -340,7 +340,7 @@ describe OpenTelemetry::Exporter::OTLP::HTTP::Exporter do
 
     it 'returns TIMEOUT on timeout after retrying' do
       stub_request(:post, 'http://localhost:4318/v1/traces').to_timeout.then.to_raise('this should not be reached')
-      span_data = create_span_data
+      span_data = OpenTelemetry::TestHelpers.create_span_data
 
       @retry_count = 0
       backoff_stubbed_call = lambda do |**_args|
@@ -365,7 +365,7 @@ describe OpenTelemetry::Exporter::OTLP::HTTP::Exporter do
     it 'returns FAILURE when encryption to receiver endpoint fails' do
       exporter = OpenTelemetry::Exporter::OTLP::HTTP::Exporter.new(endpoint: 'https://localhost:4318/v1/traces')
       stub_request(:post, 'https://localhost:4318/v1/traces').to_raise(OpenSSL::SSL::SSLError.new('enigma wedged'))
-      span_data = create_span_data
+      span_data = OpenTelemetry::TestHelpers.create_span_data
       exporter.stub(:backoff?, ->(**_) { false }) do
         _(exporter.export([span_data])).must_equal(FAILURE)
       end
@@ -373,7 +373,7 @@ describe OpenTelemetry::Exporter::OTLP::HTTP::Exporter do
 
     it 'exports a span_data' do
       stub_request(:post, 'http://localhost:4318/v1/traces').to_return(status: 200)
-      span_data = create_span_data
+      span_data = OpenTelemetry::TestHelpers.create_span_data
       result = exporter.export([span_data])
       _(result).must_equal(SUCCESS)
     end
@@ -384,7 +384,7 @@ describe OpenTelemetry::Exporter::OTLP::HTTP::Exporter do
       OpenTelemetry.logger = ::Logger.new(log_stream)
 
       stub_request(:post, 'http://localhost:4318/v1/traces').to_return(status: 200)
-      span_data = create_span_data(total_recorded_attributes: 1, attributes: { 'a' => "\xC2".dup.force_encoding(::Encoding::ASCII_8BIT) })
+      span_data = OpenTelemetry::TestHelpers.create_span_data(total_recorded_attributes: 1, attributes: { 'a' => "\xC2".dup.force_encoding(::Encoding::ASCII_8BIT) })
 
       result = exporter.export([span_data])
 
@@ -405,7 +405,7 @@ describe OpenTelemetry::Exporter::OTLP::HTTP::Exporter do
       details = [::Google::Protobuf::Any.pack(::Google::Protobuf::StringValue.new(value: 'you are a bad request'))]
       status = ::Google::Rpc::Status.encode(::Google::Rpc::Status.new(code: 1, message: 'bad request', details: details))
       stub_request(:post, 'http://localhost:4318/v1/traces').to_return(status: 400, body: status)
-      span_data = create_span_data
+      span_data = OpenTelemetry::TestHelpers.create_span_data
 
       result = exporter.export([span_data])
 
@@ -420,7 +420,7 @@ describe OpenTelemetry::Exporter::OTLP::HTTP::Exporter do
 
     it 'handles Zlib gzip compression errors' do
       stub_request(:post, 'http://localhost:4318/v1/traces').to_raise(Zlib::DataError.new('data error'))
-      span_data = create_span_data
+      span_data = OpenTelemetry::TestHelpers.create_span_data
       exporter.stub(:backoff?, ->(**_) { false }) do
         _(exporter.export([span_data])).must_equal(FAILURE)
       end
@@ -442,7 +442,7 @@ describe OpenTelemetry::Exporter::OTLP::HTTP::Exporter do
         { status: 200 }
       end
 
-      span_data = create_span_data
+      span_data = OpenTelemetry::TestHelpers.create_span_data
       result = exporter.export([span_data])
 
       _(result).must_equal(SUCCESS)
@@ -457,8 +457,8 @@ describe OpenTelemetry::Exporter::OTLP::HTTP::Exporter do
         { status: 200 }
       end
 
-      span_data1 = create_span_data(resource: OpenTelemetry::SDK::Resources::Resource.create('k1' => 'v1'))
-      span_data2 = create_span_data(resource: OpenTelemetry::SDK::Resources::Resource.create('k2' => 'v2'))
+      span_data1 = OpenTelemetry::TestHelpers.create_span_data(resource: OpenTelemetry::SDK::Resources::Resource.create('k1' => 'v1'))
+      span_data2 = OpenTelemetry::TestHelpers.create_span_data(resource: OpenTelemetry::SDK::Resources::Resource.create('k2' => 'v2'))
 
       result = exporter.export([span_data1, span_data2])
 
@@ -483,11 +483,11 @@ describe OpenTelemetry::Exporter::OTLP::HTTP::Exporter do
       end_timestamp = start_timestamp + 6
 
       OpenTelemetry.tracer_provider.add_span_processor(processor)
-      root = with_ids(trace_id, root_span_id) { tracer.start_root_span('root', kind: :internal, start_timestamp: start_timestamp) }
+      root = OpenTelemetry::TestHelpers.with_ids(trace_id, root_span_id) { tracer.start_root_span('root', kind: :internal, start_timestamp: start_timestamp) }
       root.status = OpenTelemetry::Trace::Status.ok
       root.finish(end_timestamp: end_timestamp)
       root_ctx = OpenTelemetry::Trace.context_with_span(root)
-      span = with_ids(trace_id, child_span_id) { tracer.start_span('child', with_parent: root_ctx, kind: :producer, start_timestamp: start_timestamp + 1, links: [OpenTelemetry::Trace::Link.new(root.context, 'attr' => 4)]) }
+      span = OpenTelemetry::TestHelpers.with_ids(trace_id, child_span_id) { tracer.start_span('child', with_parent: root_ctx, kind: :producer, start_timestamp: start_timestamp + 1, links: [OpenTelemetry::Trace::Link.new(root.context, 'attr' => 4)]) }
       span['b'] = true
       span['f'] = 1.1
       span['i'] = 2
@@ -495,11 +495,11 @@ describe OpenTelemetry::Exporter::OTLP::HTTP::Exporter do
       span['a'] = [3, 4]
       span.status = OpenTelemetry::Trace::Status.error
       child_ctx = OpenTelemetry::Trace.context_with_span(span)
-      client = with_ids(trace_id, client_span_id) { tracer.start_span('client', with_parent: child_ctx, kind: :client, start_timestamp: start_timestamp + 2).finish(end_timestamp: end_timestamp) }
+      client = OpenTelemetry::TestHelpers.with_ids(trace_id, client_span_id) { tracer.start_span('client', with_parent: child_ctx, kind: :client, start_timestamp: start_timestamp + 2).finish(end_timestamp: end_timestamp) }
       client_ctx = OpenTelemetry::Trace.context_with_span(client)
-      with_ids(trace_id, server_span_id) { other_tracer.start_span('server', with_parent: client_ctx, kind: :server, start_timestamp: start_timestamp + 3).finish(end_timestamp: end_timestamp) }
+      OpenTelemetry::TestHelpers.with_ids(trace_id, server_span_id) { other_tracer.start_span('server', with_parent: client_ctx, kind: :server, start_timestamp: start_timestamp + 3).finish(end_timestamp: end_timestamp) }
       span.add_event('event', attributes: { 'attr' => 42 }, timestamp: start_timestamp + 4)
-      with_ids(trace_id, consumer_span_id) { tracer.start_span('consumer', with_parent: child_ctx, kind: :consumer, start_timestamp: start_timestamp + 5).finish(end_timestamp: end_timestamp) }
+      OpenTelemetry::TestHelpers.with_ids(trace_id, consumer_span_id) { tracer.start_span('consumer', with_parent: child_ctx, kind: :consumer, start_timestamp: start_timestamp + 5).finish(end_timestamp: end_timestamp) }
       span.finish(end_timestamp: end_timestamp)
       OpenTelemetry.tracer_provider.shutdown
 
@@ -635,25 +635,5 @@ describe OpenTelemetry::Exporter::OTLP::HTTP::Exporter do
         req.body == Zlib.gzip(encoded_etsr)
       end
     end
-  end
-
-  def with_ids(trace_id, span_id)
-    OpenTelemetry::Trace.stub(:generate_trace_id, trace_id) do
-      OpenTelemetry::Trace.stub(:generate_span_id, span_id) do
-        yield
-      end
-    end
-  end
-
-  def create_span_data(name: '', kind: nil, status: nil, parent_span_id: OpenTelemetry::Trace::INVALID_SPAN_ID,
-                       total_recorded_attributes: 0, total_recorded_events: 0, total_recorded_links: 0, start_timestamp: OpenTelemetry::TestHelpers.exportable_timestamp,
-                       end_timestamp: OpenTelemetry::TestHelpers.exportable_timestamp, attributes: nil, links: nil, events: nil, resource: nil,
-                       instrumentation_library: OpenTelemetry::SDK::InstrumentationLibrary.new('', 'v0.0.1'),
-                       span_id: OpenTelemetry::Trace.generate_span_id, trace_id: OpenTelemetry::Trace.generate_trace_id,
-                       trace_flags: OpenTelemetry::Trace::TraceFlags::DEFAULT, tracestate: nil)
-    resource ||= OpenTelemetry::SDK::Resources::Resource.telemetry_sdk
-    OpenTelemetry::SDK::Trace::SpanData.new(name, kind, status, parent_span_id, total_recorded_attributes,
-                                            total_recorded_events, total_recorded_links, start_timestamp, end_timestamp,
-                                            attributes, links, events, resource, instrumentation_library, span_id, trace_id, trace_flags, tracestate)
   end
 end

--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -281,7 +281,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
     it 'integrates with collector' do
       skip unless ENV['TRACING_INTEGRATION_TEST']
       WebMock.disable_net_connect!(allow: 'localhost')
-      span_data = create_span_data
+      span_data = OpenTelemetry::TestHelpers.create_span_data
       exporter = OpenTelemetry::Exporter::OTLP::Exporter.new(endpoint: 'http://localhost:4318', compression: 'gzip')
       result = exporter.export([span_data])
       _(result).must_equal(SUCCESS)
@@ -289,14 +289,14 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
 
     it 'retries on timeout' do
       stub_request(:post, 'http://localhost:4318/v1/traces').to_timeout.then.to_return(status: 200)
-      span_data = create_span_data
+      span_data = OpenTelemetry::TestHelpers.create_span_data
       result = exporter.export([span_data])
       _(result).must_equal(SUCCESS)
     end
 
     it 'returns TIMEOUT on timeout' do
       stub_request(:post, 'http://localhost:4318/v1/traces').to_return(status: 200)
-      span_data = create_span_data
+      span_data = OpenTelemetry::TestHelpers.create_span_data
       result = exporter.export([span_data], timeout: 0)
       _(result).must_equal(FAILURE)
     end
@@ -307,7 +307,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       OpenTelemetry.logger = ::Logger.new(log_stream)
 
       stub_request(:post, 'http://localhost:4318/v1/traces').to_raise('something unexpected')
-      span_data = create_span_data
+      span_data = OpenTelemetry::TestHelpers.create_span_data
       result = exporter.export([span_data], timeout: 1)
 
       _(log_stream.string).must_match(
@@ -325,7 +325,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       OpenTelemetry.logger = ::Logger.new(log_stream)
 
       stub_request(:post, 'http://localhost:4318/v1/traces').to_return(status: 200)
-      span_data = create_span_data
+      span_data = OpenTelemetry::TestHelpers.create_span_data
 
       Opentelemetry::Proto::Collector::Trace::V1::ExportTraceServiceRequest.stub(:encode, ->(_) { raise 'a little hell' }) do
         _(exporter.export([span_data], timeout: 1)).must_equal(FAILURE)
@@ -340,7 +340,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
 
     it 'returns TIMEOUT on timeout after retrying' do
       stub_request(:post, 'http://localhost:4318/v1/traces').to_timeout.then.to_raise('this should not be reached')
-      span_data = create_span_data
+      span_data = OpenTelemetry::TestHelpers.create_span_data
 
       @retry_count = 0
       backoff_stubbed_call = lambda do |**_args|
@@ -365,7 +365,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
     it 'returns FAILURE when encryption to receiver endpoint fails' do
       exporter = OpenTelemetry::Exporter::OTLP::Exporter.new(endpoint: 'https://localhost:4318/v1/traces')
       stub_request(:post, 'https://localhost:4318/v1/traces').to_raise(OpenSSL::SSL::SSLError.new('enigma wedged'))
-      span_data = create_span_data
+      span_data = OpenTelemetry::TestHelpers.create_span_data
       exporter.stub(:backoff?, ->(**_) { false }) do
         _(exporter.export([span_data])).must_equal(FAILURE)
       end
@@ -373,7 +373,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
 
     it 'exports a span_data' do
       stub_request(:post, 'http://localhost:4318/v1/traces').to_return(status: 200)
-      span_data = create_span_data
+      span_data = OpenTelemetry::TestHelpers.create_span_data
       result = exporter.export([span_data])
       _(result).must_equal(SUCCESS)
     end
@@ -384,7 +384,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       OpenTelemetry.logger = ::Logger.new(log_stream)
 
       stub_request(:post, 'http://localhost:4318/v1/traces').to_return(status: 200)
-      span_data = create_span_data(total_recorded_attributes: 1, attributes: { 'a' => "\xC2".dup.force_encoding(::Encoding::ASCII_8BIT) })
+      span_data = OpenTelemetry::TestHelpers.create_span_data(total_recorded_attributes: 1, attributes: { 'a' => "\xC2".dup.force_encoding(::Encoding::ASCII_8BIT) })
 
       result = exporter.export([span_data])
 
@@ -405,7 +405,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       details = [::Google::Protobuf::Any.pack(::Google::Protobuf::StringValue.new(value: 'you are a bad request'))]
       status = ::Google::Rpc::Status.encode(::Google::Rpc::Status.new(code: 1, message: 'bad request', details: details))
       stub_request(:post, 'http://localhost:4318/v1/traces').to_return(status: 400, body: status)
-      span_data = create_span_data
+      span_data = OpenTelemetry::TestHelpers.create_span_data
 
       result = exporter.export([span_data])
 
@@ -420,7 +420,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
 
     it 'handles Zlib gzip compression errors' do
       stub_request(:post, 'http://localhost:4318/v1/traces').to_raise(Zlib::DataError.new('data error'))
-      span_data = create_span_data
+      span_data = OpenTelemetry::TestHelpers.create_span_data
       exporter.stub(:backoff?, ->(**_) { false }) do
         _(exporter.export([span_data])).must_equal(FAILURE)
       end
@@ -442,7 +442,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
         { status: 200 }
       end
 
-      span_data = create_span_data
+      span_data = OpenTelemetry::TestHelpers.create_span_data
       result = exporter.export([span_data])
 
       _(result).must_equal(SUCCESS)
@@ -457,8 +457,8 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
         { status: 200 }
       end
 
-      span_data1 = create_span_data(resource: OpenTelemetry::SDK::Resources::Resource.create('k1' => 'v1'))
-      span_data2 = create_span_data(resource: OpenTelemetry::SDK::Resources::Resource.create('k2' => 'v2'))
+      span_data1 = OpenTelemetry::TestHelpers.create_span_data(resource: OpenTelemetry::SDK::Resources::Resource.create('k1' => 'v1'))
+      span_data2 = OpenTelemetry::TestHelpers.create_span_data(resource: OpenTelemetry::SDK::Resources::Resource.create('k2' => 'v2'))
 
       result = exporter.export([span_data1, span_data2])
 
@@ -483,11 +483,11 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       end_timestamp = start_timestamp + 6
 
       OpenTelemetry.tracer_provider.add_span_processor(processor)
-      root = with_ids(trace_id, root_span_id) { tracer.start_root_span('root', kind: :internal, start_timestamp: start_timestamp) }
+      root = OpenTelemetry::TestHelpers.with_ids(trace_id, root_span_id) { tracer.start_root_span('root', kind: :internal, start_timestamp: start_timestamp) }
       root.status = OpenTelemetry::Trace::Status.ok
       root.finish(end_timestamp: end_timestamp)
       root_ctx = OpenTelemetry::Trace.context_with_span(root)
-      span = with_ids(trace_id, child_span_id) { tracer.start_span('child', with_parent: root_ctx, kind: :producer, start_timestamp: start_timestamp + 1, links: [OpenTelemetry::Trace::Link.new(root.context, 'attr' => 4)]) }
+      span = OpenTelemetry::TestHelpers.with_ids(trace_id, child_span_id) { tracer.start_span('child', with_parent: root_ctx, kind: :producer, start_timestamp: start_timestamp + 1, links: [OpenTelemetry::Trace::Link.new(root.context, 'attr' => 4)]) }
       span['b'] = true
       span['f'] = 1.1
       span['i'] = 2
@@ -495,11 +495,11 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       span['a'] = [3, 4]
       span.status = OpenTelemetry::Trace::Status.error
       child_ctx = OpenTelemetry::Trace.context_with_span(span)
-      client = with_ids(trace_id, client_span_id) { tracer.start_span('client', with_parent: child_ctx, kind: :client, start_timestamp: start_timestamp + 2).finish(end_timestamp: end_timestamp) }
+      client = OpenTelemetry::TestHelpers.with_ids(trace_id, client_span_id) { tracer.start_span('client', with_parent: child_ctx, kind: :client, start_timestamp: start_timestamp + 2).finish(end_timestamp: end_timestamp) }
       client_ctx = OpenTelemetry::Trace.context_with_span(client)
-      with_ids(trace_id, server_span_id) { other_tracer.start_span('server', with_parent: client_ctx, kind: :server, start_timestamp: start_timestamp + 3).finish(end_timestamp: end_timestamp) }
+      OpenTelemetry::TestHelpers.with_ids(trace_id, server_span_id) { other_tracer.start_span('server', with_parent: client_ctx, kind: :server, start_timestamp: start_timestamp + 3).finish(end_timestamp: end_timestamp) }
       span.add_event('event', attributes: { 'attr' => 42 }, timestamp: start_timestamp + 4)
-      with_ids(trace_id, consumer_span_id) { tracer.start_span('consumer', with_parent: child_ctx, kind: :consumer, start_timestamp: start_timestamp + 5).finish(end_timestamp: end_timestamp) }
+      OpenTelemetry::TestHelpers.with_ids(trace_id, consumer_span_id) { tracer.start_span('consumer', with_parent: child_ctx, kind: :consumer, start_timestamp: start_timestamp + 5).finish(end_timestamp: end_timestamp) }
       span.finish(end_timestamp: end_timestamp)
       OpenTelemetry.tracer_provider.shutdown
 
@@ -635,25 +635,5 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
         req.body == Zlib.gzip(encoded_etsr)
       end
     end
-  end
-
-  def with_ids(trace_id, span_id)
-    OpenTelemetry::Trace.stub(:generate_trace_id, trace_id) do
-      OpenTelemetry::Trace.stub(:generate_span_id, span_id) do
-        yield
-      end
-    end
-  end
-
-  def create_span_data(name: '', kind: nil, status: nil, parent_span_id: OpenTelemetry::Trace::INVALID_SPAN_ID,
-                       total_recorded_attributes: 0, total_recorded_events: 0, total_recorded_links: 0, start_timestamp: OpenTelemetry::TestHelpers.exportable_timestamp,
-                       end_timestamp: OpenTelemetry::TestHelpers.exportable_timestamp, attributes: nil, links: nil, events: nil, resource: nil,
-                       instrumentation_library: OpenTelemetry::SDK::InstrumentationLibrary.new('', 'v0.0.1'),
-                       span_id: OpenTelemetry::Trace.generate_span_id, trace_id: OpenTelemetry::Trace.generate_trace_id,
-                       trace_flags: OpenTelemetry::Trace::TraceFlags::DEFAULT, tracestate: nil)
-    resource ||= OpenTelemetry::SDK::Resources::Resource.telemetry_sdk
-    OpenTelemetry::SDK::Trace::SpanData.new(name, kind, status, parent_span_id, total_recorded_attributes,
-                                            total_recorded_events, total_recorded_links, start_timestamp, end_timestamp,
-                                            attributes, links, events, resource, instrumentation_library, span_id, trace_id, trace_flags, tracestate)
   end
 end

--- a/test_helpers/lib/opentelemetry/test_helpers.rb
+++ b/test_helpers/lib/opentelemetry/test_helpers.rb
@@ -54,5 +54,25 @@ module OpenTelemetry
       env_to_reset.each_pair { |k, v| ENV[k] = v }
       keys_to_delete.each { |k| ENV.delete(k) }
     end
+
+    def with_ids(trace_id, span_id)
+      OpenTelemetry::Trace.stub(:generate_trace_id, trace_id) do
+        OpenTelemetry::Trace.stub(:generate_span_id, span_id) do
+          yield
+        end
+      end
+    end
+
+    def create_span_data(name: '', kind: nil, status: nil, parent_span_id: OpenTelemetry::Trace::INVALID_SPAN_ID,
+                         total_recorded_attributes: 0, total_recorded_events: 0, total_recorded_links: 0, start_timestamp: OpenTelemetry::TestHelpers.exportable_timestamp,
+                         end_timestamp: OpenTelemetry::TestHelpers.exportable_timestamp, attributes: nil, links: nil, events: nil, resource: nil,
+                         instrumentation_library: OpenTelemetry::SDK::InstrumentationLibrary.new('', 'v0.0.1'),
+                         span_id: OpenTelemetry::Trace.generate_span_id, trace_id: OpenTelemetry::Trace.generate_trace_id,
+                         trace_flags: OpenTelemetry::Trace::TraceFlags::DEFAULT, tracestate: nil)
+      resource ||= OpenTelemetry::SDK::Resources::Resource.telemetry_sdk
+      OpenTelemetry::SDK::Trace::SpanData.new(name, kind, status, parent_span_id, total_recorded_attributes,
+                                              total_recorded_events, total_recorded_links, start_timestamp, end_timestamp,
+                                              attributes, links, events, resource, instrumentation_library, span_id, trace_id, trace_flags, tracestate)
+    end
   end
 end


### PR DESCRIPTION
Implements a starting point for a OTLP via GRPC exporter.  This implementation currently has no error handling, and must not be considered production ready.

Follow on from https://github.com/open-telemetry/opentelemetry-ruby/pull/1179