### PR TITLE
chore: Remove Local Path Gem Dependencies

### DIFF
--- a/common/Gemfile
+++ b/common/Gemfile
@@ -8,9 +8,8 @@ source 'https://rubygems.org'
 
 gemspec
 
-# Use the opentelemetry-api gem from source
-gem 'opentelemetry-api', path: '../api'
-
 group :development, :test do
+  # Use the opentelemetry-api gem from source
+  gem 'opentelemetry-api', path: '../api'
   gem 'pry'
 end

--- a/exporter/jaeger/Gemfile
+++ b/exporter/jaeger/Gemfile
@@ -8,13 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
-# Use the opentelemetry-api gem from source
-gem 'opentelemetry-api', path: '../../api'
-gem 'opentelemetry-common', path: '../../common'
-gem 'opentelemetry-instrumentation-base', path: '../../instrumentation/base'
-gem 'opentelemetry-sdk', path: '../../sdk'
-gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions'
-
 group :test, :development do
+  gem 'opentelemetry-api', path: '../../api'
+  gem 'opentelemetry-common', path: '../../common'
+  gem 'opentelemetry-sdk', path: '../../sdk'
+  gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions'
   gem 'opentelemetry-test-helpers', path: '../../test_helpers'
 end

--- a/exporter/jaeger/opentelemetry-exporter-jaeger.gemspec
+++ b/exporter/jaeger/opentelemetry-exporter-jaeger.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
   spec.add_dependency 'opentelemetry-sdk', '~> 1.0'
+  spec.add_dependency 'opentelemetry-semantic_conventions'
   spec.add_dependency 'thrift'
 
   spec.add_development_dependency 'bundler', '>= 1.17'

--- a/exporter/otlp/Gemfile
+++ b/exporter/otlp/Gemfile
@@ -8,13 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
-# Use the opentelemetry-api gem from source
-gem 'opentelemetry-api', path: '../../api'
-gem 'opentelemetry-common', path: '../../common'
-gem 'opentelemetry-instrumentation-base', path: '../../instrumentation/base'
-gem 'opentelemetry-sdk', path: '../../sdk'
-gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions'
-
 group :test, :development do
+  gem 'opentelemetry-api', path: '../../api'
+  gem 'opentelemetry-common', path: '../../common'
+  gem 'opentelemetry-sdk', path: '../../sdk'
+  gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions'
   gem 'opentelemetry-test-helpers', path: '../../test_helpers'
 end

--- a/exporter/otlp/opentelemetry-exporter-otlp.gemspec
+++ b/exporter/otlp/opentelemetry-exporter-otlp.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
   spec.add_dependency 'opentelemetry-sdk', '~> 1.0'
+  spec.add_dependency 'opentelemetry-semantic_conventions'
 
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'faraday', '~> 0.13'

--- a/exporter/zipkin/Gemfile
+++ b/exporter/zipkin/Gemfile
@@ -8,13 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
-# Use the opentelemetry-api gem from source
-gem 'opentelemetry-api', path: '../../api'
-gem 'opentelemetry-common', path: '../../common'
-gem 'opentelemetry-instrumentation-base', path: '../../instrumentation/base'
-gem 'opentelemetry-sdk', path: '../../sdk'
-gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions'
-
 group :test, :development do
+  gem 'opentelemetry-api', path: '../../api'
+  gem 'opentelemetry-common', path: '../../common'
+  gem 'opentelemetry-sdk', path: '../../sdk'
+  gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions'
   gem 'opentelemetry-test-helpers', path: '../../test_helpers'
 end

--- a/exporter/zipkin/opentelemetry-exporter-zipkin.gemspec
+++ b/exporter/zipkin/opentelemetry-exporter-zipkin.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
   spec.add_dependency 'opentelemetry-sdk', '~> 1.0'
+  spec.add_dependency 'opentelemetry-semantic_conventions'
 
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'faraday', '~> 0.13'

--- a/metrics_api/Gemfile
+++ b/metrics_api/Gemfile
@@ -8,9 +8,8 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'opentelemetry-api', path: '../api'
-
 group :test, :development do
+  gem 'opentelemetry-api', path: '../api'
   gem 'pry'
   gem 'pry-byebug' unless RUBY_ENGINE == 'jruby'
 end

--- a/propagator/b3/Gemfile
+++ b/propagator/b3/Gemfile
@@ -8,5 +8,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'opentelemetry-api', path: '../../api'
-gem 'opentelemetry-instrumentation-base', path: '../../instrumentation/base'
+group :test do
+  gem 'opentelemetry-api', path: '../../api'
+end

--- a/propagator/jaeger/Gemfile
+++ b/propagator/jaeger/Gemfile
@@ -12,4 +12,3 @@ group :test do
   gem 'opentelemetry-api', path: '../../api'
   gem 'opentelemetry-sdk', path: '../../sdk'
 end
-

--- a/propagator/jaeger/Gemfile
+++ b/propagator/jaeger/Gemfile
@@ -8,8 +8,8 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'opentelemetry-api', path: '../../api'
-gem 'opentelemetry-common', path: '../../common'
-gem 'opentelemetry-instrumentation-base', path: '../../instrumentation/base'
-gem 'opentelemetry-sdk', path: '../../sdk'
-gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions'
+group :test do
+  gem 'opentelemetry-api', path: '../../api'
+  gem 'opentelemetry-sdk', path: '../../sdk'
+end
+

--- a/propagator/ottrace/Gemfile
+++ b/propagator/ottrace/Gemfile
@@ -4,9 +4,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in opentelemetry-propragator-ottrace.gemspec
 gemspec
-
-gem 'opentelemetry-api', path: '../../api'
-gem 'opentelemetry-common', path: '../../common'
-gem 'opentelemetry-instrumentation-base', path: '../../instrumentation/base'
-gem 'opentelemetry-sdk', path: '../../sdk'
-gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions'

--- a/propagator/ottrace/opentelemetry-propagator-ottrace.gemspec
+++ b/propagator/ottrace/opentelemetry-propagator-ottrace.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'minitest', '~> 5.0'
-  spec.add_development_dependency 'opentelemetry-sdk', '~> 1.0'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rubocop', '~> 0.73.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'

--- a/propagator/ottrace/test/test_helper.rb
+++ b/propagator/ottrace/test/test_helper.rb
@@ -12,7 +12,7 @@ end
 
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'minitest/autorun'
-require 'opentelemetry/sdk'
+require 'opentelemetry-api'
 require 'opentelemetry-propagator-ottrace'
 
 OpenTelemetry.logger = Logger.new(File::NULL)

--- a/propagator/xray/Gemfile
+++ b/propagator/xray/Gemfile
@@ -7,6 +7,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-gem 'opentelemetry-api', path: '../../api'
-gem 'opentelemetry-instrumentation-base', path: '../../instrumentation/base'

--- a/registry/Gemfile
+++ b/registry/Gemfile
@@ -8,4 +8,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'opentelemetry-api', path: '../api'
+group :test do
+  gem 'opentelemetry-api', path: '../api'
+end

--- a/resource_detectors/Gemfile
+++ b/resource_detectors/Gemfile
@@ -8,12 +8,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'opentelemetry-api', path: '../api'
-gem 'opentelemetry-common', path: '../common'
-gem 'opentelemetry-instrumentation-base', path: '../instrumentation/base'
-gem 'opentelemetry-sdk', path: '../sdk'
-gem 'opentelemetry-semantic_conventions', path: '../semantic_conventions'
-
 group :development, :test do
   gem 'byebug' unless RUBY_PLATFORM == 'java'
   gem 'pry'

--- a/sdk/Gemfile
+++ b/sdk/Gemfile
@@ -8,13 +8,10 @@ source 'https://rubygems.org'
 
 gemspec
 
-# Use the opentelemetry-api gem from source
-gem 'opentelemetry-api', path: '../api'
-gem 'opentelemetry-common', path: '../common'
-gem 'opentelemetry-exporter-zipkin', path: '../exporter/zipkin'
-gem 'opentelemetry-instrumentation-base', path: '../instrumentation/base'
-gem 'opentelemetry-semantic_conventions', path: '../semantic_conventions'
-
 group :test, :development do
+  gem 'opentelemetry-api', path: '../api'
+  gem 'opentelemetry-common', path: '../common'
+  gem 'opentelemetry-exporter-zipkin', path: '../exporter/zipkin'
+  gem 'opentelemetry-semantic_conventions', path: '../semantic_conventions'
   gem 'opentelemetry-test-helpers', path: '../test_helpers'
 end

--- a/semantic_conventions/Gemfile
+++ b/semantic_conventions/Gemfile
@@ -8,9 +8,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-# Use the opentelemetry-api gem from source
-gem 'opentelemetry-api', path: '../api'
-
 group :development, :test do
+  gem 'opentelemetry-api', path: '../api'
   gem 'pry'
 end

--- a/test_helpers/Gemfile
+++ b/test_helpers/Gemfile
@@ -10,8 +10,5 @@ gemspec
 
 group :test, :development do
   gem 'opentelemetry-api', path: '../api'
-  gem 'opentelemetry-common', path: '../common'
-  gem 'opentelemetry-instrumentation-base', path: '../instrumentation/base'
   gem 'opentelemetry-sdk', path: '../sdk'
-  gem 'opentelemetry-semantic_conventions', path: '../semantic_conventions'
 end

--- a/test_helpers/opentelemetry-test-helpers.gemspec
+++ b/test_helpers/opentelemetry-test-helpers.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'opentelemetry-sdk'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
   spec.add_development_dependency 'rake', '~> 12.0'

--- a/test_helpers/test/test_helper.rb
+++ b/test_helpers/test/test_helper.rb
@@ -4,8 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'opentelemetry'
-require 'opentelemetry/sdk'
+require 'opentelemetry-sdk'
 require 'opentelemetry-test-helpers'
 require 'minitest/autorun'
 require 'pry'


### PR DESCRIPTION
Additional step to decouple the contrib packages from the main repo that are outside of the instrumentation directory

See open-telemetry/opentelemetry-ruby-contrib#1