### PR TITLE
fix: Trace parent could have span_id as nil

### DIFF
--- a/api/lib/opentelemetry/trace/propagation/trace_context/trace_parent.rb
+++ b/api/lib/opentelemetry/trace/propagation/trace_context/trace_parent.rb
@@ -33,7 +33,11 @@ module OpenTelemetry
             # Creates a new {TraceParent} from a supplied {Trace::SpanContext}
             # @param [SpanContext] ctx The span context
             # @return [TraceParent] a trace parent
+            # @raise [InvalidTraceIDError] on an invalid trace_id
+            # @raise [InvalidSpanIDError] on an invalid span_id
             def from_span_context(ctx)
+              raise InvalidSpanIDError if ctx.span_id.nil?
+              raise InvalidTraceIDError if ctx.trace_id.nil?
               new(trace_id: ctx.trace_id, span_id: ctx.span_id, flags: ctx.trace_flags)
             end
 

--- a/api/test/opentelemetry/trace/propagation/trace_context/trace_parent_test.rb
+++ b/api/test/opentelemetry/trace/propagation/trace_context/trace_parent_test.rb
@@ -22,6 +22,17 @@ describe OpenTelemetry::Trace::Propagation::TraceContext::TraceParent do
     it 'should be lowercase' do
       _(good.to_s).must_equal good.to_s.downcase
     end
+
+    it 'should make a traceparent from a span context with empty span' do
+      sp = OpenTelemetry::Trace::SpanContext.new(span_id: nil)
+      
+      _(proc {
+        TraceParent.from_span_context(sp)
+      }).must_raise TraceParent::InvalidSpanIDError
+      
+      # tp = TraceParent.from_span_context(sp)
+      # _(tp.to_s).must_equal ""
+    end
   end
 
   it 'should make a traceparent from a span context' do


### PR DESCRIPTION
I have flood of warning messages:
```
W, [2022-05-24T15:29:12.276061 #12246]  WARN -- : Error in CompositePropagator#inject undefined method `unpack1' for nil:NilClass

            "00-#{trace_id.unpack1('H*')}-#{span_id.unpack1('H*')}-#{flag_string}"
                                                   ^^^^^^^^
.../project/vendor/bundle/ruby/3.1.0/gems/opentelemetry-api-1.0.1/lib/opentelemetry/trace/propagation/trace_context/trace_parent.rb:109:in `to_s'
.../project/vendor/bundle/ruby/3.1.0/gems/opentelemetry-api-1.0.1/lib/opentelemetry/trace/propagation/trace_context/text_map_propagator.rb:30:in `inject'
.../project/vendor/bundle/ruby/3.1.0/gems/opentelemetry-api-1.0.1/lib/opentelemetry/context/propagation/composite_text_map_propagator.rb:62:in `block in inject'
.../project/vendor/bundle/ruby/3.1.0/gems/opentelemetry-api-1.0.1/lib/opentelemetry/context/propagation/composite_text_map_propagator.rb:61:in `each'
.../project/vendor/bundle/ruby/3.1.0/gems/opentelemetry-api-1.0.1/lib/opentelemetry/context/propagation/composite_text_map_propagator.rb:61:in `inject'
.../project/vendor/bundle/ruby/3.1.0/gems/opentelemetry-instrumentation-net_http-0.19.3/lib/opentelemetry/instrumentation/net/http/patches/instrumentation.rb:33:in `block in request'
.../project/vendor/bundle/ruby/3.1.0/gems/opentelemetry-api-1.0.1/lib/opentelemetry/trace/tracer.rb:29:in `block in in_span'
.../project/vendor/bundle/ruby/3.1.0/gems/opentelemetry-api-1.0.1/lib/opentelemetry/trace.rb:82:in `block in with_span'
.../project/vendor/bundle/ruby/3.1.0/gems/opentelemetry-api-1.0.1/lib/opentelemetry/context.rb:87:in `with_value'
.../project/vendor/bundle/ruby/3.1.0/gems/opentelemetry-api-1.0.1/lib/opentelemetry/trace.rb:82:in `with_span'
.../project/vendor/bundle/ruby/3.1.0/gems/opentelemetry-api-1.0.1/lib/opentelemetry/trace/tracer.rb:29:in `in_span'
...
```