### PR TITLE
fix: Refactor consistent prob sampler for reuse

### DIFF
--- a/sdk_experimental/lib/opentelemetry/sdk/trace/samplers/consistent_probability_based.rb
+++ b/sdk_experimental/lib/opentelemetry/sdk/trace/samplers/consistent_probability_based.rb
@@ -69,12 +69,6 @@ module OpenTelemetry
 
           private
 
-          def generate_r(trace_id)
-            x = trace_id[8, 8].unpack1('Q>') | 0x3
-            clz = 64 - x.bit_length
-            clz
-          end
-
           def probabilistic_p
             if Random.rand < @p_ceil_probability
               @p_ceil

--- a/sdk_experimental/lib/opentelemetry/sdk/trace/samplers/parent_consistent_probability_based.rb
+++ b/sdk_experimental/lib/opentelemetry/sdk/trace/samplers/parent_consistent_probability_based.rb
@@ -55,31 +55,6 @@ module OpenTelemetry
           protected
 
           attr_reader :root
-
-          private
-
-          # sanitized_tracestate returns an OpenTelemetry Tracestate object with the
-          # tracestate sanitized according to the Context invariants defined in the
-          # tracestate probability sampling spec.
-          #
-          # @param span_context [OpenTelemetry::Trace::SpanContext] the parent span context
-          # @return [OpenTelemetry::Trace::Tracestate] the sanitized tracestate
-          def sanitized_tracestate(span_context)
-            sampled = span_context.trace_flags.sampled?
-            tracestate = span_context.tracestate
-            parse_ot_vendor_tag(tracestate) do |p, r, rest|
-              if !r.nil? && r > 62
-                p = r = nil
-              elsif !p.nil? && p > 63
-                p = nil
-              elsif !p.nil? && !r.nil? && !invariant(p, r, sampled)
-                p = nil
-              else
-                return tracestate
-              end
-              update_tracestate(tracestate, p, r, rest)
-            end
-          end
         end
       end
     end


### PR DESCRIPTION
This refactors the consistent probability sampler code to ease reuse in custom samplers that wish to interoperate with tracestate-based sampling. The primary change is to hoist pure functions from the concrete sampler classes into the included `ConsistentProbabilityTraceState` mixin. It also makes methods from that mixin `private` - they were accidentally `public` previously, although the entire module was marked `@api private`.