### PR TITLE
feat: Implement the Trace Response propagator

### DIFF
--- a/sdk_experimental/lib/opentelemetry/sdk/experimental.rb
+++ b/sdk_experimental/lib/opentelemetry/sdk/experimental.rb
@@ -14,3 +14,4 @@ module OpenTelemetry
 end
 
 require 'opentelemetry/sdk/experimental/samplers_patch'
+require 'opentelemetry/sdk/trace/propagation/trace_context/response_text_map_propagator'

--- a/sdk_experimental/lib/opentelemetry/sdk/trace/propagation/trace_context/response_text_map_propagator.rb
+++ b/sdk_experimental/lib/opentelemetry/sdk/trace/propagation/trace_context/response_text_map_propagator.rb
@@ -41,8 +41,7 @@ module OpenTelemetry
           #   will be used to read the header from the carrier, otherwise the default
           #   text map getter will be used.
           #
-          # @return [Context] context updated with extracted baggage, or the original context
-          #   if extraction fails
+          # @return [Context] the original context.
           def extract(carrier, context: Context.current, getter: Context::Propagation.text_map_getter)
             context
           end

--- a/sdk_experimental/lib/opentelemetry/sdk/trace/propagation/trace_context/response_text_map_propagator.rb
+++ b/sdk_experimental/lib/opentelemetry/sdk/trace/propagation/trace_context/response_text_map_propagator.rb
@@ -4,54 +4,56 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-module OpenTelemetry
-  module Trace
-    module Propagation
-      module TraceContext
-        # Propagates trace response using the W3C Trace Context format
-        # https://w3c.github.io/trace-context/#traceresponse-header
-        class ResponseTextMapPropagator
-          TRACERESPONSE_KEY = 'traceresponse'
-          FIELDS = [TRACERESPONSE_KEY].freeze
+unless OpenTelemetry::Trace::Propagation::TraceContext.const_defined?(:ResponseTextMapPropagator)
+  module OpenTelemetry
+    module Trace
+      module Propagation
+        module TraceContext
+          # Propagates trace response using the W3C Trace Context format
+          # https://w3c.github.io/trace-context/#traceresponse-header
+          class ResponseTextMapPropagator
+            TRACERESPONSE_KEY = 'traceresponse'
+            FIELDS = [TRACERESPONSE_KEY].freeze
 
-          private_constant :TRACERESPONSE_KEY, :FIELDS
+            private_constant :TRACERESPONSE_KEY, :FIELDS
 
-          # Inject trace context into the supplied carrier.
-          #
-          # @param [Carrier] carrier The mutable carrier to inject trace context into
-          # @param [Context] context The context to read trace context from
-          # @param [optional Setter] setter If the optional setter is provided, it
-          #   will be used to write context into the carrier, otherwise the default
-          #   text map setter will be used.
-          def inject(carrier, context: Context.current, setter: Context::Propagation.text_map_setter)
-            span_context = Trace.current_span(context).context
-            return unless span_context.valid?
+            # Inject trace context into the supplied carrier.
+            #
+            # @param [Carrier] carrier The mutable carrier to inject trace context into
+            # @param [Context] context The context to read trace context from
+            # @param [optional Setter] setter If the optional setter is provided, it
+            #   will be used to write context into the carrier, otherwise the default
+            #   text map setter will be used.
+            def inject(carrier, context: Context.current, setter: Context::Propagation.text_map_setter)
+              span_context = Trace.current_span(context).context
+              return unless span_context.valid?
 
-            setter.set(carrier, TRACERESPONSE_KEY, TraceParent.from_span_context(span_context).to_s)
-            nil
-          end
+              setter.set(carrier, TRACERESPONSE_KEY, TraceParent.from_span_context(span_context).to_s)
+              nil
+            end
 
-          # Extract trace context from the supplied carrier. This is a no-op for
-          # this propagator, and will return the provided context.
-          #
-          # @param [Carrier] carrier The carrier to get the header from
-          # @param [optional Context] context Context to be updated with the trace context
-          #   extracted from the carrier. Defaults to +Context.current+.
-          # @param [optional Getter] getter If the optional getter is provided, it
-          #   will be used to read the header from the carrier, otherwise the default
-          #   text map getter will be used.
-          #
-          # @return [Context] the original context.
-          def extract(carrier, context: Context.current, getter: Context::Propagation.text_map_getter)
-            context
-          end
+            # Extract trace context from the supplied carrier. This is a no-op for
+            # this propagator, and will return the provided context.
+            #
+            # @param [Carrier] carrier The carrier to get the header from
+            # @param [optional Context] context Context to be updated with the trace context
+            #   extracted from the carrier. Defaults to +Context.current+.
+            # @param [optional Getter] getter If the optional getter is provided, it
+            #   will be used to read the header from the carrier, otherwise the default
+            #   text map getter will be used.
+            #
+            # @return [Context] the original context.
+            def extract(carrier, context: Context.current, getter: Context::Propagation.text_map_getter)
+              context
+            end
 
-          # Returns the predefined propagation fields. If your carrier is reused, you
-          # should delete the fields returned by this method before calling +inject+.
-          #
-          # @return [Array<String>] a list of fields that will be used by this propagator.
-          def fields
-            FIELDS
+            # Returns the predefined propagation fields. If your carrier is reused, you
+            # should delete the fields returned by this method before calling +inject+.
+            #
+            # @return [Array<String>] a list of fields that will be used by this propagator.
+            def fields
+              FIELDS
+            end
           end
         end
       end

--- a/sdk_experimental/lib/opentelemetry/sdk/trace/propagation/trace_context/response_text_map_propagator.rb
+++ b/sdk_experimental/lib/opentelemetry/sdk/trace/propagation/trace_context/response_text_map_propagator.rb
@@ -31,8 +31,8 @@ module OpenTelemetry
             nil
           end
 
-          # Extract trace context from the supplied carrier.
-          # If extraction fails, the original context will be returned
+          # Extract trace context from the supplied carrier. This is a no-op for
+          # this propagator, and will return the provided context.
           #
           # @param [Carrier] carrier The carrier to get the header from
           # @param [optional Context] context Context to be updated with the trace context

--- a/sdk_experimental/lib/opentelemetry/sdk/trace/propagation/trace_context/response_text_map_propagator.rb
+++ b/sdk_experimental/lib/opentelemetry/sdk/trace/propagation/trace_context/response_text_map_propagator.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Trace
+    module Propagation
+      module TraceContext
+        # Propagates trace response using the W3C Trace Context format
+        # https://w3c.github.io/trace-context/#traceresponse-header
+        class ResponseTextMapPropagator
+          TRACERESPONSE_KEY = 'traceresponse'
+          FIELDS = [TRACERESPONSE_KEY].freeze
+
+          private_constant :TRACERESPONSE_KEY, :FIELDS
+
+          # Inject trace context into the supplied carrier.
+          #
+          # @param [Carrier] carrier The mutable carrier to inject trace context into
+          # @param [Context] context The context to read trace context from
+          # @param [optional Setter] setter If the optional setter is provided, it
+          #   will be used to write context into the carrier, otherwise the default
+          #   text map setter will be used.
+          def inject(carrier, context: Context.current, setter: Context::Propagation.text_map_setter)
+            span_context = Trace.current_span(context).context
+            return unless span_context.valid?
+
+            setter.set(carrier, TRACERESPONSE_KEY, TraceParent.from_span_context(span_context).to_s)
+            nil
+          end
+
+          # Extract trace context from the supplied carrier.
+          # If extraction fails, the original context will be returned
+          #
+          # @param [Carrier] carrier The carrier to get the header from
+          # @param [optional Context] context Context to be updated with the trace context
+          #   extracted from the carrier. Defaults to +Context.current+.
+          # @param [optional Getter] getter If the optional getter is provided, it
+          #   will be used to read the header from the carrier, otherwise the default
+          #   text map getter will be used.
+          #
+          # @return [Context] context updated with extracted baggage, or the original context
+          #   if extraction fails
+          def extract(carrier, context: Context.current, getter: Context::Propagation.text_map_getter)
+            context
+          end
+
+          # Returns the predefined propagation fields. If your carrier is reused, you
+          # should delete the fields returned by this method before calling +inject+.
+          #
+          # @return [Array<String>] a list of fields that will be used by this propagator.
+          def fields
+            FIELDS
+          end
+        end
+      end
+    end
+  end
+end

--- a/sdk_experimental/test/opentelemetry/sdk/trace/propagation/trace_context/response_text_map_propagator_test.rb
+++ b/sdk_experimental/test/opentelemetry/sdk/trace/propagation/trace_context/response_text_map_propagator_test.rb
@@ -11,12 +11,7 @@ describe OpenTelemetry::Trace::Propagation::TraceContext::ResponseTextMapPropaga
   let(:propagator) do
     OpenTelemetry::Trace::Propagation::TraceContext::ResponseTextMapPropagator.new
   end
-  let(:valid_traceresponse_header) do
-    '00-000000000000000000000000000000AA-00000000000000ea-01'
-  end
-  let(:invalid_traceresponse_header) do
-    'FF-000000000000000000000000000000AA-00000000000000ea-01'
-  end
+
   let(:carrier) do
     {
       traceresponse_key => valid_traceresponse_header

--- a/sdk_experimental/test/opentelemetry/sdk/trace/propagation/trace_context/response_text_map_propagator_test.rb
+++ b/sdk_experimental/test/opentelemetry/sdk/trace/propagation/trace_context/response_text_map_propagator_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+describe OpenTelemetry::Trace::Propagation::TraceContext::ResponseTextMapPropagator do
+  let(:traceresponse_key) { 'traceresponse' }
+  let(:propagator) do
+    OpenTelemetry::Trace::Propagation::TraceContext::ResponseTextMapPropagator.new
+  end
+  let(:valid_traceresponse_header) do
+    '00-000000000000000000000000000000AA-00000000000000ea-01'
+  end
+  let(:invalid_traceresponse_header) do
+    'FF-000000000000000000000000000000AA-00000000000000ea-01'
+  end
+  let(:carrier) do
+    {
+      traceresponse_key => valid_traceresponse_header
+    }
+  end
+  let(:context) { OpenTelemetry::Context.empty }
+  let(:context_valid) do
+    span_context = OpenTelemetry::Trace::SpanContext.new(trace_id: ("\xff" * 16).b, span_id: ("\x11" * 8).b)
+    span = OpenTelemetry::Trace.non_recording_span(span_context)
+    OpenTelemetry::Trace.context_with_span(span)
+  end
+
+  describe '#inject' do
+    it 'writes traceresponse into the carrier' do
+      carrier = {}
+      propagator.inject(carrier, context: context_valid)
+      _(carrier[traceresponse_key]).must_equal('00-ffffffffffffffffffffffffffffffff-1111111111111111-00')
+    end
+
+    it "doesn't write if the context is not valid" do
+      carrier = {}
+      propagator.inject(carrier, context: context)
+      _(carrier).wont_include(traceresponse_key)
+    end
+  end
+end


### PR DESCRIPTION
Adds a TextMapPropagator in the experimental SDK to inject `traceresponse` headers as defined in the [Trace Context][1] draft specification.

[Here is a gist][2] demonstrating the propagator, based off of the existing http server example from this repo.

[1]: https://w3c.github.io/trace-context/#traceresponse-header
[2]: https://gist.github.com/wperron/d2566b65785a5aa2b670d07ea4cbc07a