### PR TITLE
chore: promote Robb Kidd to Approver

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam
+* @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Approvers ([@open-telemetry/ruby-approvers](https://github.com/orgs/open-telemet
 - [Ariel Valentin](https://github.com/arielvalentin), GitHub
 - [Andrew Hayworth](https://github.com/ahayworth), Shopify
 - [Sam Handler](https://github.com/plantfansam), Shopify
+- [Robb Kidd](https://github.com/robbkidd), Honeycomb
 
 *Find more about the approver role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver).*
 


### PR DESCRIPTION
Follow-up to [the conversation in CNCF Slack #otel-ruby](https://cloud-native.slack.com/archives/C01NWKKMKMY/p1657664615160479), I would like to help more with reviews and contributions.

If approved, TODO outside this PR before merge:
- [ ] Write access granted to @robbkidd (or added as member of @open-telemetry/ruby-approvers)