### PR TITLE
chore: Updates opentelemetry-collector docker image

### DIFF
--- a/examples/otel-collector/.env
+++ b/examples/otel-collector/.env
@@ -1,2 +1,2 @@
-OTELCOL_IMG=otel/opentelemetry-collector:0.35.0
+OTELCOL_IMG=otel/opentelemetry-collector-contrib:0.35.0
 OTELCOL_ARGS=


### PR DESCRIPTION
Since `examples/otel-collector` might be the first contact for ruby developers with `otel-collector`, using the `contrib` docker image version in `OTELCOL_IMG` variable makes easier to explore the example with exporters included only on `contrib` docker image version (eg: datadog). It should not conflict with https://github.com/open-telemetry/opentelemetry-ruby/pull/970 since the image version still pinned.