### PR TITLE
fix: Stop leaking basic authentication credentials in Faraday instrumentation

### DIFF
--- a/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
+++ b/instrumentation/faraday/lib/opentelemetry/instrumentation/faraday/middlewares/tracer_middleware.rb
@@ -44,7 +44,7 @@ module OpenTelemetry
           def span_creation_attributes(http_method:, url:)
             instrumentation_attrs = {
               'http.method' => http_method,
-              'http.url' => url.to_s,
+              'http.url' => OpenTelemetry::Common::Utilities.cleanse_url(url.to_s),
               'net.peer.name' => url.host
             }
             config = Faraday::Instrumentation.instance.config


### PR DESCRIPTION
Some Ruby gems (e.g. [`elasticsearch-transport`](https://github.com/elastic/elastic-transport-ruby/blob/391ed956b23b9b3be3fd962f8fc5366e410006eb/lib/elastic/transport/transport/http/faraday.rb#L49-L54) use [`Faraday::Connection#run_request`](https://www.rubydoc.info/github/lostisland/faraday/Faraday%2FConnection:run_request) directly. This method accepts full URL along with the basic auth credentials as part of it.
As a result, credentials leak via `http.url` span attribute.
This PR modifies the specs to fail by using `run_request` and also fixes the code to "cleanse" the URL with the existing helper method.


<details>
<summary>How to reproduce</summary>

```ruby
# Gemfile
gem 'faraday', '= 0.15.4'
gem 'opentelemetry-sdk'
gem 'opentelemetry-exporter-otlp'
gem 'opentelemetry-instrumentation-all'
gem 'elasticsearch', '= 6.1.0'
```

```ruby
# script.rb
require 'opentelemetry/sdk'
require 'opentelemetry/exporter/otlp'
require 'opentelemetry/instrumentation/all'
require 'elasticsearch'

ENV['OTEL_TRACES_EXPORTER'] = 'console'

OpenTelemetry::SDK.configure do |c|
  c.service_name = 'test_app'
  c.use 'OpenTelemetry::Instrumentation::Faraday'
end

client = Elasticsearch::Client.new(hosts: "http://elastic:top-secret@localhost:9200");
client.search
```

Output:
```
I, [2022-06-09T16:41:13.061317 #13360]  INFO -- : Instrumentation: OpenTelemetry::Instrumentation::Faraday was successfully installed with the following options {:peer_service=>nil}
#<struct OpenTelemetry::SDK::Trace::SpanData
 name="HTTP GET",
 kind=:client,
 status=
  #<OpenTelemetry::Trace::Status:0x0000000114a10328 @code=1, @description="">,
 parent_span_id="\x00\x00\x00\x00\x00\x00\x00\x00",
 total_recorded_attributes=4,
 total_recorded_events=0,
 total_recorded_links=0,
 start_timestamp=1654789273069515000,
 end_timestamp=1654789273093570000,
 attributes=
  {"http.method"=>"GET",
   "http.url"=>"http://elastic:top-secret@localhost:9200/_search",
   "net.peer.name"=>"localhost",
   "http.status_code"=>200},
 links=nil,
 events=nil,
 resource=
  #<OpenTelemetry::SDK::Resources::Resource:0x00000001249dcf40
   @attributes=
    {"service.name"=>"test_app",
     "process.pid"=>13360,
     "process.command"=>"app.rb",
     "process.runtime.name"=>"ruby",
     "process.runtime.version"=>"2.6.5",
     "process.runtime.description"=>
      "ruby 2.6.5p114 (2019-10-01 revision 67812) [-darwin20]",
     "telemetry.sdk.name"=>"opentelemetry",
     "telemetry.sdk.language"=>"ruby",
     "telemetry.sdk.version"=>"1.1.0"}>,
 instrumentation_library=
  #<struct OpenTelemetry::SDK::InstrumentationLibrary
   name="OpenTelemetry::Instrumentation::Faraday",
   version="0.20.1">,
 span_id="v\x9D\xBF;\xFE\x9B\xD9\xD4",
 trace_id="\xB3\x8ASX\x90NA\xDF\x9E\x1ET\xC9\xBE[+\x7F",
 trace_flags=#<OpenTelemetry::Trace::TraceFlags:0x0000000114913d80 @flags=1>,
 tracestate=#<OpenTelemetry::Trace::Tracestate:0x0000000114973000 @hash={}>>
```

</details>

