### PR TITLE
Add API ref and Examples to docs sidebar

### DIFF
--- a/website_docs/api.md
+++ b/website_docs/api.md
@@ -1,0 +1,8 @@
+---
+title: API reference
+linkTitle: API
+redirect: https://open-telemetry.github.io/opentelemetry-ruby/
+manualLinkTarget: _blank
+_build: { render: link }
+weight: 50
+---

--- a/website_docs/examples.md
+++ b/website_docs/examples.md
@@ -1,0 +1,7 @@
+---
+title: Examples
+redirect: https://github.com/open-telemetry/opentelemetry-ruby/tree/main/examples
+manualLinkTarget: _blank
+_build: { render: link }
+weight: 60
+---


### PR DESCRIPTION
This adds the Ruby version of https://github.com/open-telemetry/opentelemetry.io/issues/1808