### PR TITLE
docs: Improve formatting of usage examples in OpenTelemetry SDK rubydocs

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/export/in_memory_span_exporter.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/in_memory_span_exporter.rb
@@ -10,26 +10,26 @@ module OpenTelemetry
       module Export
         # A SpanExporter implementation that can be used to test OpenTelemetry integration.
         #
-        # Example usage in a test suite:
+        # @example Usage in a test suite:
+        #   class MyClassTest
+        #     def setup
+        #       @tracer_provider = TracerProvider.new
+        #       # The default is `recording: true`, which is appropriate in non-test environments.
+        #       @exporter = InMemorySpanExporter.new(recording: false)
+        #       @tracer_provider.add_span_processor(SimpleSampledSpansProcessor.new(@exporter))
+        #     end
         #
-        # class MyClassTest
-        #   def setup
-        #     @tracer_provider = TracerProvider.new
-        #     # The default is `recording: true`, which is appropriate in non-test environments.
-        #     @exporter = InMemorySpanExporter.new(recording: false)
-        #     @tracer_provider.add_span_processor(SimpleSampledSpansProcessor.new(@exporter))
-        #   end
+        #     def test_finished_spans
+        #       @exporter.recording = true
+        #       @tracer_provider.tracer.in_span("span") {}
         #
-        #   def test_finished_spans
-        #     @exporter.recording = true
-        #     @tracer_provider.tracer.in_span("span") {}
+        #       spans = @exporter.finished_spans
+        #       spans.wont_be_nil
+        #       spans.size.must_equal(1)
+        #       spans[0].name.must_equal("span")
         #
-        #     spans = @exporter.finished_spans
-        #     spans.wont_be_nil
-        #     spans.size.must_equal(1)
-        #     spans[0].name.must_equal("span")
-        #
-        #     @exporter.recording = false
+        #       @exporter.recording = false
+        #     end
         #   end
         class InMemorySpanExporter
           # Controls whether or not the exporter will record spans, or discard them.

--- a/sdk/lib/opentelemetry/sdk/trace/export/metrics_reporter.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/metrics_reporter.rb
@@ -15,6 +15,7 @@ module OpenTelemetry
         # the unstable OpenTelemetry Metrics API. An example implementation in
         # terms of StatsD is:
         #
+        # @example
         #   module MetricsReporter
         #     def add_to_counter(metric, increment: 1, labels: {})
         #       StatsD.increment(metric, increment, labels, no_prefix: true)


### PR DESCRIPTION
Some usage examples I came across didn't have proper markup to allow them to be presented nicely in code blocks. This fixes that.

# InMemorySpanExporter

https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-sdk/v1.2.0/OpenTelemetry/SDK/Trace/Export/InMemorySpanExporter.html

## Before

![image](https://user-images.githubusercontent.com/298026/193438793-1d8fd17c-58e1-44d2-adfd-951d6762e8a9.png)

## After

![image](https://user-images.githubusercontent.com/298026/193438804-c0c43443-2b49-4bd4-9ee7-0e10de42cab5.png)

# MetricsReporter

https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-sdk/v1.2.0/OpenTelemetry/SDK/Trace/Export/MetricsReporter.html

## Before

![image](https://user-images.githubusercontent.com/298026/193438835-b9a7298f-fdbd-4036-a0a7-0d64ada3f03f.png)

## After

![image](https://user-images.githubusercontent.com/298026/193438827-d64ace05-411d-49ce-98d2-6c382b764ef4.png)
