### PR TITLE
chore: Upgrade rubocop 0.73 -> 1.3 for SemanticConventions

### DIFF
--- a/semantic_conventions/.rubocop.yml
+++ b/semantic_conventions/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   TargetRubyVersion: '2.6.0'
+  NewCops: enable
 
 Bundler/OrderedGems:
   Exclude:
@@ -8,7 +9,7 @@ Lint/UnusedMethodArgument:
   Enabled: false
 Metrics/AbcSize:
   Enabled: false
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Max: 20
@@ -33,5 +34,7 @@ Layout/EmptyLinesAroundModuleBody:
   Enabled: false
 Layout/TrailingWhitespace:
   Enabled: false
-Layout/TrailingBlankLines:
-  Enabled: False
+Layout/TrailingEmptyLines:
+  Enabled: false
+Gemspec/RequireMFA:
+  Enabled: false

--- a/semantic_conventions/Rakefile
+++ b/semantic_conventions/Rakefile
@@ -51,7 +51,7 @@ task :generate do
         -f /source code
         --template /templates/semantic_conventions.j2
         --output /output/opentelemetry/semantic_conventions/#{kind}.rb
-        -Dmodule=#{kind[0].upcase}#{kind[1..-1]}
+        -Dmodule=#{kind[0].upcase}#{kind[1..]}
       ]
 
       puts "Running: #{cmd.join(' ')}"

--- a/semantic_conventions/opentelemetry-semantic_conventions.gemspec
+++ b/semantic_conventions/opentelemetry-semantic_conventions.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 12.0'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3'
   spec.add_development_dependency 'simplecov', '~> 0.17'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'


### PR DESCRIPTION

  * Enable all new cops by default
  * TrailingBlankLines cop was renamed to TrailingEmptyLines
  * LineLength changed group from Metrics to Layout
  * disable Gemspec/RequireMFA
  * autocorrect slicing array from index until end

Partially addresses: https://github.com/open-telemetry/opentelemetry-ruby/issues/1321