### PR TITLE
Add experimental SDK to releases.yml

### DIFF
--- a/.toys/.data/releases.yml
+++ b/.toys/.data/releases.yml
@@ -45,6 +45,10 @@ gems:
     directory: sdk
     version_constant: [OpenTelemetry, SDK, VERSION]
 
+  - name: opentelemetry-sdk-experimental
+    directory: sdk_experimental
+    version_constant: [OpenTelemetry, SDK, Experimental, VERSION]
+
   - name: opentelemetry-common
     directory: common
     version_rb_path: lib/opentelemetry/common/version.rb

--- a/.toys/.data/releases.yml
+++ b/.toys/.data/releases.yml
@@ -47,6 +47,7 @@ gems:
 
   - name: opentelemetry-sdk-experimental
     directory: sdk_experimental
+    version_rb_path: lib/opentelemetry/sdk/experimental/version.rb
     version_constant: [OpenTelemetry, SDK, Experimental, VERSION]
 
   - name: opentelemetry-common


### PR DESCRIPTION
To release the experimental SDK, I think we need to add to `releases.yml`.