### PR TITLE
Changed signal names for website docs

### DIFF
--- a/website_docs/_index.md
+++ b/website_docs/_index.md
@@ -20,7 +20,7 @@ This documentation is designed to help you understand how to get started using O
 The current status of the major functional components for OpenTelemetry Ruby is
 as follows:
 
-| Tracing | Metrics | Logging |
+| Traces  | Metrics | Logs    |
 | ------- | ------- | ------- |
 | Stable | Not Yet Implemented | Not Yet Implemented |
 


### PR DESCRIPTION
This PR contains changes for signal name consistency in the website doc.
Issue: https://github.com/open-telemetry/opentelemetry.io/issues/1121