### PR TITLE
Refactor configuration to use environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 **/tmp/**/*
 **/target/**/*
 **/*.bundle
+**/*.so
 
 
 # Appraisals

--- a/sdk_rust/Cargo.lock
+++ b/sdk_rust/Cargo.lock
@@ -12,6 +12,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+
+[[package]]
+name = "async-stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,6 +54,58 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "axum"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08b108ad2665fa3f6e6a517c3d80ec3e77d224c47d605167aefaa5d7ef97fa48"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79b8558f5a0581152dc94dcd289132a1d377494bdeafcd41869b3258e3e2ad92"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bindgen"
@@ -58,6 +137,12 @@ name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+
+[[package]]
+name = "bytes"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "cexpr"
@@ -105,12 +190,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
 name = "ext"
 version = "0.0.1"
 dependencies = [
+ "lazy_static",
  "magnus",
  "opentelemetry",
+ "opentelemetry-otlp",
  "rb-sys",
+ "tokio",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "futures"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
 ]
 
 [[package]]
@@ -120,6 +262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -138,6 +281,12 @@ dependencies = [
  "futures-task",
  "futures-util",
 ]
+
+[[package]]
+name = "futures-io"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
 name = "futures-macro"
@@ -168,10 +317,13 @@ version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -195,10 +347,120 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
+name = "h2"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "http"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-range-header"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "hyper"
+version = "0.14.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
 
 [[package]]
 name = "indexmap"
@@ -209,6 +471,30 @@ dependencies = [
  "autocfg",
  "hashbrown",
 ]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "js-sys"
@@ -248,6 +534,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,8 +554,9 @@ dependencies = [
 
 [[package]]
 name = "magnus"
-version = "0.4.2"
-source = "git+https://github.com/matsadler/magnus#69ff299ac05f890afca03f443861e6763aa8b740"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d904f55da4e2b0ac7f133257af80580ff4ca17bcca67f51ea06be46aa634ac"
 dependencies = [
  "magnus-macros",
  "rb-sys",
@@ -269,12 +566,19 @@ dependencies = [
 [[package]]
 name = "magnus-macros"
 version = "0.2.0"
-source = "git+https://github.com/matsadler/magnus#69ff299ac05f890afca03f443861e6763aa8b740"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acc8ba6908cb0f67a4e75cb48fc81a1f0e6a6dd1501936e0c9e2c7c8f9f18e05"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
 name = "memchr"
@@ -283,10 +587,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "nom"
@@ -296,6 +624,16 @@ checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -315,11 +653,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-otlp"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c928609d087790fc936a1067bdc310ae702bdf3b090c3f281b713622c8bbde"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-util",
+ "http",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "prost",
+ "thiserror",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61a2f56df5574508dd86aaca016c917489e589ece4141df1b5e349af8d66c28"
+dependencies = [
+ "futures",
+ "futures-util",
+ "opentelemetry",
+ "prost",
+ "tonic",
+ "tonic-build",
+]
+
+[[package]]
 name = "opentelemetry_api"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c24f96e21e7acc813c7a8394ee94978929db2bcc46cf6b5014fc612bf7760c22"
 dependencies = [
+ "fnv",
  "futures-channel",
  "futures-util",
  "indexmap",
@@ -337,6 +708,8 @@ checksum = "1ca41c4933371b61c2a2f214bf16931499af4ec90543604ec828f7a625c09113"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
+ "dashmap",
+ "fnv",
  "futures-channel",
  "futures-executor",
  "futures-util",
@@ -345,6 +718,31 @@ dependencies = [
  "percent-encoding",
  "rand",
  "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -358,6 +756,36 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "petgraph"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -378,12 +806,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "prettyplease"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c142c0e46b57171fe0c528bee8c5b7569e80f0c17e377cd0e30ea57dbc11bb51"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b18e655c21ff5ac2084a5ad0611e827b3f92badf79f4910b5a5c58f4d87ff0"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e330bf1316db56b12c2bcfa399e8edddd4821965ea25ddb2c134b610b1c1c604"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "164ae68b6587001ca506d3bf7f1000bfa248d0e1217b618108fba4ec1d0cc306"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747761bc3dc48f9a34553bf65605cf6cb6288ba219f3450b4275dbd81539551a"
+dependencies = [
+ "bytes",
+ "prost",
 ]
 
 [[package]]
@@ -427,18 +920,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.44"
+version = "0.9.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f48777b8161ff5c077ad74ce486ebe963ca8a92257512bab473b405a80d69f"
+checksum = "b9f1cfd225389bd9333d93d393d0feeeacd191d97f9b1c881528ac1233c67f0f"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.44"
+version = "0.9.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a46785122aff7077527b78c2518d739c45dc0fbc410a2b8361076ff4bbf993f9"
+checksum = "fad39a523a00dc5d4f6dcec077568d985807aa5bd03204a0ddf7c1f36544289c"
 dependencies = [
  "bindgen",
  "regex",
@@ -450,6 +943,15 @@ name = "rb-sys-env"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74c38752410925faeb82c400c06ba2fd9ee6aa8f719dd33994c9e53f5242d25f"
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "regex"
@@ -469,10 +971,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustversion"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "serde"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
 
 [[package]]
 name = "shell-words"
@@ -487,12 +1016,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "socket2"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -504,6 +1058,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]
@@ -527,10 +1101,231 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
+dependencies = [
+ "autocfg",
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project",
+ "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if",
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -593,6 +1388,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
+name = "which"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,3 +1419,60 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"

--- a/sdk_rust/Gemfile
+++ b/sdk_rust/Gemfile
@@ -14,6 +14,7 @@ gem "rb_sys", "~> 0.9"
 gem "test-unit"
 
 group :test, :development do
+  gem 'pry'
   gem 'opentelemetry-api', path: '../api'
   gem 'opentelemetry-common', path: '../common'
   gem 'opentelemetry-registry', path: '../registry'

--- a/sdk_rust/Gemfile
+++ b/sdk_rust/Gemfile
@@ -15,6 +15,8 @@ gem "test-unit"
 
 group :test, :development do
   gem 'pry'
+  gem 'benchmark'
+  gem 'benchmark-memory'
   gem 'opentelemetry-api', path: '../api'
   gem 'opentelemetry-common', path: '../common'
   gem 'opentelemetry-registry', path: '../registry'

--- a/sdk_rust/Gemfile
+++ b/sdk_rust/Gemfile
@@ -18,7 +18,6 @@ group :test, :development do
   gem 'benchmark'
   gem 'benchmark-memory'
   gem 'opentelemetry-api', path: '../api'
-  gem 'opentelemetry-sdk', path: '../sdk'
   gem 'opentelemetry-common', path: '../common'
   gem 'opentelemetry-registry', path: '../registry'
   gem 'opentelemetry-semantic_conventions', path: '../semantic_conventions'

--- a/sdk_rust/Gemfile
+++ b/sdk_rust/Gemfile
@@ -18,6 +18,7 @@ group :test, :development do
   gem 'benchmark'
   gem 'benchmark-memory'
   gem 'opentelemetry-api', path: '../api'
+  gem 'opentelemetry-sdk', path: '../sdk'
   gem 'opentelemetry-common', path: '../common'
   gem 'opentelemetry-registry', path: '../registry'
   gem 'opentelemetry-semantic_conventions', path: '../semantic_conventions'

--- a/sdk_rust/Rakefile
+++ b/sdk_rust/Rakefile
@@ -21,5 +21,5 @@ end
 
 Rake::TestTask.new do |t|
   t.deps << :dev << :compile
-  t.test_files = FileList[File.expand_path("test/*_test.rb", __dir__)]
+  t.test_files = FileList[File.expand_path("test/*_test.rb", __dir__), "test/*bench.rb"]
 end

--- a/sdk_rust/Rakefile
+++ b/sdk_rust/Rakefile
@@ -16,8 +16,5 @@ end
 
 Rake::TestTask.new do |t|
   t.deps << :dev << :compile
-  # t.libs << 'test'
-  # t.libs << 'lib'
-  # t.libs << '../api/lib'
-  t.test_files = FileList[File.expand_path("test/*_test.rb", __dir__)]
+  t.test_files = FileList[File.expand_path("test/*_test.rb", __dir__), "test/bench.rb"]
 end

--- a/sdk_rust/Rakefile
+++ b/sdk_rust/Rakefile
@@ -21,5 +21,9 @@ end
 
 Rake::TestTask.new do |t|
   t.deps << :dev << :compile
-  t.test_files = FileList[File.expand_path("test/*_test.rb", __dir__), "test/*bench.rb"]
+  t.test_files = FileList[File.expand_path("test/*_test.rb", __dir__)]
 end
+
+# task "benchmark" do
+#   ENV["RB_SYS_CARGO_PROFILE"] = "dev"
+

--- a/sdk_rust/Rakefile
+++ b/sdk_rust/Rakefile
@@ -10,11 +10,16 @@ Rake::ExtensionTask.new("ext") do |c|
   c.ext_dir = "ext"
 end
 
+task "compile:debug" do
+  ENV["RB_SYS_CARGO_PROFILE"] = "dev"
+  Rake::Task["compile"].invoke
+end
+
 task :dev do
   ENV['RB_SYS_CARGO_PROFILE'] = 'dev'
 end
 
 Rake::TestTask.new do |t|
   t.deps << :dev << :compile
-  t.test_files = FileList[File.expand_path("test/*_test.rb", __dir__), "test/bench.rb"]
+  t.test_files = FileList[File.expand_path("test/*_test.rb", __dir__)]
 end

--- a/sdk_rust/ext/Cargo.toml
+++ b/sdk_rust/ext/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-opentelemetry = "0.18.0"
-magnus = { git = "https://github.com/matsadler/magnus", features = ["rb-sys-interop"] }
-rb-sys = "~0.9.44"
+opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
+magnus = { version = "0.4.3", features = ["rb-sys-interop"] }
+rb-sys = "~0.9.46"
+opentelemetry-otlp = "0.11.0"
+tokio = { version = "1.23.0", features = [ "full" ] }
+lazy_static = "1.4.0"

--- a/sdk_rust/ext/src/lib.rs
+++ b/sdk_rust/ext/src/lib.rs
@@ -26,7 +26,7 @@ fn configure() -> Result<(), Error> {
     let mut tracer_provider_builder =
         sdk::trace::Builder::default().with_config(opentelemetry::sdk::trace::config());
 
-    let env_exporters = env!("OTEL_TRACES_EXPORTER");
+    let env_exporters = std::env::var("OTEL_TRACES_EXPORTER").unwrap_or("".to_owned());
     for exp in env_exporters.split(",") {
         match exp {
             "otlp" => {

--- a/sdk_rust/ext/src/lib.rs
+++ b/sdk_rust/ext/src/lib.rs
@@ -1,26 +1,17 @@
-use lazy_static::lazy_static;
 use magnus::{define_module, function, Error, Module};
 use std::io::stdout;
-use tokio::runtime::Builder;
 
 use opentelemetry::{
     global,
-    runtime::{self},
+    runtime::{self as otel_runtime},
     sdk::{self},
 };
 use opentelemetry_otlp::WithExportConfig;
 
 mod span;
+mod tokio_rb; // TODO(wperron): this should be in its own crate
 mod tracer;
 mod tracer_provider;
-
-lazy_static! {
-    static ref LOCAL_RUNTIME: tokio::runtime::Runtime = Builder::new_multi_thread()
-        .enable_all()
-        .thread_name("tokio-worker")
-        .build()
-        .expect("failed to build local tokio runtime, this is a bug");
-}
 
 fn configure() -> Result<(), Error> {
     let mut tracer_provider_builder =
@@ -30,21 +21,13 @@ fn configure() -> Result<(), Error> {
     for exp in env_exporters.split(",") {
         match exp {
             "otlp" => {
-                // IMPORTANT: it's imperative to get a guard on a Tokio runtime before
-                // using a batch exporter because OpenTelemetry needs an async runtime
-                // instance in order to perform batching asynchronously. Removing this line
-                // will cause a runtime panic because [there is no reactor running][1].
-                //
-                // [1]: https://users.rust-lang.org/t/there-is-no-reactor-running-must-be-called-from-the-context-of-a-tokio-1-x-runtime/75393
-                let _guard = LOCAL_RUNTIME.enter();
-
                 let exporter_builder: opentelemetry_otlp::SpanExporterBuilder =
                     opentelemetry_otlp::new_exporter().tonic().with_env().into();
                 tracer_provider_builder = tracer_provider_builder.with_batch_exporter(
                     exporter_builder
                         .build_span_exporter()
                         .expect("failed to build otlp exporter. this is a bug."),
-                    runtime::Tokio,
+                    otel_runtime::Tokio,
                 );
             }
             "console" => {
@@ -70,6 +53,8 @@ fn init() -> Result<(), Error> {
     tracer_provider::init(module)?;
     tracer::init(module)?;
     span::init(module)?;
+
+    tokio_rb::init()?;
 
     Ok(())
 }

--- a/sdk_rust/ext/src/lib.rs
+++ b/sdk_rust/ext/src/lib.rs
@@ -14,8 +14,6 @@ mod tracer;
 mod tracer_provider;
 
 fn configure() -> Result<(), Error> {
-    println!("[RUST] configure");
-
     let mut tracer_provider_builder =
         sdk::trace::Builder::default().with_config(opentelemetry::sdk::trace::config());
 

--- a/sdk_rust/ext/src/lib.rs
+++ b/sdk_rust/ext/src/lib.rs
@@ -1,16 +1,62 @@
+use lazy_static::lazy_static;
 use magnus::{define_module, function, Error, Module};
+use std::io::stdout;
+use tokio::runtime::Builder;
 
-use opentelemetry::sdk::export::trace::stdout;
+use opentelemetry::{
+    global,
+    runtime::{self},
+    sdk::{self},
+};
+use opentelemetry_otlp::WithExportConfig;
 
 mod span;
 mod tracer;
 mod tracer_provider;
 
+lazy_static! {
+    static ref LOCAL_RUNTIME: tokio::runtime::Runtime = Builder::new_multi_thread()
+        .enable_all()
+        .thread_name("tokio-worker")
+        .build()
+        .expect("failed to build local tokio runtime, this is a bug");
+}
+
 fn configure() -> Result<(), Error> {
-    // let _ = opentelemetry_otlp::new_pipeline().tracing().install_simple()?;
-    let _ = stdout::new_pipeline()
-        .with_pretty_print(true)
-        .install_simple();
+    let mut tracer_provider_builder =
+        sdk::trace::Builder::default().with_config(opentelemetry::sdk::trace::config());
+
+    let env_exporters = env!("OTEL_TRACES_EXPORTER");
+    for exp in env_exporters.split(",") {
+        match exp {
+            "otlp" => {
+                // IMPORTANT: it's imperative to get a guard on a Tokio runtime before
+                // using a batch exporter because OpenTelemetry needs an async runtime
+                // instance in order to perform batching asynchronously. Removing this line
+                // will cause a runtime panic because [there is no reactor running][1].
+                //
+                // [1]: https://users.rust-lang.org/t/there-is-no-reactor-running-must-be-called-from-the-context-of-a-tokio-1-x-runtime/75393
+                let _guard = LOCAL_RUNTIME.enter();
+
+                let exporter_builder: opentelemetry_otlp::SpanExporterBuilder =
+                    opentelemetry_otlp::new_exporter().tonic().with_env().into();
+                tracer_provider_builder = tracer_provider_builder.with_batch_exporter(
+                    exporter_builder
+                        .build_span_exporter()
+                        .expect("failed to build otlp exporter. this is a bug."),
+                    runtime::Tokio,
+                );
+            }
+            "console" => {
+                let exporter = sdk::export::trace::stdout::Exporter::new(stdout(), false);
+                tracer_provider_builder = tracer_provider_builder.with_simple_exporter(exporter);
+            }
+            _ => {}
+        }
+    }
+
+    let provider = tracer_provider_builder.build();
+    global::set_tracer_provider(provider);
     Ok(())
 }
 

--- a/sdk_rust/ext/src/lib.rs
+++ b/sdk_rust/ext/src/lib.rs
@@ -14,6 +14,8 @@ mod tracer;
 mod tracer_provider;
 
 fn configure() -> Result<(), Error> {
+    println!("[RUST] configure");
+
     let mut tracer_provider_builder =
         sdk::trace::Builder::default().with_config(opentelemetry::sdk::trace::config());
 

--- a/sdk_rust/ext/src/tokio_rb/error.rs
+++ b/sdk_rust/ext/src/tokio_rb/error.rs
@@ -1,0 +1,23 @@
+use magnus::exception::standard_error;
+use magnus::ExceptionClass;
+
+use crate::tokio_rb::prelude::*;
+
+/// Base error class for all Tokio errors.
+pub fn base_error() -> ExceptionClass {
+    *memoize!(ExceptionClass: root().define_error("Error", standard_error()).unwrap())
+}
+
+/// Macro to create a new Tokio error with a formatted message.
+#[macro_export]
+macro_rules! error {
+    ($($arg:expr),*) => {
+        magnus::Error::new($crate::tokio_rb::error::base_error(), format!($($arg),*))
+    };
+}
+
+pub fn init() -> Result<(), Error> {
+    let _ = base_error();
+
+    Ok(())
+}

--- a/sdk_rust/ext/src/tokio_rb/helpers.rs
+++ b/sdk_rust/ext/src/tokio_rb/helpers.rs
@@ -1,0 +1,3 @@
+mod wrapped_struct;
+
+pub use wrapped_struct::{Wrapped, WrappedStruct};

--- a/sdk_rust/ext/src/tokio_rb/helpers/wrapped_struct.rs
+++ b/sdk_rust/ext/src/tokio_rb/helpers/wrapped_struct.rs
@@ -1,0 +1,100 @@
+use std::marker::PhantomData;
+use std::ops::Deref;
+
+use magnus::error::Error;
+use magnus::value::Value;
+use magnus::{exception, gc, RTypedData, TryConvert, TypedData};
+
+/// A small wrapper for `RTypedData` that keeps track of the concrete struct
+/// type, and the underlying [`Value`] for GC purposes.
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct WrappedStruct<T: TypedData> {
+    inner: RTypedData,
+    phantom: PhantomData<T>,
+}
+
+impl<T: TypedData> Clone for WrappedStruct<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner,
+            phantom: PhantomData,
+        }
+    }
+}
+impl<T: TypedData> Copy for WrappedStruct<T> {}
+
+impl<T: TypedData> WrappedStruct<T> {
+    /// Gets the underlying struct.
+    pub fn get(&self) -> Result<&T, Error> {
+        self.inner.try_convert()
+    }
+
+    /// Get the Ruby [`Value`] for this struct.
+    pub fn to_value(self) -> Value {
+        self.inner.into()
+    }
+
+    /// Marks the Ruby [`Value`] for GC.
+    pub fn mark(&self) {
+        gc::mark(&self.inner.into());
+    }
+}
+
+impl<T: TypedData> From<WrappedStruct<T>> for Value {
+    fn from(wrapped_struct: WrappedStruct<T>) -> Self {
+        wrapped_struct.to_value()
+    }
+}
+
+impl<T: TypedData> Deref for WrappedStruct<T> {
+    type Target = RTypedData;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T: TypedData> From<T> for WrappedStruct<T> {
+    fn from(t: T) -> Self {
+        Self {
+            inner: RTypedData::wrap(t),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> TryConvert for WrappedStruct<T>
+where
+    T: TypedData,
+{
+    fn try_convert(val: Value) -> Result<Self, Error> {
+        let inner = RTypedData::from_value(val).ok_or_else(|| {
+            Error::new(
+                exception::type_error(),
+                format!(
+                    "no implicit conversion of {} into {}",
+                    unsafe { val.classname() },
+                    T::class()
+                ),
+            )
+        })?;
+
+        Ok(Self {
+            inner,
+            phantom: PhantomData,
+        })
+    }
+}
+
+pub trait Wrapped<T: TypedData> {
+    /// Convert the typed struct into a [`WrappedStruct`], which makes it usable
+    /// from Ruby.
+    fn to_ruby_value(self) -> WrappedStruct<T>;
+}
+
+impl<T: TypedData> Wrapped<T> for T {
+    fn to_ruby_value(self) -> WrappedStruct<T> {
+        WrappedStruct::from(self)
+    }
+}

--- a/sdk_rust/ext/src/tokio_rb/mod.rs
+++ b/sdk_rust/ext/src/tokio_rb/mod.rs
@@ -1,0 +1,27 @@
+mod error;
+mod helpers;
+mod prelude;
+mod runtime;
+
+pub use helpers::{Wrapped, WrappedStruct};
+use magnus::{define_module, gc};
+pub use runtime::Runtime;
+
+use crate::tokio_rb::prelude::*;
+
+/// The "Tokio" Ruby module.
+pub fn root() -> RModule {
+    *memoize!(RModule: {
+        let rmod = define_module("Tokio").unwrap();
+        gc::register_mark_object(rmod);
+        rmod
+    })
+}
+
+#[magnus::init(name = "tokio")]
+pub fn init() -> Result<(), Error> {
+    error::init()?;
+    runtime::init()?;
+
+    Ok(())
+}

--- a/sdk_rust/ext/src/tokio_rb/prelude.rs
+++ b/sdk_rust/ext/src/tokio_rb/prelude.rs
@@ -1,0 +1,10 @@
+pub use magnus::prelude::*;
+pub use magnus::r_typed_data::DataTypeBuilder;
+pub use magnus::{
+    function, memoize, method, DataTypeFunctions, Error, RClass, RModule, RTypedData, TypedData,
+    Value, QNIL,
+};
+
+pub use crate::tokio_rb::error::*;
+pub use crate::tokio_rb::helpers::{Wrapped, WrappedStruct};
+pub use crate::tokio_rb::root;

--- a/sdk_rust/ext/src/tokio_rb/runtime.rs
+++ b/sdk_rust/ext/src/tokio_rb/runtime.rs
@@ -1,0 +1,93 @@
+mod builder;
+mod enter_guard;
+mod handle;
+
+use magnus::block::{block_given, yield_value};
+
+use self::builder::Builder;
+use crate::tokio_rb::prelude::*;
+
+/// @yard
+/// @rename Tokio::Runtime
+/// Represents a Tokio runtime.
+/// @see https://docs.rs/tokio/latest/tokio/runtime/struct.Runtime.html Rust doc
+#[derive(Debug)]
+pub struct Runtime {
+    inner: tokio::runtime::Runtime,
+}
+
+unsafe impl TypedData for Runtime {
+    fn class() -> magnus::RClass {
+        *memoize!(RClass: root().define_class("Runtime", Default::default()).unwrap())
+    }
+
+    fn data_type() -> &'static magnus::DataType {
+        memoize!(magnus::DataType: {
+            let mut builder = DataTypeBuilder::<Runtime>::new("Tokio::Runtime");
+            builder.free_immediately();
+            builder.build()
+        })
+    }
+}
+
+impl DataTypeFunctions for Runtime {}
+
+impl Runtime {
+    /// @yard
+    /// Creates a new multi-threaded Tokio runtime.
+    ///
+    /// Suitable for providing a runtime for executing tasks that do not require
+    /// Ruby access (i.e. telemetry for Rust crates).
+    ///
+    /// As of now, it is **not safe** to send execute any Ruby code in this
+    /// runtime. There are no built-in synchronization mechanisms to prevent
+    /// this. Doing so will likely segfault your program.
+    ///
+    /// @method new
+    /// @return [Tokio::Runtime]
+    /// @see https://docs.rs/tokio/latest/tokio/runtime/struct.Runtime.html#method.new Rust doc
+    pub fn new() -> Result<Self, Error> {
+        if block_given() {
+            let builder = Builder::new_multi_thread().to_ruby_value();
+            let _ = yield_value::<_, Value>(builder)?;
+            builder.get()?.build()
+        } else {
+            Builder::new_multi_thread().build()
+        }
+    }
+
+    /// @yard
+    /// Enters the runtime context so that Tokio tasks can be spawned within it.
+    /// @method enter
+    /// @yield [Tokio::Runtime::EnterGuard]
+    /// @return [NilClass]
+    /// @see https://docs.rs/tokio/latest/tokio/runtime/struct.Runtime.html#method.enter Rust doc
+    pub fn enter(&self) -> Result<Value, Error> {
+        let ret = {
+            let _inner_guard = self.inner.enter();
+            yield_value(())
+        }?;
+
+        Ok(ret)
+    }
+}
+
+/// The "Tokio::Runtime" Ruby class.
+pub fn class() -> RClass {
+    *memoize!(RClass: {
+        crate::tokio_rb::root().define_class("Runtime", Default::default()).unwrap()
+    })
+}
+
+pub fn init() -> Result<(), Error> {
+    builder::init()?;
+
+    let klass = class();
+    klass.define_singleton_method("new", function!(Runtime::new, 0))?;
+    klass.define_method("enter", method!(Runtime::enter, 0))?;
+
+    handle::init()?;
+    enter_guard::init()?;
+
+    Ok(())
+}

--- a/sdk_rust/ext/src/tokio_rb/runtime/builder.rs
+++ b/sdk_rust/ext/src/tokio_rb/runtime/builder.rs
@@ -1,0 +1,111 @@
+use std::cell::{RefCell, RefMut};
+
+use magnus::{Error, Module, RString};
+
+use crate::error;
+use crate::tokio_rb::prelude::*;
+use crate::tokio_rb::{Runtime, WrappedStruct};
+
+#[magnus::wrap(class = "Tokio::Runtime::Builder", free_immediately)]
+#[derive(Debug)]
+pub struct Builder {
+    inner: RefCell<tokio::runtime::Builder>,
+}
+
+type RbBuilder = WrappedStruct<Builder>;
+
+impl Builder {
+    /// @yard
+    /// Creates a new builder for a multi-threaded Tokio runtime.
+    /// @method new_multi_thread
+    /// @return [Tokio::Runtime::Builder]
+    /// @see https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html#method.new_multi_thread Rust doc
+    pub fn new_multi_thread() -> Self {
+        let inner = tokio::runtime::Builder::new_multi_thread();
+
+        Self {
+            inner: RefCell::new(inner),
+        }
+    }
+
+    /// @yard
+    /// Creates a new builder with the current thread scheduler selected.
+    /// @method new_current_thread
+    /// @return [Tokio::Runtime::Builder]
+    /// @see https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html#method.new_current_thread Rust doc
+    pub fn new_current_thread() -> Self {
+        let inner = tokio::runtime::Builder::new_current_thread();
+
+        Self {
+            inner: RefCell::new(inner),
+        }
+    }
+
+    /// @yard
+    /// Set maximum number of blocking threads.
+    /// @method max_blocking_threads
+    /// @param n [Integer]
+    /// @return [Tokio::Runtime::Builder]
+    /// @see https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html#method.max_blocking_threads Rust doc
+    pub fn max_blocking_threads(rb_self: RbBuilder, n: usize) -> Result<RbBuilder, Error> {
+        let mut inner = rb_self.get().unwrap().inner().unwrap();
+        inner.max_blocking_threads(n);
+
+        Ok(rb_self)
+    }
+
+    /// @yard
+    /// Set the name of the threads spawned by the runtime.
+    /// @method thread_name
+    /// @param name [String]
+    /// @return [Tokio::Runtime::Builder]
+    /// @see https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html#method.thread_name Rust doc
+    pub fn thread_name(rb_self: RbBuilder, val: RString) -> Result<RbBuilder, Error> {
+        let mut inner = rb_self.get()?.inner()?;
+        let prefix = val.to_string()?;
+        inner.thread_name(&prefix);
+
+        Ok(rb_self)
+    }
+
+    /// @yard
+    /// Converts the builder into a runtime.
+    /// @return [Tokio::Runtime]
+    /// @see https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html#method.build Rust doc
+    pub fn build(&self) -> Result<Runtime, Error> {
+        let mut inner = self.inner()?;
+        let built = inner
+            .enable_all()
+            .build()
+            .map_err(|e| error!("Failed to build runtime: {}", e))?;
+
+        Ok(Runtime { inner: built })
+    }
+
+    fn inner(&self) -> Result<RefMut<tokio::runtime::Builder>, Error> {
+        let inner = self
+            .inner
+            .try_borrow_mut()
+            .map_err(|_| error!("Runtime is already borrowed"))?;
+
+        Ok(inner)
+    }
+}
+
+pub fn init() -> Result<(), Error> {
+    let rt = crate::tokio_rb::runtime::class();
+    let b = rt.define_class("Builder", Default::default())?;
+
+    b.define_singleton_method("new_multi_thread", function!(Builder::new_multi_thread, 0))?;
+    b.define_singleton_method(
+        "new_current_thread",
+        function!(Builder::new_current_thread, 0),
+    )?;
+    b.define_method("thread_name", method!(Builder::thread_name, 1))?;
+    b.define_method(
+        "max_blocking_threads",
+        method!(Builder::max_blocking_threads, 1),
+    )?;
+
+    Ok(())
+}

--- a/sdk_rust/ext/src/tokio_rb/runtime/enter_guard.rs
+++ b/sdk_rust/ext/src/tokio_rb/runtime/enter_guard.rs
@@ -1,0 +1,43 @@
+use magnus::Error;
+
+use crate::tokio_rb::prelude::*;
+use crate::tokio_rb::runtime;
+
+/// @yard
+/// @rename Tokio::EnterGuard
+/// Represents a Tokio EnterGuard.
+/// @see https://docs.rs/tokio/latest/tokio/EnterGuard/struct.EnterGuard.html Rust doc
+#[derive(Debug)]
+pub struct EnterGuard<'a> {
+    #[allow(dead_code)]
+    inner: tokio::runtime::EnterGuard<'a>,
+}
+
+unsafe impl<'a> TypedData for EnterGuard<'a> {
+    fn class() -> magnus::RClass {
+        *memoize!(RClass: runtime::class().define_class("EnterGuard", Default::default()).unwrap())
+    }
+
+    fn data_type() -> &'static magnus::DataType {
+        memoize!(magnus::DataType: {
+            let mut builder = DataTypeBuilder::<EnterGuard>::new("Tokio::Runtime::EnterGuard");
+            builder.free_immediately();
+            builder.build()
+        })
+    }
+}
+
+impl DataTypeFunctions for EnterGuard<'_> {}
+
+impl<'a> EnterGuard<'a> {
+    #[allow(dead_code)]
+    pub fn new(inner: tokio::runtime::EnterGuard<'a>) -> Result<Self, Error> {
+        Ok(Self { inner })
+    }
+}
+
+pub fn init() -> Result<(), Error> {
+    runtime::class().define_class("EnterGuard", Default::default())?;
+
+    Ok(())
+}

--- a/sdk_rust/ext/src/tokio_rb/runtime/handle.rs
+++ b/sdk_rust/ext/src/tokio_rb/runtime/handle.rs
@@ -1,0 +1,52 @@
+use magnus::{Error, Symbol};
+use tokio::runtime::RuntimeFlavor;
+
+use crate::error;
+use crate::tokio_rb::prelude::*;
+use crate::tokio_rb::runtime;
+
+/// @yard
+/// Represents a Tokio runtime handle.
+/// @see https://docs.rs/tokio/latest/tokio/runtime/struct.Handle.html Rust doc
+#[magnus::wrap(class = "Tokio::Runtime::Handle")]
+#[derive(Debug)]
+pub struct Handle {
+    inner: tokio::runtime::Handle,
+}
+
+impl Handle {
+    /// @yard
+    /// Gets a handle to the current runtime.
+    /// @method current
+    /// @return [Tokio::Runtime::Handle]
+    /// @see https://docs.rs/tokio/latest/tokio/runtime/struct.Handle.html#method.current Rust doc
+    pub fn current() -> Result<Self, Error> {
+        let inner = tokio::runtime::Handle::try_current().map_err(|e| error!("{}", e))?;
+
+        Ok(Self { inner })
+    }
+
+    /// @yard
+    /// Get the runtime's flavor (:current_thread or :multi_thread).
+    /// @method runtime_flavor
+    /// @return [Symbol]
+    /// @see https://docs.rs/tokio/latest/tokio/runtime/struct.Handle.html#method.runtime_flavor Rust doc
+    pub fn runtime_flavor(&self) -> Result<Symbol, Error> {
+        let flavor = self.inner.runtime_flavor();
+        let flavor = match flavor {
+            RuntimeFlavor::CurrentThread => "current_thread",
+            RuntimeFlavor::MultiThread => "multi_thread",
+            _ => return Err(error!("Unknown runtime flavor")),
+        };
+
+        Ok(Symbol::from(flavor))
+    }
+}
+
+pub fn init() -> Result<(), Error> {
+    let klass = runtime::class().define_class("Handle", Default::default())?;
+    klass.define_singleton_method("current", function!(Handle::current, 0))?;
+    klass.define_method("runtime_flavor", method!(Handle::runtime_flavor, 0))?;
+
+    Ok(())
+}

--- a/sdk_rust/test/bench.rb
+++ b/sdk_rust/test/bench.rb
@@ -1,35 +1,64 @@
 require "benchmark"
-require_relative "../lib/opentelemetry_sdk_rust"
+require "benchmark/memory"
+
+ENV['OTEL_TRACES_EXPORTER'] = ''
 
 n = 1_000_000
 Benchmark.bmbm do |x|
-  # x.report("empty") do
-  #   n.times {"".blank?}
-  # end
+  x.report("rust-cpu") do
+    require_relative "../lib/opentelemetry_sdk_rust"
+    OpenTelemetry::SDK.configure
+    tp = OpenTelemetry::SDK::Trace::TracerProvider.new
+    tracer = tp.tracer("benchmark", "0.1.0")
 
-  # x.report("blank") do
-  #   n.times {" ".blank?}
-  # end
+    n.times {
+      span = tracer.start_span("foo", attributes: {"answer" => 42, "true" => true, "false" => false, "float" => 1.0, "stringy" => "mcstringface"})
+      span.finish
+    }
+    GC.start
+  end
 
-  # x.report("present") do
-  #   n.times {"x".blank?}
-  # end
+  x.report("ruby-cpu") do
+    require "opentelemetry/sdk"
+    OpenTelemetry::SDK.configure
+    tp = OpenTelemetry::SDK::Trace::TracerProvider.new
+    tracer = tp.tracer("benchmark", "0.1.0")
 
-  # x.report("lots of spaces blank") do
-  #   n.times {"                                          ".blank?}
-  # end
+    n.times {
+      span = tracer.start_span("foo", attributes: {"answer" => 42, "true" => true, "false" => false, "float" => 1.0, "stringy" => "mcstringface"})
+      span.finish
+    }
+    GC.start
+  end
+end
 
-  # x.report("lots of spaces present") do
-  #   n.times {"                                          x".blank?}
-  # end
+n = 1_000
+Benchmark.memory do |x|
+  x.report("rust-memory") do
+    require_relative "../lib/opentelemetry_sdk_rust"
+    OpenTelemetry::SDK.configure
+    tp = OpenTelemetry::SDK::Trace::TracerProvider.new
+    tracer = tp.tracer("benchmark", "0.1.0")
 
-  # x.report("blank US-ASCII") do
-  #   s = " ".encode("US-ASCII")
-  #   n.times {s.blank?}
-  # end
+    n.times {
+      span = tracer.start_span("foo", attributes: {"answer" => 42, "true" => true, "false" => false, "float" => 1.0, "stringy" => "mcstringface"})
+      span.finish
+    }
+    GC.start
+  end
 
-  # x.report("blank non-utf-8") do
-  #   s = " ".encode("UTF-16LE")
-  #   n.times {s.blank?}
-  # end
+  x.report("ruby-memory") do
+    require "opentelemetry/sdk"
+    OpenTelemetry::SDK.configure
+    tp = OpenTelemetry::SDK::Trace::TracerProvider.new
+    tracer = tp.tracer("benchmark", "0.1.0")
+
+    n.times {
+      span = tracer.start_span("foo", attributes: {"answer" => 42, "true" => true, "false" => false, "float" => 1.0, "stringy" => "mcstringface"})
+      span.finish
+    }
+    GC.start
+  end
+
+  x.compare!
 end

--- a/sdk_rust/test/ruby_bench.rb
+++ b/sdk_rust/test/ruby_bench.rb
@@ -4,7 +4,7 @@
 
 require "benchmark"
 require "benchmark/memory"
-require "opentelemetry/sdk"
+require_relative "../../sdk/lib/opentelemetry-sdk"
 
 ENV['OTEL_TRACES_EXPORTER'] = ''
 

--- a/sdk_rust/test/ruby_bench.rb
+++ b/sdk_rust/test/ruby_bench.rb
@@ -26,7 +26,6 @@ end
 n = 1_000
 Benchmark.memory do |x|
   x.report("ruby-memory") do
-    before = GC.stat[:total_allocated_objects]
     OpenTelemetry::SDK.configure
     tp = OpenTelemetry::SDK::Trace::TracerProvider.new
     tracer = tp.tracer("benchmark", "0.1.0")
@@ -35,9 +34,5 @@ Benchmark.memory do |x|
       span = tracer.start_span("foo", attributes: {"answer" => 42, "true" => true, "false" => false, "float" => 1.0, "stringy" => "mcstringface"})
       span.finish
     }
-    GC.start
-    puts GC.stat[:total_allocated_objects] - before
   end
-
-  x.compare!
 end

--- a/sdk_rust/test/rust_bench.rb
+++ b/sdk_rust/test/rust_bench.rb
@@ -23,10 +23,9 @@ Benchmark.bmbm do |x|
   end
 end
 
-n = 1_000
+n = 1_000_000
 Benchmark.memory do |x|
   x.report("rust-memory") do
-    before = GC.stat[:total_allocated_objects]
     OpenTelemetry::SDK.configure
     tp = OpenTelemetry::SDK::Trace::TracerProvider.new
     tracer = tp.tracer("benchmark", "0.1.0")
@@ -35,7 +34,5 @@ Benchmark.memory do |x|
       span = tracer.start_span("foo", attributes: {"answer" => 42, "true" => true, "false" => false, "float" => 1.0, "stringy" => "mcstringface"})
       span.finish
     }
-    GC.start
-    puts GC.stat[:total_allocated_objects] - before
   end
 end

--- a/sdk_rust/test/rust_bench.rb
+++ b/sdk_rust/test/rust_bench.rb
@@ -1,0 +1,41 @@
+###
+# Benchmark the new Rust implementation
+###
+
+require "benchmark"
+require "benchmark/memory"
+require_relative "../lib/opentelemetry_sdk_rust"
+
+ENV['OTEL_TRACES_EXPORTER'] = ''
+
+n = 1_000_000
+Benchmark.bmbm do |x|
+  x.report("rust-cpu") do
+    OpenTelemetry::SDK.configure
+    tp = OpenTelemetry::SDK::Trace::TracerProvider.new
+    tracer = tp.tracer("benchmark", "0.1.0")
+
+    n.times {
+      span = tracer.start_span("foo", attributes: {"answer" => 42, "true" => true, "false" => false, "float" => 1.0, "stringy" => "mcstringface"})
+      span.finish
+    }
+    GC.start
+  end
+end
+
+n = 1_000
+Benchmark.memory do |x|
+  x.report("rust-memory") do
+    before = GC.stat[:total_allocated_objects]
+    OpenTelemetry::SDK.configure
+    tp = OpenTelemetry::SDK::Trace::TracerProvider.new
+    tracer = tp.tracer("benchmark", "0.1.0")
+
+    n.times {
+      span = tracer.start_span("foo", attributes: {"answer" => 42, "true" => true, "false" => false, "float" => 1.0, "stringy" => "mcstringface"})
+      span.finish
+    }
+    GC.start
+    puts GC.stat[:total_allocated_objects] - before
+  end
+end

--- a/sdk_rust/test/sdk_test.rb
+++ b/sdk_rust/test/sdk_test.rb
@@ -4,39 +4,42 @@ require "test/unit"
 require_relative "../lib/opentelemetry_sdk_rust"
 
 class SDKTest < Test::Unit::TestCase
-  def test_tracer_provider
-    assert { !OpenTelemetry::SDK::Trace::TracerProvider.new.nil? }
-    assert { !OpenTelemetry::SDK::Trace::TracerProvider.new.tracer("foo").nil? }
-    assert { !OpenTelemetry::SDK::Trace::TracerProvider.new.tracer("foo", "1.2.3").nil? }
-    assert_nothing_raised { OpenTelemetry::SDK::Trace::TracerProvider.new.tracer("foo", "1.2.3").start_span("bar").finish }
-  end
+  # def test_tracer_provider
+  #   assert { !OpenTelemetry::SDK::Trace::TracerProvider.new.nil? }
+  #   assert { !OpenTelemetry::SDK::Trace::TracerProvider.new.tracer("foo").nil? }
+  #   assert { !OpenTelemetry::SDK::Trace::TracerProvider.new.tracer("foo", "1.2.3").nil? }
+  #   assert_nothing_raised { OpenTelemetry::SDK::Trace::TracerProvider.new.tracer("foo", "1.2.3").start_span("bar").finish }
+  # end
 
-  def test_sdk_configure
-    assert_nothing_raised do
-      OpenTelemetry::SDK.configure
-      tp = OpenTelemetry::SDK::Trace::TracerProvider.new
-      tp.tracer("foo", "1.2.3").start_span("bar", attributes: {"answer" => 42, "true" => true, "false" => false, "float" => 1.0, "stringy" => "mcstringface"}).finish
-      tp.shutdown
-    end
-  end
+  # def test_sdk_configure
+  #   assert_nothing_raised do
+  #     OpenTelemetry::SDK.configure
+  #     tp = OpenTelemetry::SDK::Trace::TracerProvider.new
+  #     tp.tracer("foo", "1.2.3").start_span("bar", attributes: {"answer" => 42, "true" => true, "false" => false, "float" => 1.0, "stringy" => "mcstringface"}).finish
+  #     tp.shutdown
+  #   end
+  # end
 
   def test_sdk_configure_with_env
     assert_nothing_raised do
-      # require "pry"
-      # binding.pry
       ENV['OTEL_EXPORTER_OTLP_ENDPOINT'] = 'http://localhost:4317'
-      ENV['OTEL_TRACES_EXPORTER'] = 'console,otlp'
+      ENV['OTEL_TRACES_EXPORTER'] = 'otlp'
 
-      tokio = Tokio::Runtime.new
-      tokio.enter do
-        puts "Ruby land handle", Tokio::Runtime::Handle.current.runtime_flavor
+      rt = Tokio::Runtime.new
+
+      rt.enter do
         OpenTelemetry::SDK.configure
       end
 
       tp = OpenTelemetry::SDK::Trace::TracerProvider.new
       tp.tracer("foo", "1.2.3").start_span("bar", attributes: {"answer" => 42, "true" => true, "false" => false, "float" => 1.0, "stringy" => "mcstringface"}).finish
-      tp.shutdown
 
+      tp.shutdown # on the Rust side, drops the inner TracerProvider held in global
+
+      rt = nil # drop reference to tokio runtime
+      GC.start
+      tp = nil # drop reference to tracer provider
+      GC.start
       ENV.delete('OTEL_EXPORTER_OTLP_ENDPOINT')
       ENV.delete('OTEL_TRACES_EXPORTER')
     end

--- a/sdk_rust/test/sdk_test.rb
+++ b/sdk_rust/test/sdk_test.rb
@@ -19,4 +19,16 @@ class SDKTest < Test::Unit::TestCase
       tp.shutdown
     end
   end
+
+  def test_sdk_configure_with_env
+    assert_nothing_raised do
+      ENV['OTEL_EXPORTER_OTLP_ENDPOINT'] = 'http://localhost:4317'
+      ENV['OTEL_TRACES_EXPORTER'] = 'console,otlp'
+
+      OpenTelemetry::SDK.configure
+
+      ENV.delete('OTEL_EXPORTER_OTLP_ENDPOINT')
+      ENV.delete('OTEL_TRACES_EXPORTER')
+    end
+  end
 end

--- a/sdk_rust/test/sdk_test.rb
+++ b/sdk_rust/test/sdk_test.rb
@@ -4,21 +4,21 @@ require "test/unit"
 require_relative "../lib/opentelemetry_sdk_rust"
 
 class SDKTest < Test::Unit::TestCase
-  # def test_tracer_provider
-  #   assert { !OpenTelemetry::SDK::Trace::TracerProvider.new.nil? }
-  #   assert { !OpenTelemetry::SDK::Trace::TracerProvider.new.tracer("foo").nil? }
-  #   assert { !OpenTelemetry::SDK::Trace::TracerProvider.new.tracer("foo", "1.2.3").nil? }
-  #   assert_nothing_raised { OpenTelemetry::SDK::Trace::TracerProvider.new.tracer("foo", "1.2.3").start_span("bar").finish }
-  # end
+  def test_tracer_provider
+    assert { !OpenTelemetry::SDK::Trace::TracerProvider.new.nil? }
+    assert { !OpenTelemetry::SDK::Trace::TracerProvider.new.tracer("foo").nil? }
+    assert { !OpenTelemetry::SDK::Trace::TracerProvider.new.tracer("foo", "1.2.3").nil? }
+    assert_nothing_raised { OpenTelemetry::SDK::Trace::TracerProvider.new.tracer("foo", "1.2.3").start_span("bar").finish }
+  end
 
-  # def test_sdk_configure
-  #   assert_nothing_raised do
-  #     OpenTelemetry::SDK.configure
-  #     tp = OpenTelemetry::SDK::Trace::TracerProvider.new
-  #     tp.tracer("foo", "1.2.3").start_span("bar", attributes: {"answer" => 42, "true" => true, "false" => false, "float" => 1.0, "stringy" => "mcstringface"}).finish
-  #     tp.shutdown
-  #   end
-  # end
+  def test_sdk_configure
+    assert_nothing_raised do
+      OpenTelemetry::SDK.configure
+      tp = OpenTelemetry::SDK::Trace::TracerProvider.new
+      tp.tracer("foo", "1.2.3").start_span("bar", attributes: {"answer" => 42, "true" => true, "false" => false, "float" => 1.0, "stringy" => "mcstringface"}).finish
+      tp.shutdown
+    end
+  end
 
   def test_sdk_configure_with_env
     assert_nothing_raised do
@@ -35,11 +35,6 @@ class SDKTest < Test::Unit::TestCase
       tp.tracer("foo", "1.2.3").start_span("bar", attributes: {"answer" => 42, "true" => true, "false" => false, "float" => 1.0, "stringy" => "mcstringface"}).finish
 
       tp.shutdown # on the Rust side, drops the inner TracerProvider held in global
-
-      rt = nil # drop reference to tokio runtime
-      GC.start
-      tp = nil # drop reference to tracer provider
-      GC.start
       ENV.delete('OTEL_EXPORTER_OTLP_ENDPOINT')
       ENV.delete('OTEL_TRACES_EXPORTER')
     end

--- a/sdk_rust/test/sdk_test.rb
+++ b/sdk_rust/test/sdk_test.rb
@@ -22,10 +22,20 @@ class SDKTest < Test::Unit::TestCase
 
   def test_sdk_configure_with_env
     assert_nothing_raised do
+      # require "pry"
+      # binding.pry
       ENV['OTEL_EXPORTER_OTLP_ENDPOINT'] = 'http://localhost:4317'
       ENV['OTEL_TRACES_EXPORTER'] = 'console,otlp'
 
-      OpenTelemetry::SDK.configure
+      tokio = Tokio::Runtime.new
+      tokio.enter do
+        puts "Ruby land handle", Tokio::Runtime::Handle.current.runtime_flavor
+        OpenTelemetry::SDK.configure
+      end
+
+      tp = OpenTelemetry::SDK::Trace::TracerProvider.new
+      tp.tracer("foo", "1.2.3").start_span("bar", attributes: {"answer" => 42, "true" => true, "false" => false, "float" => 1.0, "stringy" => "mcstringface"}).finish
+      tp.shutdown
 
       ENV.delete('OTEL_EXPORTER_OTLP_ENDPOINT')
       ENV.delete('OTEL_TRACES_EXPORTER')


### PR DESCRIPTION
* Removes the `otel::sdk::export::trace::stdout::new_pipeline` usage in
  favor of building a `TracerProvider` manually, which gives more
  controls on the options used.
* Implement `OTEL_TRACES_EXPORTER` environment variable handling for
  `otlp` and `console`
* Adds dependencies on `tokio` and `lazy_static` to provide an async
  runtime for OpenTelemetry's `BatchSpanProcessor` (needed for otlp)

Also adds pattern to `.gitignore` to ignore the Rust build artifact