### PR TITLE
feat: support truffleruby

### DIFF
--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -44,6 +44,8 @@ runs:
         echo "::set-output name=cache_key::mri"
         if [[ "${{ inputs.ruby }}" == "jruby" ]]; then
           echo "::set-output name=cache_key::jruby"
+        elif [[ "${{ inputs.ruby }}" == "truffleruby" ]]; then
+          echo "::set-output name=cache_key::truffleruby"
         fi
 
         echo "::set-output name=appraisals::false"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,12 @@ jobs:
         with:
           gem: "${{ matrix.gem }}"
           ruby: "jruby"
+      - name: "Test truffleruby"
+        if: "${{ matrix.os == 'ubuntu-latest' }}"
+        uses: ./.github/actions/test_gem
+        with:
+          gem: "${{ matrix.gem }}"
+          ruby: "truffleruby"
 
   exporters:
     strategy:
@@ -103,6 +109,20 @@ jobs:
         with:
           gem: "${{ matrix.gem }}"
           ruby: "jruby"
+      - name: "Truffleruby Filter"
+        id: truffleruby_skip
+        shell: bash
+        run: |
+          echo "::set-output name=skip::false"
+          [[ "${{ matrix.gem }}" == "opentelemetry-exporter-otlp" ]] && echo "::set-output name=skip::true"
+          # This is essentially a bash script getting evaluated, so we need to return true or the whole job fails.
+          true
+      - name: "Test truffleruby"
+        if: "${{ matrix.os == 'ubuntu-latest' && steps.truffleruby_skip.outputs.skip == 'false' }}"
+        uses: ./.github/actions/test_gem
+        with:
+          gem: "${{ matrix.gem }}"
+          ruby: "truffleruby"
 
   propagators:
     strategy:
@@ -145,3 +165,9 @@ jobs:
         with:
           gem: "${{ matrix.gem }}"
           ruby: "jruby"
+      - name: "Test truffleruby"
+        if: "${{ matrix.os == 'ubuntu-latest' }}"
+        uses: ./.github/actions/test_gem
+        with:
+          gem: "${{ matrix.gem }}"
+          ruby: "truffleruby"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,10 @@ jobs:
         shell: bash
         run: |
           echo "::set-output name=skip::false"
-          [[ "${{ matrix.gem }}" == "opentelemetry-exporter-otlp" ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "opentelemetry-exporter-otlp"        ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "opentelemetry-exporter-otlp-common" ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "opentelemetry-exporter-otlp-http"   ]] && echo "::set-output name=skip::true"
+          [[ "${{ matrix.gem }}" == "opentelemetry-exporter-otlp-grpc"   ]] && echo "::set-output name=skip::true"
           # This is essentially a bash script getting evaluated, so we need to return true or the whole job fails.
           true
       - name: "Test truffleruby"

--- a/website_docs/getting-started.md
+++ b/website_docs/getting-started.md
@@ -13,10 +13,12 @@ Manual instrumentation can be added using the [OpenTelemetry API][manual].
 These instructions will explain how to set up automatic and manual instrumentation for a Ruby service.
 In order to follow along, you will need:
 
-- MRI Ruby >= `2.7`, or jruby >= `9.3.2.0`
+- MRI Ruby >= `2.7`, jruby >= `9.3.2.0`, or truffleruby >= 22.1
 - Docker Compose
 
 > jruby only targets compatibility with MRI Ruby 2.6.8; which is EOL. This project does not officially support MRI Ruby 2.6.8, and provides jruby support on a best-effort basis until the jruby project supports compatibility with more modern Ruby runtimes.
+
+> truffleruby is tested, but support is best-effort at this time.
 
 ### Installation
 


### PR DESCRIPTION
Does what it says on the tin. By "support" I mean "turn it on in CI and
see if everything works."

The compatibility list is actually a bit better than JRuby!

Notably, I needed to exclude the OTLP exporter to make tests pass. I'm
not certain it's a real bug; I just haven't tried to fix those test
failures yet.

---

For discussion: Do we actually even want this? I went down a rabbithole today and landed on truffleruby, and thought it might be neat to support it. It seems like it's broadly more compatible than JRuby to me. Digging through past issues and PRs, it looks like we've at least attempted to support this in the past, and then maybe accidentally dropped it over time.