### PR TITLE
fix: Rails 7.0.3 test suite incompatibility

### DIFF
--- a/instrumentation/delayed_job/test/test_helper.rb
+++ b/instrumentation/delayed_job/test/test_helper.rb
@@ -4,6 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require 'active_support/core_ext/kernel/reporting'
 require 'delayed_job'
 require 'delayed_job_active_record'
 


### PR DESCRIPTION
It is possible that a transitive require statement was removed in this PR https://github.com/rails/rails/pull/44340/files

It is likely that in most Rails production workloads this will not be a problem since the Rails Railtie requires `kernel/reporting`.

https://github.com/rails/rails/blob/8ace32c4ccdc760d17548de777b08c13bc9e07bd/railties/lib/rails.rb#L8

Fixes: https://github.com/open-telemetry/opentelemetry-ruby/issues/1234
cc: https://github.com/collectiveidea/delayed_job/issues/1168