### PR TITLE
Refactor: common exporter methods

### DIFF
--- a/exporter/jaeger/lib/opentelemetry/exporter/jaeger/collector_exporter.rb
+++ b/exporter/jaeger/lib/opentelemetry/exporter/jaeger/collector_exporter.rb
@@ -30,7 +30,7 @@ module OpenTelemetry
                        password: ENV['OTEL_EXPORTER_JAEGER_PASSWORD'],
                        timeout: ENV.fetch('OTEL_EXPORTER_JAEGER_TIMEOUT', 10),
                        ssl_verify_mode: CollectorExporter.ssl_verify_mode)
-          raise ArgumentError, "invalid url for Jaeger::CollectorExporter #{endpoint}" if invalid_url?(endpoint)
+          raise ArgumentError, "invalid url for Jaeger::CollectorExporter #{endpoint}" unless OpenTelemetry::Common::Utilities.valid_url?(endpoint)
           raise ArgumentError, 'username and password should either both be nil or both be set' if username.nil? != password.nil?
 
           transport_opts = { ssl_verify_mode: Integer(ssl_verify_mode) }
@@ -87,15 +87,6 @@ module OpenTelemetry
         end
 
         private
-
-        def invalid_url?(url)
-          return true if url.nil? || url.strip.empty?
-
-          URI(url)
-          false
-        rescue URI::InvalidURIError
-          true
-        end
 
         def encoded_batches(span_data)
           span_data.group_by(&:resource).map do |resource, spans|

--- a/exporter/jaeger/opentelemetry-exporter-jaeger.gemspec
+++ b/exporter/jaeger/opentelemetry-exporter-jaeger.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.6.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
+  spec.add_dependency 'opentelemetry-common', '~> 0.19.6'
   spec.add_dependency 'opentelemetry-sdk', '~> 1.0'
   spec.add_dependency 'opentelemetry-semantic_conventions'
   spec.add_dependency 'thrift'

--- a/exporter/otlp-grpc/lib/opentelemetry/exporter/otlp/grpc/exporter.rb
+++ b/exporter/otlp-grpc/lib/opentelemetry/exporter/otlp/grpc/exporter.rb
@@ -22,8 +22,8 @@ module OpenTelemetry
           FAILURE = OpenTelemetry::SDK::Trace::Export::FAILURE
           private_constant(:SUCCESS, :FAILURE)
 
-          def initialize(endpoint: config_opt('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', 'OTEL_EXPORTER_OTLP_ENDPOINT', default: 'http://localhost:4317/v1/traces'),
-                         timeout: config_opt('OTEL_EXPORTER_OTLP_TRACES_TIMEOUT', 'OTEL_EXPORTER_OTLP_TIMEOUT', default: 10),
+          def initialize(endpoint: OpenTelemetry::Common::Utilities.config_opt('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', 'OTEL_EXPORTER_OTLP_ENDPOINT', default: 'http://localhost:4317/v1/traces'),
+                         timeout: OpenTelemetry::Common::Utilities.config_opt('OTEL_EXPORTER_OTLP_TRACES_TIMEOUT', 'OTEL_EXPORTER_OTLP_TIMEOUT', default: 10),
                          metrics_reporter: nil)
             raise ArgumentError, "invalid url for OTLP::Exporter #{endpoint}" unless OpenTelemetry::Common::Utilities.valid_url?(endpoint)
 
@@ -70,16 +70,6 @@ module OpenTelemetry
           def shutdown(timeout: nil)
             @shutdown = true
             SUCCESS
-          end
-
-          private
-
-          def config_opt(*env_vars, default: nil)
-            env_vars.each do |env_var|
-              val = ENV[env_var]
-              return val unless val.nil?
-            end
-            default
           end
         end
       end

--- a/exporter/otlp-grpc/lib/opentelemetry/exporter/otlp/grpc/exporter.rb
+++ b/exporter/otlp-grpc/lib/opentelemetry/exporter/otlp/grpc/exporter.rb
@@ -25,7 +25,7 @@ module OpenTelemetry
           def initialize(endpoint: config_opt('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', 'OTEL_EXPORTER_OTLP_ENDPOINT', default: 'http://localhost:4317/v1/traces'),
                          timeout: config_opt('OTEL_EXPORTER_OTLP_TRACES_TIMEOUT', 'OTEL_EXPORTER_OTLP_TIMEOUT', default: 10),
                          metrics_reporter: nil)
-            raise ArgumentError, "invalid url for OTLP::Exporter #{endpoint}" if invalid_url?(endpoint)
+            raise ArgumentError, "invalid url for OTLP::Exporter #{endpoint}" unless OpenTelemetry::Common::Utilities.valid_url?(endpoint)
 
             uri = URI(endpoint)
 
@@ -80,15 +80,6 @@ module OpenTelemetry
               return val unless val.nil?
             end
             default
-          end
-
-          def invalid_url?(url)
-            return true if url.nil? || url.strip.empty?
-
-            URI(url)
-            false
-          rescue URI::InvalidURIError
-            true
           end
         end
       end

--- a/exporter/otlp-grpc/opentelemetry-exporter-otlp-grpc.gemspec
+++ b/exporter/otlp-grpc/opentelemetry-exporter-otlp-grpc.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'grpc'
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
+  spec.add_dependency 'opentelemetry-common', '~> 0.19.6'
   spec.add_dependency 'opentelemetry-exporter-otlp-common'
   spec.add_dependency 'opentelemetry-sdk', '~> 1.0'
 

--- a/exporter/otlp-http/lib/opentelemetry/exporter/otlp/http/exporter.rb
+++ b/exporter/otlp-http/lib/opentelemetry/exporter/otlp/http/exporter.rb
@@ -39,7 +39,7 @@ module OpenTelemetry
                          compression: config_opt('OTEL_EXPORTER_OTLP_TRACES_COMPRESSION', 'OTEL_EXPORTER_OTLP_COMPRESSION', default: 'gzip'),
                          timeout: config_opt('OTEL_EXPORTER_OTLP_TRACES_TIMEOUT', 'OTEL_EXPORTER_OTLP_TIMEOUT', default: 10),
                          metrics_reporter: nil)
-            raise ArgumentError, "invalid url for OTLP::Exporter #{endpoint}" if invalid_url?(endpoint)
+            raise ArgumentError, "invalid url for OTLP::Exporter #{endpoint}" unless OpenTelemetry::Common::Utilities.valid_url?(endpoint)
             raise ArgumentError, "unsupported compression key #{compression}" unless compression.nil? || %w[gzip none].include?(compression)
 
             @uri = if endpoint == ENV['OTEL_EXPORTER_OTLP_ENDPOINT']
@@ -123,15 +123,6 @@ module OpenTelemetry
               return val unless val.nil?
             end
             default
-          end
-
-          def invalid_url?(url)
-            return true if url.nil? || url.strip.empty?
-
-            URI(url)
-            false
-          rescue URI::InvalidURIError
-            true
           end
 
           # The around_request is a private method that provides an extension

--- a/exporter/otlp-http/lib/opentelemetry/exporter/otlp/http/exporter.rb
+++ b/exporter/otlp-http/lib/opentelemetry/exporter/otlp/http/exporter.rb
@@ -32,12 +32,12 @@ module OpenTelemetry
           ERROR_MESSAGE_INVALID_HEADERS = 'headers must be a String with comma-separated URL Encoded UTF-8 k=v pairs or a Hash'
           private_constant(:ERROR_MESSAGE_INVALID_HEADERS)
 
-          def initialize(endpoint: config_opt('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', 'OTEL_EXPORTER_OTLP_ENDPOINT', default: 'http://localhost:4318/v1/traces'), # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-                         certificate_file: config_opt('OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE', 'OTEL_EXPORTER_OTLP_CERTIFICATE'),
+          def initialize(endpoint: OpenTelemetry::Common::Utilities.config_opt('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', 'OTEL_EXPORTER_OTLP_ENDPOINT', default: 'http://localhost:4318/v1/traces'), # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+                         certificate_file: OpenTelemetry::Common::Utilities.config_opt('OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE', 'OTEL_EXPORTER_OTLP_CERTIFICATE'),
                          ssl_verify_mode: fetch_ssl_verify_mode,
-                         headers: config_opt('OTEL_EXPORTER_OTLP_TRACES_HEADERS', 'OTEL_EXPORTER_OTLP_HEADERS', default: {}),
-                         compression: config_opt('OTEL_EXPORTER_OTLP_TRACES_COMPRESSION', 'OTEL_EXPORTER_OTLP_COMPRESSION', default: 'gzip'),
-                         timeout: config_opt('OTEL_EXPORTER_OTLP_TRACES_TIMEOUT', 'OTEL_EXPORTER_OTLP_TIMEOUT', default: 10),
+                         headers: OpenTelemetry::Common::Utilities.config_opt('OTEL_EXPORTER_OTLP_TRACES_HEADERS', 'OTEL_EXPORTER_OTLP_HEADERS', default: {}),
+                         compression: OpenTelemetry::Common::Utilities.config_opt('OTEL_EXPORTER_OTLP_TRACES_COMPRESSION', 'OTEL_EXPORTER_OTLP_COMPRESSION', default: 'gzip'),
+                         timeout: OpenTelemetry::Common::Utilities.config_opt('OTEL_EXPORTER_OTLP_TRACES_TIMEOUT', 'OTEL_EXPORTER_OTLP_TIMEOUT', default: 10),
                          metrics_reporter: nil)
             raise ArgumentError, "invalid url for OTLP::Exporter #{endpoint}" unless OpenTelemetry::Common::Utilities.valid_url?(endpoint)
             raise ArgumentError, "unsupported compression key #{compression}" unless compression.nil? || %w[gzip none].include?(compression)
@@ -115,14 +115,6 @@ module OpenTelemetry
             http.ca_file = certificate_file unless certificate_file.nil?
             http.keep_alive_timeout = KEEP_ALIVE_TIMEOUT
             http
-          end
-
-          def config_opt(*env_vars, default: nil)
-            env_vars.each do |env_var|
-              val = ENV[env_var]
-              return val unless val.nil?
-            end
-            default
           end
 
           # The around_request is a private method that provides an extension

--- a/exporter/otlp-http/opentelemetry-exporter-otlp-http.gemspec
+++ b/exporter/otlp-http/opentelemetry-exporter-otlp-http.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.6.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
+  spec.add_dependency 'opentelemetry-common', '~> 0.19.6'
   spec.add_dependency 'opentelemetry-exporter-otlp-common'
   spec.add_dependency 'opentelemetry-sdk', '~> 1.0'
 

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -52,7 +52,7 @@ module OpenTelemetry
                        compression: config_opt('OTEL_EXPORTER_OTLP_TRACES_COMPRESSION', 'OTEL_EXPORTER_OTLP_COMPRESSION', default: 'gzip'),
                        timeout: config_opt('OTEL_EXPORTER_OTLP_TRACES_TIMEOUT', 'OTEL_EXPORTER_OTLP_TIMEOUT', default: 10),
                        metrics_reporter: nil)
-          raise ArgumentError, "invalid url for OTLP::Exporter #{endpoint}" if invalid_url?(endpoint)
+          raise ArgumentError, "invalid url for OTLP::Exporter #{endpoint}" unless OpenTelemetry::Common::Utilities.valid_url?(endpoint)
           raise ArgumentError, "unsupported compression key #{compression}" unless compression.nil? || %w[gzip none].include?(compression)
 
           @uri = if endpoint == ENV['OTEL_EXPORTER_OTLP_ENDPOINT']
@@ -126,15 +126,6 @@ module OpenTelemetry
             return val unless val.nil?
           end
           default
-        end
-
-        def invalid_url?(url)
-          return true if url.nil? || url.strip.empty?
-
-          URI(url)
-          false
-        rescue URI::InvalidURIError
-          true
         end
 
         # The around_request is a private method that provides an extension

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -45,12 +45,12 @@ module OpenTelemetry
           end
         end
 
-        def initialize(endpoint: config_opt('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', 'OTEL_EXPORTER_OTLP_ENDPOINT', default: 'http://localhost:4318/v1/traces'), # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-                       certificate_file: config_opt('OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE', 'OTEL_EXPORTER_OTLP_CERTIFICATE'),
+        def initialize(endpoint: OpenTelemetry::Common::Utilities.config_opt('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', 'OTEL_EXPORTER_OTLP_ENDPOINT', default: 'http://localhost:4318/v1/traces'), # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+                       certificate_file: OpenTelemetry::Common::Utilities.config_opt('OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE', 'OTEL_EXPORTER_OTLP_CERTIFICATE'),
                        ssl_verify_mode: Exporter.ssl_verify_mode,
-                       headers: config_opt('OTEL_EXPORTER_OTLP_TRACES_HEADERS', 'OTEL_EXPORTER_OTLP_HEADERS', default: {}),
-                       compression: config_opt('OTEL_EXPORTER_OTLP_TRACES_COMPRESSION', 'OTEL_EXPORTER_OTLP_COMPRESSION', default: 'gzip'),
-                       timeout: config_opt('OTEL_EXPORTER_OTLP_TRACES_TIMEOUT', 'OTEL_EXPORTER_OTLP_TIMEOUT', default: 10),
+                       headers: OpenTelemetry::Common::Utilities.config_opt('OTEL_EXPORTER_OTLP_TRACES_HEADERS', 'OTEL_EXPORTER_OTLP_HEADERS', default: {}),
+                       compression: OpenTelemetry::Common::Utilities.config_opt('OTEL_EXPORTER_OTLP_TRACES_COMPRESSION', 'OTEL_EXPORTER_OTLP_COMPRESSION', default: 'gzip'),
+                       timeout: OpenTelemetry::Common::Utilities.config_opt('OTEL_EXPORTER_OTLP_TRACES_TIMEOUT', 'OTEL_EXPORTER_OTLP_TIMEOUT', default: 10),
                        metrics_reporter: nil)
           raise ArgumentError, "invalid url for OTLP::Exporter #{endpoint}" unless OpenTelemetry::Common::Utilities.valid_url?(endpoint)
           raise ArgumentError, "unsupported compression key #{compression}" unless compression.nil? || %w[gzip none].include?(compression)
@@ -118,14 +118,6 @@ module OpenTelemetry
           http.ca_file = certificate_file unless certificate_file.nil?
           http.keep_alive_timeout = KEEP_ALIVE_TIMEOUT
           http
-        end
-
-        def config_opt(*env_vars, default: nil)
-          env_vars.each do |env_var|
-            val = ENV[env_var]
-            return val unless val.nil?
-          end
-          default
         end
 
         # The around_request is a private method that provides an extension

--- a/exporter/otlp/opentelemetry-exporter-otlp.gemspec
+++ b/exporter/otlp/opentelemetry-exporter-otlp.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'google-protobuf', '~> 3.19'
   spec.add_dependency 'googleapis-common-protos-types', '~> 1.3'
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
+  spec.add_dependency 'opentelemetry-common', '~> 0.19.6'
   spec.add_dependency 'opentelemetry-sdk', '~> 1.0'
   spec.add_dependency 'opentelemetry-semantic_conventions'
 

--- a/exporter/zipkin/lib/opentelemetry/exporter/zipkin/exporter.rb
+++ b/exporter/zipkin/lib/opentelemetry/exporter/zipkin/exporter.rb
@@ -27,9 +27,9 @@ module OpenTelemetry
         WRITE_TIMEOUT_SUPPORTED = Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6')
         private_constant(:KEEP_ALIVE_TIMEOUT, :RETRY_COUNT, :WRITE_TIMEOUT_SUPPORTED)
 
-        def initialize(endpoint: config_opt('OTEL_EXPORTER_ZIPKIN_ENDPOINT', default: 'http://localhost:9411/api/v2/spans'),
-                       headers: config_opt('OTEL_EXPORTER_ZIPKIN_TRACES_HEADERS', 'OTEL_EXPORTER_ZIPKIN_HEADERS'),
-                       timeout: config_opt('OTEL_EXPORTER_ZIPKIN_TRACES_TIMEOUT', 'OTEL_EXPORTER_ZIPKIN_TIMEOUT', default: 10))
+        def initialize(endpoint: OpenTelemetry::Common::Utilities.config_opt('OTEL_EXPORTER_ZIPKIN_ENDPOINT', default: 'http://localhost:9411/api/v2/spans'),
+                       headers: OpenTelemetry::Common::Utilities.config_opt('OTEL_EXPORTER_ZIPKIN_TRACES_HEADERS', 'OTEL_EXPORTER_ZIPKIN_HEADERS'),
+                       timeout: OpenTelemetry::Common::Utilities.config_opt('OTEL_EXPORTER_ZIPKIN_TRACES_TIMEOUT', 'OTEL_EXPORTER_ZIPKIN_TIMEOUT', default: 10))
           raise ArgumentError, "invalid url for Zipkin::Exporter #{endpoint}" unless OpenTelemetry::Common::Utilities.valid_url?(endpoint)
           raise ArgumentError, 'headers must be comma-separated k=v pairs or a Hash' unless valid_headers?(headers)
 
@@ -93,14 +93,6 @@ module OpenTelemetry
         end
 
         private
-
-        def config_opt(*env_vars, default: nil)
-          env_vars.each do |env_var|
-            val = ENV[env_var]
-            return val unless val.nil?
-          end
-          default
-        end
 
         def encode_spans(span_data)
           span_data.map! { |span| Transformer.to_zipkin_span(span, span.resource) }

--- a/exporter/zipkin/lib/opentelemetry/exporter/zipkin/exporter.rb
+++ b/exporter/zipkin/lib/opentelemetry/exporter/zipkin/exporter.rb
@@ -30,7 +30,7 @@ module OpenTelemetry
         def initialize(endpoint: config_opt('OTEL_EXPORTER_ZIPKIN_ENDPOINT', default: 'http://localhost:9411/api/v2/spans'),
                        headers: config_opt('OTEL_EXPORTER_ZIPKIN_TRACES_HEADERS', 'OTEL_EXPORTER_ZIPKIN_HEADERS'),
                        timeout: config_opt('OTEL_EXPORTER_ZIPKIN_TRACES_TIMEOUT', 'OTEL_EXPORTER_ZIPKIN_TIMEOUT', default: 10))
-          raise ArgumentError, "invalid url for Zipkin::Exporter #{endpoint}" if invalid_url?(endpoint)
+          raise ArgumentError, "invalid url for Zipkin::Exporter #{endpoint}" unless OpenTelemetry::Common::Utilities.valid_url?(endpoint)
           raise ArgumentError, 'headers must be comma-separated k=v pairs or a Hash' unless valid_headers?(headers)
 
           @uri = if endpoint == ENV['OTEL_EXPORTER_ZIPKIN_ENDPOINT']
@@ -108,15 +108,6 @@ module OpenTelemetry
 
         def around_request
           OpenTelemetry::Common::Utilities.untraced { yield }
-        end
-
-        def invalid_url?(url)
-          return true if url.nil? || url.strip.empty?
-
-          URI(url)
-          false
-        rescue URI::InvalidURIError
-          true
         end
 
         def valid_headers?(headers)

--- a/exporter/zipkin/opentelemetry-exporter-zipkin.gemspec
+++ b/exporter/zipkin/opentelemetry-exporter-zipkin.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.6.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
-  spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
+  spec.add_dependency 'opentelemetry-common', '~> 0.19.6'
   spec.add_dependency 'opentelemetry-sdk', '~> 1.0'
   spec.add_dependency 'opentelemetry-semantic_conventions'
 


### PR DESCRIPTION
Follow up from https://github.com/open-telemetry/opentelemetry-ruby/pull/1263

Uses common utils for repeated methods.