### PR TITLE
fix: make sidekiq instrumentation compatible with sidekiq 6.5.0

### DIFF
--- a/instrumentation/sidekiq/Appraisals
+++ b/instrumentation/sidekiq/Appraisals
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 
+appraise 'sidekiq-6.5' do
+  gem 'sidekiq', '~> 6.5'
+end
+
+appraise 'sidekiq-6.4' do
+  gem 'sidekiq', '~> 6.4'
+end
+
 appraise 'sidekiq-6.3' do
   gem 'sidekiq', '~> 6.3'
 end

--- a/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/client/tracer_middleware.rb
+++ b/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/middlewares/client/tracer_middleware.rb
@@ -20,9 +20,9 @@ module OpenTelemetry
                 'messaging.destination' => job['queue'],
                 'messaging.destination_kind' => 'queue'
               }
-              attributes['peer.service'] = config[:peer_service] if config[:peer_service]
+              attributes['peer.service'] = instrumentation_config[:peer_service] if instrumentation_config[:peer_service]
 
-              span_name = case config[:span_naming]
+              span_name = case instrumentation_config[:span_naming]
                           when :job_class then "#{job['wrapped']&.to_s || job['class']} send"
                           else "#{job['queue']} send"
                           end
@@ -36,7 +36,7 @@ module OpenTelemetry
 
             private
 
-            def config
+            def instrumentation_config
               Sidekiq::Instrumentation.instance.config
             end
 

--- a/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/patches/launcher.rb
+++ b/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/patches/launcher.rb
@@ -13,9 +13,9 @@ module OpenTelemetry
           private
 
           def ❤ # rubocop:disable Naming/MethodName
-            if config[:trace_launcher_heartbeat]
+            if instrumentation_config[:trace_launcher_heartbeat]
               attributes = {}
-              attributes['peer.service'] = config[:peer_service] if config[:peer_service]
+              attributes['peer.service'] = instrumentation_config[:peer_service] if instrumentation_config[:peer_service]
               tracer.in_span('Sidekiq::Launcher#heartbeat', attributes: attributes) { super }
             else
               OpenTelemetry::Common::Utilities.untraced { super }
@@ -26,7 +26,7 @@ module OpenTelemetry
             Sidekiq::Instrumentation.instance.tracer
           end
 
-          def config
+          def instrumentation_config
             Sidekiq::Instrumentation.instance.config
           end
         end

--- a/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/patches/poller.rb
+++ b/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/patches/poller.rb
@@ -11,9 +11,9 @@ module OpenTelemetry
         # The Poller module contains instrumentation for the enqueue and wait methods
         module Poller
           def enqueue
-            if config[:trace_poller_enqueue]
+            if instrumentation_config[:trace_poller_enqueue]
               attributes = {}
-              attributes['peer.service'] = config[:peer_service] if config[:peer_service]
+              attributes['peer.service'] = instrumentation_config[:peer_service] if instrumentation_config[:peer_service]
               tracer.in_span('Sidekiq::Scheduled::Poller#enqueue', attributes: attributes) { super }
             else
               OpenTelemetry::Common::Utilities.untraced { super }
@@ -23,7 +23,7 @@ module OpenTelemetry
           private
 
           def wait
-            if config[:trace_poller_wait]
+            if instrumentation_config[:trace_poller_wait]
               tracer.in_span('Sidekiq::Scheduled::Poller#wait') { super }
             else
               OpenTelemetry::Common::Utilities.untraced { super }
@@ -34,7 +34,7 @@ module OpenTelemetry
             Sidekiq::Instrumentation.instance.tracer
           end
 
-          def config
+          def instrumentation_config
             Sidekiq::Instrumentation.instance.config
           end
         end

--- a/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/patches/processor.rb
+++ b/instrumentation/sidekiq/lib/opentelemetry/instrumentation/sidekiq/patches/processor.rb
@@ -13,9 +13,9 @@ module OpenTelemetry
           private
 
           def process_one
-            if config[:trace_processor_process_one]
+            if instrumentation_config[:trace_processor_process_one]
               attributes = {}
-              attributes['peer.service'] = config[:peer_service] if config[:peer_service]
+              attributes['peer.service'] = instrumentation_config[:peer_service] if instrumentation_config[:peer_service]
               tracer.in_span('Sidekiq::Processor#process_one', attributes: attributes) { super }
             else
               OpenTelemetry::Common::Utilities.untraced { super }
@@ -26,7 +26,7 @@ module OpenTelemetry
             Sidekiq::Instrumentation.instance.tracer
           end
 
-          def config
+          def instrumentation_config
             Sidekiq::Instrumentation.instance.config
           end
         end

--- a/instrumentation/sidekiq/test/helpers/mock_loader_new_launcher.rb
+++ b/instrumentation/sidekiq/test/helpers/mock_loader_new_launcher.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'sidekiq/cli'
+require 'sidekiq/launcher'
+
+class MockLoader
+  attr_reader :launcher
+
+  def initialize
+    Sidekiq[:queues] << 'default'
+
+    @launcher = Sidekiq::Launcher.new(Sidekiq)
+    @launcher.fire_event(:startup)
+  end
+
+  def poller
+    launcher.poller
+  end
+
+  def manager
+    launcher.manager
+  end
+end

--- a/instrumentation/sidekiq/test/test_helper.rb
+++ b/instrumentation/sidekiq/test/test_helper.rb
@@ -12,9 +12,17 @@ require 'opentelemetry-test-helpers'
 
 require 'minitest/autorun'
 require 'rspec/mocks/minitest_integration'
-require 'helpers/mock_loader'
 require 'active_job'
 require 'pry'
+
+# Sidekiq changed its loading mechanism in 6.5.0, but we still want to test the
+# older versions. We can eliminate the first part of this conditional when we no
+# longer support Sidekiq 6.4.x versions.
+if Gem::Version.new(Sidekiq::VERSION) < Gem::Version.new("6.5.0")
+  require 'helpers/mock_loader'
+else
+  require 'helpers/mock_loader_new_launcher'
+end
 
 # OpenTelemetry SDK config for testing
 EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new

--- a/instrumentation/sidekiq/test/test_helper.rb
+++ b/instrumentation/sidekiq/test/test_helper.rb
@@ -18,7 +18,7 @@ require 'pry'
 # Sidekiq changed its loading mechanism in 6.5.0, but we still want to test the
 # older versions. We can eliminate the first part of this conditional when we no
 # longer support Sidekiq 6.4.x versions.
-if Gem::Version.new(Sidekiq::VERSION) < Gem::Version.new("6.5.0")
+if Gem::Version.new(Sidekiq::VERSION) < Gem::Version.new('6.5.0')
   require 'helpers/mock_loader'
 else
   require 'helpers/mock_loader_new_launcher'


### PR DESCRIPTION
This PR:

- changes our config method to instrumentation_config. Sidekiq's new
Component module is mixed in in a lot of places, and that module
includes a config method that we very much do not want to overwrite.

- changes the MockLoader in our test suite to be compatible with Sidekiq
6.5.0. Starting in Sidekiq 6.5.0, Sidekiq accepts the Sidekiq singleton
as an argument to Launcher.new. It seems like this is an intermediate
step to making Sidekiq::Config its own class, which is planned for
Sidekiq 7.0.

- adds appraisals for sidekiq 6.4.0 and 6.5.0