### PR TITLE
chore: Upgrade rubocop 0.73 -> 1.3 for TestHelpers

### DIFF
--- a/test_helpers/.rubocop.yml
+++ b/test_helpers/.rubocop.yml
@@ -1,11 +1,12 @@
 AllCops:
   TargetRubyVersion: "2.6.0"
+  NewCops: enable
 
 Lint/UnusedMethodArgument:
   Enabled: false
-Metrics/AbcSize:
+Layout/LineLength:
   Enabled: false
-Metrics/LineLength:
+Metrics/AbcSize:
   Enabled: false
 Metrics/MethodLength:
   Max: 21
@@ -16,5 +17,5 @@ Naming/FileName:
     - "lib/opentelemetry-test-helpers.rb"
 Style/ModuleFunction:
   Enabled: false
-Style/BracesAroundHashParameters:
+Gemspec/RequireMFA:
   Enabled: false

--- a/test_helpers/lib/opentelemetry/test_helpers.rb
+++ b/test_helpers/lib/opentelemetry/test_helpers.rb
@@ -55,11 +55,9 @@ module OpenTelemetry
       keys_to_delete.each { |k| ENV.delete(k) }
     end
 
-    def with_ids(trace_id, span_id)
+    def with_ids(trace_id, span_id, &block)
       OpenTelemetry::Trace.stub(:generate_trace_id, trace_id) do
-        OpenTelemetry::Trace.stub(:generate_span_id, span_id) do
-          yield
-        end
+        OpenTelemetry::Trace.stub(:generate_span_id, span_id, &block)
       end
     end
 

--- a/test_helpers/opentelemetry-test-helpers.gemspec
+++ b/test_helpers/opentelemetry-test-helpers.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
   spec.add_development_dependency 'rake', '~> 12.0'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.3'
   spec.add_development_dependency 'simplecov', '~> 0.17'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/test_helpers/test/.rubocop.yml
+++ b/test_helpers/test/.rubocop.yml
@@ -1,8 +1,4 @@
 inherit_from: ../.rubocop.yml
 
-Metrics/AbcSize:
-  Enabled: false
 Metrics/BlockLength:
-  Enabled: false
-Metrics/LineLength:
   Enabled: false


### PR DESCRIPTION
* enable all new cops by default
* Style/BracesAroundHashParameters was removed - see https://github.com/rubocop/rubocop/issues/7641
* LineLength changed group from Metrics to Layout
* disable Gemspec/RequireMFA
* autocorrect explicit block over yield

Partially addresses: https://github.com/open-telemetry/opentelemetry-ruby/issues/1321