### PR TITLE
Update docs about default span status

### DIFF
--- a/api/lib/opentelemetry/trace/span.rb
+++ b/api/lib/opentelemetry/trace/span.rb
@@ -115,7 +115,7 @@ module OpenTelemetry
 
       # Sets the Status to the Span
       #
-      # If used, this will override the default Span status. Default is OK.
+      # If used, this will override the default Span status. Default status is unset.
       #
       # Only the value of the last call will be recorded, and implementations
       # are free to ignore previous calls.


### PR DESCRIPTION
In the SDK, this defaults to unset: https://github.com/open-telemetry/opentelemetry-ruby/blob/48eb8367c2eee15cc59d4f83ee137a9b931695fc/sdk/lib/opentelemetry/sdk/trace/span.rb#L19 In spec, it also notes that default is unset: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status.

I don't think  span status matters in the context of an API span, but this might reduce the chance of confusion.