### PR TITLE
feat: Custom  Metrics Reporter Support for Zipkin

### DIFF
--- a/exporter/zipkin/test/test_helper.rb
+++ b/exporter/zipkin/test/test_helper.rb
@@ -12,6 +12,8 @@ require 'opentelemetry/exporter/zipkin'
 require 'minitest/autorun'
 require 'webmock/minitest'
 
+OpenTelemetry.logger = Logger.new(File::NULL)
+
 def create_span_data(status: nil, kind: nil, attributes: nil, total_recorded_attributes: 0, events: nil, total_recorded_events: 0, links: nil, total_recorded_links: 0, instrumentation_scope: OpenTelemetry::SDK::InstrumentationScope.new('vendorlib', '0.0.0'), trace_id: OpenTelemetry::Trace.generate_trace_id, trace_flags: OpenTelemetry::Trace::TraceFlags::DEFAULT, tracestate: nil)
   OpenTelemetry::SDK::Trace::SpanData.new(
     '',
@@ -33,4 +35,32 @@ def create_span_data(status: nil, kind: nil, attributes: nil, total_recorded_att
     trace_flags,
     tracestate
   )
+end
+
+# Test helper for Zipkin Exporter
+class InMemoryMetricsReporter
+  include OpenTelemetry::SDK::Trace::Export::MetricsReporter
+  attr_reader :counters, :records, :observes
+
+  def initialize
+    @counters = []
+    @records = []
+    @observes = []
+  end
+
+  def record_value(metric, value:, labels: {})
+    @records << { metric: metric, value: value, labels: labels }
+  end
+
+  def observe_value(metric, value:, labels: {})
+    @observes << { metric: metric, value: value, labels: labels }
+  end
+
+  def add_to_counter(metric, increment: 1, labels: {})
+    @counters << { metric: metric, value: increment, labels: labels }
+  end
+
+  def empty?
+    @counters.empty? && @records.empty? && @observes.empty?
+  end
 end


### PR DESCRIPTION
Long overdue follow up task to make it possible to add a custom metrics reporter via the SDK Configurator.

This will make initializing Zipkin exporter and the OTLP Exporter symmetric and reduce complexity in https://github.com/open-telemetry/opentelemetry-ruby/pull/1110