### PR TITLE
Rename internal_create_span

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/tracer.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/tracer.rb
@@ -32,7 +32,7 @@ module OpenTelemetry
           kind ||= :internal
           with_parent ||= Context.current
 
-          @tracer_provider.internal_create_span(name, kind, attributes, links, start_timestamp, with_parent, @instrumentation_scope)
+          @tracer_provider.internal_start_span(name, kind, attributes, links, start_timestamp, with_parent, @instrumentation_scope)
         end
       end
     end

--- a/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
@@ -126,7 +126,7 @@ module OpenTelemetry
         end
 
         # @api private
-        def internal_create_span(name, kind, attributes, links, start_timestamp, parent_context, instrumentation_scope) # rubocop:disable Metrics/MethodLength
+        def internal_start_span(name, kind, attributes, links, start_timestamp, parent_context, instrumentation_scope) # rubocop:disable Metrics/MethodLength
           parent_span = OpenTelemetry::Trace.current_span(parent_context)
           parent_span_context = parent_span.context
 


### PR DESCRIPTION
This PR renames the API-internal `TracerProvider#internal_create_span` method to `TracerProvider#internal_start_span`. It is an attempt to address concerns around the change in method signature in #1281. That PR changed the signature of `internal_create_span` from:
```ruby
def internal_create_span(name, kind, trace_id, parent_span_id, attributes, links, start_timestamp, parent_context, parent_span, instrumentation_library)
```
to
```ruby
def internal_create_span(name, kind, attributes, links, start_timestamp, parent_context, instrumentation_scope)
```
and also moved some functionality between it and its caller.

While this method is marked API-internal, "someone" may have chosen to monkey-patch it to change its behaviour, and if that "someone" didn't pin the SDK version, then consumers bumping the SDK dependency may 💥.

### TODO: describe possible impact