### PR TITLE
chore: quiet the cop

### DIFF
--- a/test_helpers/.rubocop.yml
+++ b/test_helpers/.rubocop.yml
@@ -1,6 +1,5 @@
 AllCops:
   TargetRubyVersion: "2.6.0"
-  NewCops: enable
 
 Lint/UnusedMethodArgument:
   Enabled: false


### PR DESCRIPTION
```
Running RuboCop...
RuboCop failed!
Inspecting 8 files
.....C..

Offenses:

opentelemetry-test-helpers.gemspec:30:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency 'opentelemetry-sdk'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
opentelemetry-test-helpers.gemspec:31:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency 'pry'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
opentelemetry-test-helpers.gemspec:32:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
