### PR TITLE
Feat: Add url, and config_opt helpers

### DIFF
--- a/common/lib/opentelemetry/common/utilities.rb
+++ b/common/lib/opentelemetry/common/utilities.rb
@@ -101,6 +101,36 @@ module OpenTelemetry
         url
       end
 
+      # Returns the first non nil environment variable requested,
+      # or the default value if provided.
+      #
+      # @param [String] env_vars The environment variable(s) to retrieve
+      # @param default The fallback value to return if the requested
+      #  env var(s) are not present
+      #
+      # @returns [String]
+      def config_opt(*env_vars, default: nil)
+        env_vars.each do |env_var|
+          val = ENV[env_var]
+          return val unless val.nil?
+        end
+        default
+      end
+
+      # Returns a true if the provided url is invalid
+      #
+      # @param [String] url the URL string to test validity
+      #
+      # @return [boolean]
+      def invalid_url?(url)
+        return true if url.nil? || url.strip.empty?
+
+        URI(url)
+        false
+      rescue URI::InvalidURIError
+        true
+      end
+
       # Returns true if exporter is a valid exporter.
       def valid_exporter?(exporter)
         exporter && %i[export shutdown force_flush].all? { |m| exporter.respond_to?(m) }

--- a/common/lib/opentelemetry/common/utilities.rb
+++ b/common/lib/opentelemetry/common/utilities.rb
@@ -113,7 +113,7 @@ module OpenTelemetry
         ENV.values_at(*env_vars).compact.fetch(0, default)
       end
 
-      # Returns a true if the provided url is invalid
+      # Returns a true if the provided url is valid
       #
       # @param [String] url the URL string to test validity
       #

--- a/common/lib/opentelemetry/common/utilities.rb
+++ b/common/lib/opentelemetry/common/utilities.rb
@@ -110,7 +110,7 @@ module OpenTelemetry
       #
       # @returns [String]
       def config_opt(*env_vars, default: nil)
-        ENV.values_at(env_vars).compact.fetch(0, default)
+        ENV.values_at(*env_vars).compact.fetch(0, default)
       end
 
       # Returns a true if the provided url is invalid
@@ -118,13 +118,13 @@ module OpenTelemetry
       # @param [String] url the URL string to test validity
       #
       # @return [boolean]
-      def invalid_url?(url)
+      def valid_url?(url)
         return true if url.nil? || url.strip.empty?
 
         URI(url)
-        false
-      rescue URI::InvalidURIError
         true
+      rescue URI::InvalidURIError
+        false
       end
 
       # Returns true if exporter is a valid exporter.

--- a/common/lib/opentelemetry/common/utilities.rb
+++ b/common/lib/opentelemetry/common/utilities.rb
@@ -110,11 +110,7 @@ module OpenTelemetry
       #
       # @returns [String]
       def config_opt(*env_vars, default: nil)
-        env_vars.each do |env_var|
-          val = ENV[env_var]
-          return val unless val.nil?
-        end
-        default
+        ENV.values_at(env_vars).compact.fetch(0, default)
       end
 
       # Returns a true if the provided url is invalid

--- a/common/lib/opentelemetry/common/utilities.rb
+++ b/common/lib/opentelemetry/common/utilities.rb
@@ -119,7 +119,7 @@ module OpenTelemetry
       #
       # @return [boolean]
       def valid_url?(url)
-        return true if url.nil? || url.strip.empty?
+        return false if url.nil? || url.strip.empty?
 
         URI(url)
         true

--- a/common/opentelemetry-common.gemspec
+++ b/common/opentelemetry-common.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rubocop', '~> 0.73.0'
   spec.add_development_dependency 'simplecov', '~> 0.17'

--- a/common/test/opentelemetry/common/utilities_test.rb
+++ b/common/test/opentelemetry/common/utilities_test.rb
@@ -60,4 +60,38 @@ describe OpenTelemetry::Common::Utilities do
       _(common_utils.valid_exporter?({})).must_equal false
     end
   end
+
+  describe '#invalid_url?' do
+    it 'returns true if it is an invalid uri' do
+      _(common_utils.invalid_url?('123:123')).must_equal(true)
+    end
+
+    it 'returns false if it is a valid uri' do
+      _(common_utils.invalid_url?('http://example.com')).must_equal(false)
+    end
+  end
+
+  describe '#config_opt' do
+    it 'returns the env var' do
+      OpenTelemetry::TestHelpers.with_env('a' => 'b') do
+        _(common_utils.config_opt('a', default: 'bar')).must_equal('b')
+      end
+    end
+
+    it 'returns the first requested env var' do
+      OpenTelemetry::TestHelpers.with_env('a' => 'b', 'c' => 'd') do
+        _(common_utils.config_opt('a', 'b', default: 'bar')).must_equal('b')
+      end
+    end
+
+    it 'returns the second requested env var if the first is not set' do
+      OpenTelemetry::TestHelpers.with_env('c' => 'd') do
+        _(common_utils.config_opt('a', 'c', default: 'bar')).must_equal('d')
+      end
+    end
+
+    it 'returns the default value when no env var is set' do
+      _(common_utils.config_opt('a', 'b', default: 'foo')).must_equal('foo')
+    end
+  end
 end

--- a/common/test/opentelemetry/common/utilities_test.rb
+++ b/common/test/opentelemetry/common/utilities_test.rb
@@ -62,12 +62,20 @@ describe OpenTelemetry::Common::Utilities do
   end
 
   describe '#valid_url?' do
+    it 'returns true if it is a valid uri' do
+      _(common_utils.valid_url?('http://example.com')).must_equal(true)
+    end
+
     it 'returns false if it is not a valid uri' do
       _(common_utils.valid_url?('123:123')).must_equal(false)
     end
 
-    it 'returns true if it is a valid uri' do
-      _(common_utils.valid_url?('http://example.com')).must_equal(true)
+    it 'returns false if it is nil' do
+      _(common_utils.valid_url?(nil)).must_equal(false)
+    end
+
+    it 'returns false if it is an empty string' do
+      _(common_utils.valid_url?('')).must_equal(false)
     end
   end
 

--- a/common/test/opentelemetry/common/utilities_test.rb
+++ b/common/test/opentelemetry/common/utilities_test.rb
@@ -61,13 +61,13 @@ describe OpenTelemetry::Common::Utilities do
     end
   end
 
-  describe '#invalid_url?' do
-    it 'returns true if it is an invalid uri' do
-      _(common_utils.invalid_url?('123:123')).must_equal(true)
+  describe '#valid_url?' do
+    it 'returns false if it is not a valid uri' do
+      _(common_utils.valid_url?('123:123')).must_equal(false)
     end
 
-    it 'returns false if it is a valid uri' do
-      _(common_utils.invalid_url?('http://example.com')).must_equal(false)
+    it 'returns true if it is a valid uri' do
+      _(common_utils.valid_url?('http://example.com')).must_equal(true)
     end
   end
 

--- a/common/test/test_helper.rb
+++ b/common/test/test_helper.rb
@@ -7,6 +7,7 @@
 require 'simplecov'
 SimpleCov.start
 
+require 'opentelemetry-test-helpers'
 require 'opentelemetry/common'
 require 'minitest/autorun'
 require 'pry'


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-ruby/pull/1180#discussion_r874159643

- config_opt is repeated in 4 places
- invalid_url? is repeated in 5 places