### PR TITLE
chore: fix rubocop failures

### DIFF
--- a/semantic_conventions/opentelemetry-semantic_conventions.gemspec
+++ b/semantic_conventions/opentelemetry-semantic_conventions.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.homepage    = 'https://github.com/open-telemetry/opentelemetry-ruby'
   spec.license     = 'Apache-2.0'
 
-  spec.files = ::Dir.glob('lib/**/*.rb') +
-               ::Dir.glob('*.md') +
+  spec.files = Dir.glob('lib/**/*.rb') +
+               Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.6.0'

--- a/test_helpers/opentelemetry-test-helpers.gemspec
+++ b/test_helpers/opentelemetry-test-helpers.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.homepage    = 'https://github.com/open-telemetry/opentelemetry-ruby'
   spec.license     = 'Apache-2.0'
 
-  spec.files = ::Dir.glob('lib/**/*.rb') +
-               ::Dir.glob('*.md') +
+  spec.files = Dir.glob('lib/**/*.rb') +
+               Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.6.0'


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-ruby/actions/runs/3759043711/jobs/6388124989
```
opentelemetry-semantic_conventions.gemspec:22:16: C: [Correctable] Style/RedundantConstantBase: Remove redundant ::.
  spec.files = ::Dir.glob('lib/**/*.rb') +
               ^^
opentelemetry-semantic_conventions.gemspec:23:16: C: [Correctable] Style/RedundantConstantBase: Remove redundant ::.
               ::Dir.glob('*.md') +
```

```
opentelemetry-test-helpers.gemspec:22:16: C: [Correctable] Style/RedundantConstantBase: Remove redundant ::.
  spec.files = ::Dir.glob('lib/**/*.rb') +
               ^^
opentelemetry-test-helpers.gemspec:23:16: C: [Correctable] Style/RedundantConstantBase: Remove redundant ::.
               ::Dir.glob('*.md') +
               ^^
```