### PR TITLE
docs: update exporter default compression setting

### DIFF
--- a/exporter/otlp-http/README.md
+++ b/exporter/otlp-http/README.md
@@ -73,7 +73,7 @@ The collector exporter can be configured explicitly in code, or via environment 
 | `endpoint:`         | `OTEL_EXPORTER_OTLP_ENDPOINT`                | `"http://localhost:4318/v1/traces"` |
 | `certificate_file: `| `OTEL_EXPORTER_OTLP_CERTIFICATE`             |                                     |
 | `headers:`          | `OTEL_EXPORTER_OTLP_HEADERS`                 |                                     |
-| `compression:`      | `OTEL_EXPORTER_OTLP_COMPRESSION`             |                                     |
+| `compression:`      | `OTEL_EXPORTER_OTLP_COMPRESSION`             | `"gzip"`                            |
 | `timeout:`          | `OTEL_EXPORTER_OTLP_TIMEOUT`                 | `10`                                |
 | `ssl_verify_mode:`  | `OTEL_RUBY_EXPORTER_OTLP_SSL_VERIFY_PEER` or | `OpenSSL::SSL:VERIFY_PEER`          |
 |                     | `OTEL_RUBY_EXPORTER_OTLP_SSL_VERIFY_NONE`    |                                     |

--- a/exporter/otlp/README.md
+++ b/exporter/otlp/README.md
@@ -73,7 +73,7 @@ The collector exporter can be configured explicitly in code, or via environment 
 | `endpoint:`         | `OTEL_EXPORTER_OTLP_ENDPOINT`                | `"http://localhost:4318/v1/traces"` |
 | `certificate_file: `| `OTEL_EXPORTER_OTLP_CERTIFICATE`             |                                     |
 | `headers:`          | `OTEL_EXPORTER_OTLP_HEADERS`                 |                                     |
-| `compression:`      | `OTEL_EXPORTER_OTLP_COMPRESSION`             |                                     |
+| `compression:`      | `OTEL_EXPORTER_OTLP_COMPRESSION`             | `"gzip"`                            |
 | `timeout:`          | `OTEL_EXPORTER_OTLP_TIMEOUT`                 | `10`                                |
 | `ssl_verify_mode:`  | `OTEL_RUBY_EXPORTER_OTLP_SSL_VERIFY_PEER` or | `OpenSSL::SSL:VERIFY_PEER`          |
 |                     | `OTEL_RUBY_EXPORTER_OTLP_SSL_VERIFY_NONE`    |                                     |


### PR DESCRIPTION
By default the OTLP exporters use gzip for compression, as specified
with `default: 'gzip'` in the files linked below.

The `README.md` files of the exporter gems document no particular
default. This commit updates documentation of the compression env vars
to mention the default compression config value.

- Base exporter setting: https://github.com/open-telemetry/opentelemetry-ruby/blob/03e36cec755df97e08139494b85473a7ad547001/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb#L52
- HTTP exporter setting: https://github.com/open-telemetry/opentelemetry-ruby/blob/03e36cec755df97e08139494b85473a7ad547001/exporter/otlp-http/lib/opentelemetry/exporter/otlp/http/trace_exporter.rb#L39