### PR TITLE
fix: Omit `nil` `net.peer.name` attributes

### DIFF
--- a/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
+++ b/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
@@ -44,9 +44,9 @@ module OpenTelemetry
           def span_creation_attributes(http_method:, url:)
             instrumentation_attrs = {
               'http.method' => http_method,
-              'http.url' => url.to_s,
-              'net.peer.name' => url.host
+              'http.url' => url.to_s
             }
+            instrumentation_attrs['net.peer.name'] = url.host unless url.host.nil?
             config = Faraday::Instrumentation.instance.config
             instrumentation_attrs['peer.service'] = config[:peer_service] if config[:peer_service]
             instrumentation_attrs.merge!(

--- a/instrumentation/faraday/opentelemetry-instrumentation-faraday.gemspec
+++ b/instrumentation/faraday/opentelemetry-instrumentation-faraday.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.0'
   spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
   spec.add_development_dependency 'rubocop', '~> 0.73.0'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'webmock', '~> 3.7.6'

--- a/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
+++ b/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
@@ -43,83 +43,108 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
       instrumentation.install
     end
 
-    it 'has http 200 attributes' do
-      response = client.get('/success')
+    describe 'given a client with a base url' do
+      it 'has http 200 attributes' do
+        response = client.get('/success')
 
-      _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['http.method']).must_equal 'GET'
-      _(span.attributes['http.status_code']).must_equal 200
-      _(span.attributes['http.url']).must_equal 'http://example.com/success'
-      _(span.attributes['net.peer.name']).must_equal 'example.com'
-      _(response.env.request_headers['Traceparent']).must_equal(
-        "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
-      )
-    end
-
-    it 'has http.status_code 404' do
-      response = client.get('/not_found')
-
-      _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['http.method']).must_equal 'GET'
-      _(span.attributes['http.status_code']).must_equal 404
-      _(span.attributes['http.url']).must_equal 'http://example.com/not_found'
-      _(span.attributes['net.peer.name']).must_equal 'example.com'
-      _(response.env.request_headers['Traceparent']).must_equal(
-        "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
-      )
-    end
-
-    it 'has http.status_code 500' do
-      response = client.get('/failure')
-
-      _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['http.method']).must_equal 'GET'
-      _(span.attributes['http.status_code']).must_equal 500
-      _(span.attributes['http.url']).must_equal 'http://example.com/failure'
-      _(span.attributes['net.peer.name']).must_equal 'example.com'
-      _(response.env.request_headers['Traceparent']).must_equal(
-        "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
-      )
-    end
-
-    it 'merges http client attributes' do
-      client_context_attrs = {
-        'test.attribute' => 'test.value', 'http.method' => 'OVERRIDE'
-      }
-      response = OpenTelemetry::Common::HTTP::ClientContext.with_attributes(client_context_attrs) do
-        client.get('/success')
+        _(span.name).must_equal 'HTTP GET'
+        _(span.attributes['http.method']).must_equal 'GET'
+        _(span.attributes['http.status_code']).must_equal 200
+        _(span.attributes['http.url']).must_equal 'http://example.com/success'
+        _(span.attributes['net.peer.name']).must_equal 'example.com'
+        _(response.env.request_headers['Traceparent']).must_equal(
+          "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
+        )
       end
 
-      _(span.name).must_equal 'HTTP GET'
-      _(span.attributes['http.method']).must_equal 'OVERRIDE'
-      _(span.attributes['http.status_code']).must_equal 200
-      _(span.attributes['http.url']).must_equal 'http://example.com/success'
-      _(span.attributes['net.peer.name']).must_equal 'example.com'
-      _(span.attributes['test.attribute']).must_equal 'test.value'
-      _(response.env.request_headers['Traceparent']).must_equal(
-        "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
-      )
-    end
+      it 'has http.status_code 404' do
+        response = client.get('/not_found')
 
-    it 'accepts peer service name from config' do
-      instrumentation.instance_variable_set(:@installed, false)
-      instrumentation.install(peer_service: 'example:faraday')
-
-      client.get('/success')
-
-      _(span.attributes['peer.service']).must_equal 'example:faraday'
-    end
-
-    it 'prioritizes context attributes over config for peer service name' do
-      instrumentation.instance_variable_set(:@installed, false)
-      instrumentation.install(peer_service: 'example:faraday')
-
-      client_context_attrs = { 'peer.service' => 'example:custom' }
-      OpenTelemetry::Common::HTTP::ClientContext.with_attributes(client_context_attrs) do
-        client.get('/success')
+        _(span.name).must_equal 'HTTP GET'
+        _(span.attributes['http.method']).must_equal 'GET'
+        _(span.attributes['http.status_code']).must_equal 404
+        _(span.attributes['http.url']).must_equal 'http://example.com/not_found'
+        _(span.attributes['net.peer.name']).must_equal 'example.com'
+        _(response.env.request_headers['Traceparent']).must_equal(
+          "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
+        )
       end
 
-      _(span.attributes['peer.service']).must_equal 'example:custom'
+      it 'has http.status_code 500' do
+        response = client.get('/failure')
+
+        _(span.name).must_equal 'HTTP GET'
+        _(span.attributes['http.method']).must_equal 'GET'
+        _(span.attributes['http.status_code']).must_equal 500
+        _(span.attributes['http.url']).must_equal 'http://example.com/failure'
+        _(span.attributes['net.peer.name']).must_equal 'example.com'
+        _(response.env.request_headers['Traceparent']).must_equal(
+          "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
+        )
+      end
+
+      it 'merges http client attributes' do
+        client_context_attrs = {
+          'test.attribute' => 'test.value', 'http.method' => 'OVERRIDE'
+        }
+        response = OpenTelemetry::Common::HTTP::ClientContext.with_attributes(client_context_attrs) do
+          client.get('/success')
+        end
+
+        _(span.name).must_equal 'HTTP GET'
+        _(span.attributes['http.method']).must_equal 'OVERRIDE'
+        _(span.attributes['http.status_code']).must_equal 200
+        _(span.attributes['http.url']).must_equal 'http://example.com/success'
+        _(span.attributes['net.peer.name']).must_equal 'example.com'
+        _(span.attributes['test.attribute']).must_equal 'test.value'
+        _(response.env.request_headers['Traceparent']).must_equal(
+          "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
+        )
+      end
+
+      it 'accepts peer service name from config' do
+        instrumentation.instance_variable_set(:@installed, false)
+        instrumentation.install(peer_service: 'example:faraday')
+
+        client.get('/success')
+
+        _(span.attributes['peer.service']).must_equal 'example:faraday'
+      end
+
+      it 'prioritizes context attributes over config for peer service name' do
+        instrumentation.instance_variable_set(:@installed, false)
+        instrumentation.install(peer_service: 'example:faraday')
+
+        client_context_attrs = { 'peer.service' => 'example:custom' }
+        OpenTelemetry::Common::HTTP::ClientContext.with_attributes(client_context_attrs) do
+          client.get('/success')
+        end
+
+        _(span.attributes['peer.service']).must_equal 'example:custom'
+      end
+    end
+    describe 'given a client without a base url' do
+      let(:client) do
+        ::Faraday.new do |builder|
+          builder.adapter(:test) do |stub|
+            stub.get('/success') { |_| [200, {}, 'OK'] }
+          end
+        end
+      end
+
+      it 'omits missing attributes' do
+        response = client.get('/success')
+        # debugger
+
+        _(span.name).must_equal 'HTTP GET'
+        _(span.attributes['http.method']).must_equal 'GET'
+        _(span.attributes['http.status_code']).must_equal 200
+        _(span.attributes['http.url']).must_equal 'http:/success'
+        _(span.attributes).wont_include('net.peer.name')
+        _(response.env.request_headers['Traceparent']).must_equal(
+          "00-#{span.hex_trace_id}-#{span.hex_span_id}-01"
+        )
+      end
     end
   end
 end

--- a/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
+++ b/instrumentation/faraday/test/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware_test.rb
@@ -123,6 +123,7 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
         _(span.attributes['peer.service']).must_equal 'example:custom'
       end
     end
+
     describe 'given a client without a base url' do
       let(:client) do
         ::Faraday.new do |builder|
@@ -134,7 +135,6 @@ describe OpenTelemetry::Instrumentation::Faraday::Middlewares::TracerMiddleware 
 
       it 'omits missing attributes' do
         response = client.get('/success')
-        # debugger
 
         _(span.name).must_equal 'HTTP GET'
         _(span.attributes['http.method']).must_equal 'GET'

--- a/instrumentation/faraday/test/test_helper.rb
+++ b/instrumentation/faraday/test/test_helper.rb
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require 'bundler/setup'
-Bundler.require(:development, :test)
+Bundler.require(:default, :development, :test)
 
 require 'minitest/autorun'
 require 'webmock/minitest'

--- a/instrumentation/faraday/test/test_helper.rb
+++ b/instrumentation/faraday/test/test_helper.rb
@@ -4,10 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'faraday'
-
-require 'opentelemetry/sdk'
-require 'opentelemetry-test-helpers'
+require 'bundler/setup'
+Bundler.require(:development, :test)
 
 require 'minitest/autorun'
 require 'webmock/minitest'
@@ -17,5 +15,6 @@ EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
 span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(EXPORTER)
 
 OpenTelemetry::SDK.configure do |c|
+  c.error_handler = ->(exception:, message:) { raise(exception || message) }
   c.add_span_processor span_processor
 end


### PR DESCRIPTION
Faraday uses a base URL to derive the host name which is used by the tracer middleware as the span attribute value for `net.peer.name`.

Although it seems incorrect, Faraday does not require a base URL when it is initialized and is a commonly used when using Faraday test stubs.

When the base URL is absent, the `net.peer.name` is set to `nil` triggering and invalid attribute error report and creates a bit of noise for test cases.

This change omits the `net.peer.name` attribute when it is `nil` to suppress error reporting when the host is absent.