### PR TITLE
fix: SpanLimits setting event attributes length limit

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/span_limits.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span_limits.rb
@@ -24,6 +24,9 @@ module OpenTelemetry
         # The global default max number of attributes per {OpenTelemetry::SDK::Trace::Event}.
         attr_reader :event_attribute_count_limit
 
+        # The global default max length of attribute value per {OpenTelemetry::SDK::Trace::Event}.
+        attr_reader :event_attribute_length_limit
+
         # The global default max number of attributes per {OpenTelemetry::Trace::Link}.
         attr_reader :link_attribute_count_limit
 
@@ -36,12 +39,15 @@ module OpenTelemetry
                        event_count_limit: Integer(OpenTelemetry::Common::Utilities.config_opt('OTEL_SPAN_EVENT_COUNT_LIMIT', default: 128)),
                        link_count_limit: Integer(OpenTelemetry::Common::Utilities.config_opt('OTEL_SPAN_LINK_COUNT_LIMIT', default: 128)),
                        event_attribute_count_limit: Integer(OpenTelemetry::Common::Utilities.config_opt('OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT', default: 128)),
+                       event_attribute_length_limit: OpenTelemetry::Common::Utilities.config_opt('OTEL_EVENT_ATTRIBUTE_VALUE_LENGTH_LIMIT', 'OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT'),
                        link_attribute_count_limit: Integer(OpenTelemetry::Common::Utilities.config_opt('OTEL_LINK_ATTRIBUTE_COUNT_LIMIT', default: 128)))
+
           raise ArgumentError, 'attribute_count_limit must be positive' unless attribute_count_limit.positive?
           raise ArgumentError, 'attribute_length_limit must not be less than 32' unless attribute_length_limit.nil? || Integer(attribute_length_limit) >= 32
           raise ArgumentError, 'event_count_limit must be positive' unless event_count_limit.positive?
           raise ArgumentError, 'link_count_limit must be positive' unless link_count_limit.positive?
           raise ArgumentError, 'event_attribute_count_limit must be positive' unless event_attribute_count_limit.positive?
+          raise ArgumentError, 'event_attribute_length_limit must not be less than 32' unless event_attribute_length_limit.nil? || Integer(event_attribute_length_limit) >= 32
           raise ArgumentError, 'link_attribute_count_limit must be positive' unless link_attribute_count_limit.positive?
 
           @attribute_count_limit = attribute_count_limit
@@ -49,6 +55,7 @@ module OpenTelemetry
           @event_count_limit = event_count_limit
           @link_count_limit = link_count_limit
           @event_attribute_count_limit = event_attribute_count_limit
+          @event_attribute_length_limit = event_attribute_length_limit.nil? ? nil : Integer(event_attribute_length_limit)
           @link_attribute_count_limit = link_attribute_count_limit
         end
 

--- a/sdk/test/opentelemetry/sdk/trace/span_limits_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/span_limits_test.rb
@@ -111,7 +111,6 @@ describe OpenTelemetry::SDK::Trace::SpanLimits do
                                           'OTEL_ATTRIBUTE_COUNT_LIMIT' => '2',
                                           'OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '32',
                                           'OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '33') do
-
         _(span_limits.attribute_count_limit).must_equal 1
         _(span_limits.attribute_length_limit).must_equal 32
       end

--- a/sdk/test/opentelemetry/sdk/trace/span_limits_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/span_limits_test.rb
@@ -101,9 +101,8 @@ describe OpenTelemetry::SDK::Trace::SpanLimits do
     it 'reflects generic attribute env vars' do
       OpenTelemetry::TestHelpers.with_env('OTEL_ATTRIBUTE_COUNT_LIMIT' => '1',
                                           'OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '32') do
-        config = subject.new
-        _(config.attribute_count_limit).must_equal 1
-        _(config.attribute_length_limit).must_equal 32
+        _(span_limits.attribute_count_limit).must_equal 1
+        _(span_limits.attribute_length_limit).must_equal 32
       end
     end
 
@@ -112,9 +111,9 @@ describe OpenTelemetry::SDK::Trace::SpanLimits do
                                           'OTEL_ATTRIBUTE_COUNT_LIMIT' => '2',
                                           'OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '32',
                                           'OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '33') do
-        config = subject.new
-        _(config.attribute_count_limit).must_equal 1
-        _(config.attribute_length_limit).must_equal 32
+
+        _(span_limits.attribute_count_limit).must_equal 1
+        _(span_limits.attribute_length_limit).must_equal 32
       end
     end
   end

--- a/sdk/test/opentelemetry/sdk/trace/span_limits_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/span_limits_test.rb
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require 'test_helper'
-require 'pry'
+
 describe OpenTelemetry::SDK::Trace::SpanLimits do
   let(:span_limits) { OpenTelemetry::SDK::Trace::SpanLimits.new }
 

--- a/sdk/test/opentelemetry/sdk/trace/span_limits_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/span_limits_test.rb
@@ -12,9 +12,11 @@ describe OpenTelemetry::SDK::Trace::SpanLimits do
   describe '#initialize' do
     it 'provides defaults' do
       _(span_limits.attribute_count_limit).must_equal 128
+      _(span_limits.attribute_length_limit).must_be_nil
       _(span_limits.event_count_limit).must_equal 128
       _(span_limits.link_count_limit).must_equal 128
       _(span_limits.event_attribute_count_limit).must_equal 128
+      _(span_limits.event_attribute_length_limit).must_be_nil
       _(span_limits.link_attribute_count_limit).must_equal 128
     end
 

--- a/sdk/test/opentelemetry/sdk/trace/span_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/span_test.rb
@@ -22,7 +22,8 @@ describe OpenTelemetry::SDK::Trace::Span do
       link_count_limit: 1,
       event_attribute_count_limit: 1,
       link_attribute_count_limit: 1,
-      attribute_length_limit: 32
+      attribute_length_limit: 32,
+      event_attribute_length_limit: 32
     )
   end
   let(:span) do


### PR DESCRIPTION
The spec allows for generic and more specific configuration of attribute length limits. https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/README.md#attribute-limits

However we are currently applying legacy and span specific attribute environment variables to the event attribute length limit.

`OTEL_EVENT_ATTRIBUTE_VALUE_LENGTH_LIMIT` should take priority over `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT`.

`OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` and `OTEL_RUBY_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` should not configure the event attributes length limit.

Both span attribute length limit and event attribute length limit should use the more general `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT` in the event a more specific configuration is not supplied.