### PR TITLE
Handle `-` in generated instrumentation name

### DIFF
--- a/.instrumentation_generator/instrumentation_generator.rb
+++ b/.instrumentation_generator/instrumentation_generator.rb
@@ -81,7 +81,7 @@ class InstrumentationGenerator < Thor::Group
   end
 
   def pascal_cased_instrumentation_name
-    instrumentation_name.split('_').collect(&:capitalize).join
+    instrumentation_name.split(/[_-]/).collect(&:capitalize).join
   end
 
   def humanized_instrumentation_name


### PR DESCRIPTION
Currently, dashes are ignored, resulting in invalid constants such as

```ruby
OpenTelemetry::Instrumentation::Foo-bar::VERSION
```

being generated by running

```sh
bin/instrumentation_generator foo-bar
```

While convention would dictate that `foo-bar` map to `Foo::Bar`, this would require a larger refactor.