### PR TITLE
refactor: Remove duplication logic in start_span

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/tracer.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/tracer.rb
@@ -9,8 +9,6 @@ module OpenTelemetry
     module Trace
       # {Tracer} is the SDK implementation of {OpenTelemetry::Trace::Tracer}.
       class Tracer < OpenTelemetry::Trace::Tracer
-        DEFAULT_SPAN_NAME = 'empty'
-
         # @api private
         #
         # Returns a new {Tracer} instance.
@@ -30,7 +28,7 @@ module OpenTelemetry
         end
 
         def start_span(name, with_parent: nil, attributes: nil, links: nil, start_timestamp: nil, kind: nil)
-          name ||= DEFAULT_SPAN_NAME
+          name ||= 'empty'
 
           with_parent ||= Context.current
           parent_span = OpenTelemetry::Trace.current_span(with_parent)

--- a/sdk/lib/opentelemetry/sdk/trace/tracer.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/tracer.rb
@@ -32,7 +32,6 @@ module OpenTelemetry
           kind ||= :internal
           with_parent ||= Context.current
 
-
           @tracer_provider.internal_create_span(name, kind, attributes, links, start_timestamp, with_parent, @instrumentation_library)
         end
       end

--- a/sdk/lib/opentelemetry/sdk/trace/tracer.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/tracer.rb
@@ -29,11 +29,11 @@ module OpenTelemetry
 
         def start_span(name, with_parent: nil, attributes: nil, links: nil, start_timestamp: nil, kind: nil)
           name ||= 'empty'
-
+          kind ||= :internal
           with_parent ||= Context.current
-          parent_span = OpenTelemetry::Trace.current_span(with_parent)
 
-          @tracer_provider.internal_create_span(name, kind, attributes, links, start_timestamp, with_parent, parent_span, @instrumentation_library)
+
+          @tracer_provider.internal_create_span(name, kind, attributes, links, start_timestamp, with_parent, @instrumentation_library)
         end
       end
     end

--- a/sdk/lib/opentelemetry/sdk/trace/tracer.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/tracer.rb
@@ -9,6 +9,8 @@ module OpenTelemetry
     module Trace
       # {Tracer} is the SDK implementation of {OpenTelemetry::Trace::Tracer}.
       class Tracer < OpenTelemetry::Trace::Tracer
+        DEFAULT_SPAN_NAME = 'empty'
+
         # @api private
         #
         # Returns a new {Tracer} instance.
@@ -28,17 +30,12 @@ module OpenTelemetry
         end
 
         def start_span(name, with_parent: nil, attributes: nil, links: nil, start_timestamp: nil, kind: nil)
-          name ||= 'empty'
+          name ||= DEFAULT_SPAN_NAME
 
           with_parent ||= Context.current
           parent_span = OpenTelemetry::Trace.current_span(with_parent)
-          parent_span_context = OpenTelemetry::Trace.current_span(with_parent).context
-          if parent_span_context.valid?
-            parent_span_id = parent_span_context.span_id
-            trace_id = parent_span_context.trace_id
-          end
 
-          @tracer_provider.internal_create_span(name, kind, trace_id, parent_span_id, attributes, links, start_timestamp, with_parent, parent_span, @instrumentation_library)
+          @tracer_provider.internal_create_span(name, kind, attributes, links, start_timestamp, with_parent, parent_span, @instrumentation_library)
         end
       end
     end

--- a/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
@@ -127,7 +127,7 @@ module OpenTelemetry
 
         # @api private
         def internal_create_span(name, kind, attributes, links, start_timestamp, parent_context, instrumentation_library) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-          parent_span = OpenTelemetry::Trace.current_span(with_parent)
+          parent_span = OpenTelemetry::Trace.current_span(parent_context)
           parent_span_context = parent_span.context
 
           if parent_span_context.valid?

--- a/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
@@ -126,7 +126,7 @@ module OpenTelemetry
         end
 
         # @api private
-        def internal_create_span(name, kind, trace_id, parent_span_id, attributes, links, start_timestamp, parent_context, parent_span, instrumentation_library) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+        def internal_create_span(name, kind, attributes, links, start_timestamp, parent_context, parent_span, instrumentation_library) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
           parent_span_context = parent_span.context
           if parent_span_context.valid?
             parent_span_id = parent_span_context.span_id

--- a/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
@@ -126,15 +126,16 @@ module OpenTelemetry
         end
 
         # @api private
-        def internal_create_span(name, kind, attributes, links, start_timestamp, parent_context, parent_span, instrumentation_library) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+        def internal_create_span(name, kind, attributes, links, start_timestamp, parent_context, instrumentation_library) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+          parent_span = OpenTelemetry::Trace.current_span(with_parent)
           parent_span_context = parent_span.context
+
           if parent_span_context.valid?
             parent_span_id = parent_span_context.span_id
             trace_id = parent_span_context.trace_id
           end
-          name ||= 'empty'
+
           trace_id ||= @id_generator.generate_trace_id
-          kind ||= :internal
           result = @sampler.should_sample?(trace_id: trace_id, parent_context: parent_context, links: links, name: name, kind: kind, attributes: attributes)
           span_id = @id_generator.generate_span_id
           if result.recording? && !@stopped


### PR DESCRIPTION
There are 2 places in sdk, where checked mostly the same code parent_span_id and
trace_id base on parent_span's context.

Because there is no other places in gems,
that uses method `internal_start_span`, I left only logic 'internal_start_span' and removed unused attribute.

It is possible opposite: to have checking of context in `start_span`.