### PR TITLE
Fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Ruby [OpenTelemetry](https://opentelemetry.io/) client.
 - [Getting Started][getting-started]
 - [Contributing](#contributing)
 - [Contrib Repository](#contrib-repository)
-- [Instrumentation Libraries][contrib-instrumentation]
+- [Instrumentation Libraries][contrib-instrumentations]
 - [Versioning](#versioning)
 - [Useful links](#useful-links)
 - [License](#license)

--- a/website_docs/context-propagation.md
+++ b/website_docs/context-propagation.md
@@ -28,4 +28,4 @@ gem 'opentelemetry-propagator-b3'
 
 [glossary]: /docs/concepts/glossary/
 [propagators]: https://github.com/open-telemetry/opentelemetry-ruby/tree/main/propagator
-[auto-instrumentation]: https://github.com/open-telemetry/opentelemetry-ruby/tree/main/instrumentation
+[auto-instrumentation]: https://github.com/open-telemetry/opentelemetry-ruby-contrib/tree/main/instrumentation


### PR DESCRIPTION
Updating docs links, as the page https://github.com/open-telemetry/opentelemetry-ruby/tree/main/instrumentation doesn't exist anymore.