### PR TITLE
ci: replace newly-deprecated commands in actions

### DIFF
--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -33,7 +33,7 @@ runs:
       shell: bash
       run: |
         dir=$(find . -iname '${{ inputs.gem }}.gemspec' -exec dirname {} \;)
-        echo "::set-output name=dir::${dir}"
+        echo "gem_dir=${dir}" >> $GITHUB_OUTPUT
 
         # We install multiple ruby versions here, and that makes for some
         # annoying bundler conflicts when we get to the JRuby step. Removing
@@ -41,16 +41,16 @@ runs:
         # of the benefits of bundler caching.
         rm -f "${dir}/Gemfile.lock"
 
-        echo "::set-output name=cache_key::mri"
+        echo "cache_key=mri" >> $GITHUB_OUTPUT
         if [[ "${{ inputs.ruby }}" == "jruby" ]]; then
-          echo "::set-output name=cache_key::jruby"
+          echo "cache_key=jruby" >> $GITHUB_OUTPUT
         elif [[ "${{ inputs.ruby }}" == "truffleruby" ]]; then
-          echo "::set-output name=cache_key::truffleruby"
+          echo "cache_key=truffleruby" >> $GITHUB_OUTPUT
         fi
 
-        echo "::set-output name=appraisals::false"
+        echo "appraisals=false" >> $GITHUB_OUTPUT
         if [[ -f "${dir}/Appraisals" ]]; then
-          echo "::set-output name=appraisals::true"
+          echo "appraisals=true" >> $GITHUB_OUTPUT
         fi
 
     # Install ruby and bundle dependencies and cache!
@@ -60,7 +60,7 @@ runs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: "${{ inputs.ruby }}"
-        working-directory: "${{ steps.setup.outputs.dir }}"
+        working-directory: "${{ steps.setup.outputs.gem_dir }}"
         bundler-cache: true
         cache-version: "v1-${{ steps.setup.outputs.cache_key }}"
 
@@ -74,14 +74,14 @@ runs:
       if: "${{ steps.setup.outputs.appraisals == 'true' }}"
       shell: bash
       run: |
-        cd "${{ steps.setup.outputs.dir }}"
+        cd "${{ steps.setup.outputs.gem_dir }}"
         bundle install
         bundle exec appraisal install
 
     - name: Test Gem
       shell: bash
       run: |
-        cd "${{ steps.setup.outputs.dir }}"
+        cd "${{ steps.setup.outputs.gem_dir }}"
 
         if [[ -f "Appraisals" ]]; then
           bundle exec appraisal rake test

--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -114,19 +114,19 @@ runs:
       shell: bash
       if: "${{ inputs.yard == 'true' }}"
       run: |
-        cd "${{ steps.setup.outputs.dir }}"
+        cd "${{ steps.setup.outputs.gem_dir }}"
         bundle exec rake yard
 
     - name: Rubocop
       shell: bash
       if: "${{ inputs.rubocop == 'true' }}"
       run: |
-        cd "${{ steps.setup.outputs.dir }}"
+        cd "${{ steps.setup.outputs.gem_dir }}"
         bundle exec rake rubocop
 
     - name: Build Gem
       shell: bash
       if: "${{ inputs.build == 'true' }}"
       run: |
-        cd "${{ steps.setup.outputs.dir }}"
+        cd "${{ steps.setup.outputs.gem_dir }}"
         gem build ${{ inputs.gem }}.gemspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,11 +112,11 @@ jobs:
         id: jruby_skip
         shell: bash
         run: |
-          echo "::set-output name=skip::false"
-          [[ "${{ matrix.gem }}" == "opentelemetry-exporter-otlp"        ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-exporter-otlp-common" ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-exporter-otlp-http"   ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-exporter-otlp-grpc"   ]] && echo "::set-output name=skip::true"
+          echo "skip=false" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "opentelemetry-exporter-otlp"        ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "opentelemetry-exporter-otlp-common" ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "opentelemetry-exporter-otlp-http"   ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "opentelemetry-exporter-otlp-grpc"   ]] && echo "skip=true" >> $GITHUB_OUTPUT
           # This is essentially a bash script getting evaluated, so we need to return true or the whole job fails.
           true
       - name: "Test JRuby"
@@ -129,11 +129,11 @@ jobs:
         id: truffleruby_skip
         shell: bash
         run: |
-          echo "::set-output name=skip::false"
-          [[ "${{ matrix.gem }}" == "opentelemetry-exporter-otlp"        ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-exporter-otlp-common" ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-exporter-otlp-http"   ]] && echo "::set-output name=skip::true"
-          [[ "${{ matrix.gem }}" == "opentelemetry-exporter-otlp-grpc"   ]] && echo "::set-output name=skip::true"
+          echo "skip=false" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "opentelemetry-exporter-otlp"        ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "opentelemetry-exporter-otlp-common" ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "opentelemetry-exporter-otlp-http"   ]] && echo "skip=true" >> $GITHUB_OUTPUT
+          [[ "${{ matrix.gem }}" == "opentelemetry-exporter-otlp-grpc"   ]] && echo "skip=true" >> $GITHUB_OUTPUT
           # This is essentially a bash script getting evaluated, so we need to return true or the whole job fails.
           true
       - name: "Test truffleruby"


### PR DESCRIPTION
The `set-output` command is being deprecated, and so we need to migrate.
Per the guides, this looks like the easiest replacement.

See open-telemetry/opentelemetry-ruby#144 for more info.
