### PR TITLE
fix: `OTEL_EXPORTER_OTLP_ENDPOINT` appends the correct path with a trailing slash

### DIFF
--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -58,7 +58,7 @@ module OpenTelemetry
           raise ArgumentError, "unsupported compression key #{compression}" unless compression.nil? || %w[gzip none].include?(compression)
 
           @uri = if endpoint == ENV['OTEL_EXPORTER_OTLP_ENDPOINT']
-                   URI(endpoint.end_with?('/') ? "#{endpoint}#{TRACES_PATH}" : "#{endpoint}/#{TRACES_PATH}")
+                   URI(File.join(endpoint, TRACES_PATH))
                  else
                    URI(endpoint)
                  end

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -58,7 +58,7 @@ module OpenTelemetry
           raise ArgumentError, "unsupported compression key #{compression}" unless compression.nil? || %w[gzip none].include?(compression)
 
           @uri = if endpoint == ENV['OTEL_EXPORTER_OTLP_ENDPOINT']
-                   URI(File.join(endpoint, TRACES_PATH))
+                   URI.join(endpoint, 'v1/traces')
                  else
                    URI(endpoint)
                  end

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -35,6 +35,8 @@ module OpenTelemetry
         ERROR_MESSAGE_INVALID_HEADERS = 'headers must be a String with comma-separated URL Encoded UTF-8 k=v pairs or a Hash'
         private_constant(:ERROR_MESSAGE_INVALID_HEADERS)
 
+        TRACES_PATH = 'v1/traces'
+
         def self.ssl_verify_mode
           if ENV.key?('OTEL_RUBY_EXPORTER_OTLP_SSL_VERIFY_PEER')
             OpenSSL::SSL::VERIFY_PEER
@@ -56,7 +58,7 @@ module OpenTelemetry
           raise ArgumentError, "unsupported compression key #{compression}" unless compression.nil? || %w[gzip none].include?(compression)
 
           @uri = if endpoint == ENV['OTEL_EXPORTER_OTLP_ENDPOINT']
-                   URI("#{endpoint}/v1/traces")
+                   URI(endpoint.end_with?('/') ? "#{endpoint}#{TRACES_PATH}" : "#{endpoint}/#{TRACES_PATH}")
                  else
                    URI(endpoint)
                  end

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -35,7 +35,6 @@ module OpenTelemetry
         ERROR_MESSAGE_INVALID_HEADERS = 'headers must be a String with comma-separated URL Encoded UTF-8 k=v pairs or a Hash'
         private_constant(:ERROR_MESSAGE_INVALID_HEADERS)
 
-
         def self.ssl_verify_mode
           if ENV.key?('OTEL_RUBY_EXPORTER_OTLP_SSL_VERIFY_PEER')
             OpenSSL::SSL::VERIFY_PEER

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -35,7 +35,6 @@ module OpenTelemetry
         ERROR_MESSAGE_INVALID_HEADERS = 'headers must be a String with comma-separated URL Encoded UTF-8 k=v pairs or a Hash'
         private_constant(:ERROR_MESSAGE_INVALID_HEADERS)
 
-        TRACES_PATH = 'v1/traces'
 
         def self.ssl_verify_mode
           if ENV.key?('OTEL_RUBY_EXPORTER_OTLP_SSL_VERIFY_PEER')

--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -110,6 +110,24 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       _(http.port).must_equal 4321
     end
 
+    it 'appends the correct path if OTEL_EXPORTER_OTLP_ENDPOINT has a trailing slash' do
+      exp = OpenTelemetry::TestHelpers.with_env(
+        'OTEL_EXPORTER_OTLP_ENDPOINT' => 'https://localhost:1234/'
+      ) do
+        OpenTelemetry::Exporter::OTLP::Exporter.new()
+      end
+      _(exp.instance_variable_get(:@path)).must_equal '/v1/traces'
+    end
+
+    it 'appends the correct path if OTEL_EXPORTER_OTLP_ENDPOINT does not have a trailing slash' do
+      exp = OpenTelemetry::TestHelpers.with_env(
+        'OTEL_EXPORTER_OTLP_ENDPOINT' => 'https://localhost:1234'
+      ) do
+        OpenTelemetry::Exporter::OTLP::Exporter.new()
+      end
+      _(exp.instance_variable_get(:@path)).must_equal '/v1/traces'
+    end
+
     it 'restricts explicit headers to a String or Hash' do
       exp = OpenTelemetry::Exporter::OTLP::Exporter.new(headers: { 'token' => 'über' })
       _(exp.instance_variable_get(:@headers)).must_equal('token' => 'über')


### PR DESCRIPTION
Addresses #1340 

## Context
>When using the OTEL_EXPORTER_OTLP_ENDPOINT env variable, if the endpoint contains a trailing /, the final URL becomes <endpoint>//v1/traces instead of <endpoint>/v1/traces and traces are not sent to the expected place. Other OTel exporter libraries (e.g. [Python](https://github.com/open-telemetry/opentelemetry-python/blob/dbcec9f3b143e4de424c16be9ecd19a16be3e630/exporter/opentelemetry-exporter-otlp-proto-http/src/opentelemetry/exporter/otlp/proto/http/trace_exporter/__init__.py#L181), [JS](https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/otlp-exporter-base/src/util.ts#L59)) handle endpoints with or without a trailing / so it would be good to keep it consistent with the Ruby exporter as well.

## Changes
- Added a check to see if the `OTEL_EXPORTER_OTLP_ENDPOINT` ends in a trailing `/` and if it does append `v1/traces` appropriately
- Unit tests to test whether endpoints work with or without the trailing `/`
- Extracted `v1/traces` into a constant variable