### PR TITLE
Validate Gem dependencies before release

### DIFF
--- a/.github/workflows/release-request.yml
+++ b/.github/workflows/release-request.yml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Install Toys
         run: "gem install --no-document toys"
+      - name: Validate OpenTelemetry internal gem dependencies
+        run: "rake each:validate_otel_dependencies"
       - name: Open release pull request
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-request.yml
+++ b/.github/workflows/release-request.yml
@@ -23,8 +23,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Install Toys
         run: "gem install --no-document toys"
-      - name: Validate OpenTelemetry internal gem dependencies
-        run: "rake each:validate_otel_dependencies"
       - name: Open release pull request
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-gem-dependencies.yml
+++ b/.github/workflows/validate-gem-dependencies.yml
@@ -1,0 +1,24 @@
+name: Validate Gem Dependencies
+
+on:
+  push:
+    branches:
+      - 'release/*'
+
+jobs:
+  validate_gems:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby' }}
+    env:
+      ruby_version: "2.7"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Ruby ${{ env.ruby_version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.ruby_version }}
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Install rubygems API
+        run: "gem install --no-document gems"
+      - name: Validate OpenTelemetry internal gem dependencies
+        run: "rake each:validate_otel_dependencies"

--- a/Rakefile
+++ b/Rakefile
@@ -6,27 +6,59 @@
 
 namespace :each do
   task :bundle_install do
-    foreach_gem('bundle install')
+    foreach_gem { do_cmd('bundle install') }
   end
 
   task :bundle_update do
-    foreach_gem('bundle update')
+    foreach_gem { do_cmd('bundle update') }
   end
 
   task :test do
-    foreach_gem('bundle exec rake test')
+    foreach_gem { do_cmd('bundle exec rake test') }
   end
 
   task :yard do
-    foreach_gem('bundle exec rake yard')
+    foreach_gem { do_cmd('bundle exec rake yard') }
   end
 
   task :rubocop do
-    foreach_gem('bundle exec rake rubocop')
+    foreach_gem { do_cmd('bundle exec rake rubocop') }
   end
 
   task :default do
-    foreach_gem('bundle exec rake')
+    foreach_gem { do_cmd('bundle exec rake') }
+  end
+
+  task :validate_otel_dependencies do
+    gems = {}
+
+    foreach_gem do |name|
+      puts "***** Loading #{name}.gemspec"
+      spec = Gem::Specification::load("#{name}.gemspec")
+      gems[spec.name] = spec
+    end
+
+    gems.each do |gem_name, gem_spec|
+      puts "**** Validating OpenTelemetry dependencies for #{gem_name}"
+      gem_spec.dependencies.select { |s| s.name =~ /^opentelemetry/ }.each do |gem_dependency|
+        print "***** Checking for #{gem_dependency}"
+        other_gem_spec = gems[gem_dependency.name]
+
+        if other_gem_spec.nil?
+          puts ' ❌'
+          puts "****** Didn't find a spec for #{gem_dependency.name} - is this a valid opentelemetry-ruby gem?"
+          exit 1
+        end
+
+        if !gem_dependency.matches_spec?(other_gem_spec)
+          puts ' ❌'
+          puts "****** Dependency not satisfied!"
+          exit 1
+        end
+
+        puts ' ✅'
+      end
+    end
   end
 end
 
@@ -34,19 +66,23 @@ task each: 'each:default'
 
 task default: [:each]
 
-def foreach_gem(cmd)
+def do_cmd(cmd)
+  if defined?(Bundler)
+    Bundler.with_clean_env do
+      sh(cmd)
+    end
+  else
+    sh(cmd)
+  end
+end
+
+def foreach_gem(&block)
   Dir.glob("**/opentelemetry-*.gemspec") do |gemspec|
     name = File.basename(gemspec, ".gemspec")
     dir = File.dirname(gemspec)
     puts "**** Entering #{dir}"
     Dir.chdir(dir) do
-      if defined?(Bundler)
-        Bundler.with_clean_env do
-          sh(cmd)
-        end
-      else
-        sh(cmd)
-      end
+      yield name
     end
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -30,33 +30,80 @@ namespace :each do
   end
 
   task :validate_otel_dependencies do
-    gems = {}
+    require 'gems'
+    require 'pathname'
 
-    foreach_gem do |name|
-      puts "***** Loading #{name}.gemspec"
-      spec = Gem::Specification::load("#{name}.gemspec")
-      gems[spec.name] = spec
+    gem_specs = {}
+    rubygems_versions = {}
+
+    changed_gems = `git diff --name-only FETCH_HEAD...main *.gemspec`.split("\n").map do |gemspec|
+      Pathname.new(gemspec).basename.sub(/\.gemspec/, '')
     end
 
-    gems.each do |gem_name, gem_spec|
+    foreach_gem do |name|
+      puts "***** Getting info for #{name}"
+
+      puts "****** Loading #{name}.gemspec"
+      spec = Gem::Specification::load("#{name}.gemspec")
+      gem_specs[spec.name] = spec
+
+      puts "****** Getting latest released version of #{name} from rubygems.org"
+      begin
+        rubygems_versions[name] = Gems.info(name)
+      rescue Gems::NotFound
+        puts "******* #{name} not found on rubygems.org, trying to continue..."
+      end
+    end
+
+    gem_specs.each do |gem_name, gem_spec|
       puts "**** Validating OpenTelemetry dependencies for #{gem_name}"
       gem_spec.dependencies.select { |s| s.name =~ /^opentelemetry/ }.each do |gem_dependency|
         print "***** Checking for #{gem_dependency}"
-        other_gem_spec = gems[gem_dependency.name]
 
-        if other_gem_spec.nil?
-          puts ' ❌'
-          puts "****** Didn't find a spec for #{gem_dependency.name} - is this a valid opentelemetry-ruby gem?"
-          exit 1
+        # Are we releasing this dependency right now?
+        if changed_gems.include?(gem_dependency.name)
+          # If so, let's find the gemspec for the to-be-released version...
+          other_gem_spec = gems[gem_dependency.name]
+          if gem_dependency.matches_spec?(other_gem_spec)
+            # Great, it matches, we're good. Provided the release succeeds...
+            puts ' ✅'
+          else
+            # Whoops - we're not releasing a version that will satisfy the dependency.
+            puts ' ❌'
+            puts "****** Dependency not satisfied!"
+            puts "****** #{gem_name} required #{gem_dependency}"
+            puts "****** We are releasing #{gem_dependency.name} in this PR, but we will be releasing version #{other_gem_spec.version}!"
+            exit 1
+          end
+        else
+          # We are not releasing this dependency right now, so we should make sure that
+          # the latest version on rubygems.org will satisfy the dependency.
+          gem_info = rubygems_versions[gem_dependency.name]
+          if gem_info.nil?
+            puts ' ❌'
+            puts "****** Dependency not satisfied!"
+            puts "****** #{gem_name} required #{gem_dependency}"
+            puts "****** We are not releasing #{gem_dependency.name}, and it isn't published to rubygems.org!"
+            exit 1
+          end
+
+          other_gem_spec = Gem::Specification.new do |s|
+            s.name = gem_info["name"]
+            s.version = gem_info["version"]
+          end
+
+          if gem_dependency.matches_spec?(other_gem_spec)
+            # Great, it matches, we're good. Provided the release succeeds...
+            puts ' ✅'
+          else
+            # Whoops - we're not releasing a version that will satisfy the dependency.
+            puts ' ❌'
+            puts "****** Dependency not satisfied!"
+            puts "****** #{gem_name} required #{gem_dependency}"
+            puts "****** The latest version on rubygems.org is #{other_gem_spec.version}!"
+            exit 1
+          end
         end
-
-        if !gem_dependency.matches_spec?(other_gem_spec)
-          puts ' ❌'
-          puts "****** Dependency not satisfied!"
-          exit 1
-        end
-
-        puts ' ✅'
       end
     end
   end


### PR DESCRIPTION
This PR adds a way to check that the gems we are releasing will not be broken upon said release.

We run this check as a GitHub action that only fires on pushes to `release/**` branches, and we accomplish it by:
- Getting a list of changed gemspecs in this PR (ie: the things we will be releasing)
- Loading *all* gemspecs in the repo
- Loading the latest released version of every gem in the repo, directly from rubygems.org
- For each gemspec in the repo, we then check the dependencies:
  - If the dependency is included in this release request, we check that the dependency will be satisifed by interrogating the loaded gemspecs directly.
  - If the dependency is *not* included in this release request, we then construct a fake gemspec with the info on rubygems.org, and then see if it's a match.

We'll fail if there is a gem dependency that doesn't satisfy the version constraints based on what we're about to release or what's already available on rubygems.org - or if it's not published at all.

It's kinda hard to test this locally, so I'm not 100% if the `changed_gems` logic with `FETCH_HEAD` works correctly.