### PR TITLE
Add Ruby 3.2 to CI and do small fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
+      - name: "Test Ruby 3.2"
+        uses: ./.github/actions/test_gem
+        with:
+          gem: "${{ matrix.gem }}"
+          ruby: "3.2"
       - name: "Test Ruby 3.1"
+        if: "${{ matrix.os == 'ubuntu-latest' }}"
         uses: ./.github/actions/test_gem
         with:
           gem: "${{ matrix.gem }}"
@@ -88,7 +94,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
+      - name: "Test Ruby 3.2"
+        uses: ./.github/actions/test_gem
+        with:
+          gem: "${{ matrix.gem }}"
+          ruby: "3.2"
       - name: "Test Ruby 3.1"
+        if: "${{ matrix.os == 'ubuntu-latest' }}"
         uses: ./.github/actions/test_gem
         with:
           gem: "${{ matrix.gem }}"
@@ -158,7 +170,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
+      - name: "Test Ruby 3.2"
+        uses: ./.github/actions/test_gem
+        with:
+          gem: "${{ matrix.gem }}"
+          ruby: "3.2"
       - name: "Test Ruby 3.1"
+        if: "${{ matrix.os == 'ubuntu-latest' }}"
         uses: ./.github/actions/test_gem
         with:
           gem: "${{ matrix.gem }}"

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -398,7 +398,7 @@ module OpenTelemetry
             begin
               k = k.to_s.strip
               v = v.to_s.strip
-            rescue ArgumentError => e
+            rescue ArgumentError, Encoding::CompatibilityError => e
               raise e, ERROR_MESSAGE_INVALID_HEADERS
             end
             raise ArgumentError, ERROR_MESSAGE_INVALID_HEADERS if k.empty? || v.empty?

--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -233,14 +233,14 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
           OpenTelemetry::TestHelpers.with_env('OTEL_EXPORTER_OTLP_HEADERS' => 'c=hi%F3') do
             OpenTelemetry::Exporter::OTLP::Exporter.new
           end
-        }.must_raise(ArgumentError)
+        }.must_raise(Encoding::CompatibilityError)
         _(error.message).must_match(/headers/i)
 
         error = _() {
           OpenTelemetry::TestHelpers.with_env('OTEL_EXPORTER_OTLP_TRACES_HEADERS' => 'c=hi%F3') do
             OpenTelemetry::Exporter::OTLP::Exporter.new
           end
-        }.must_raise(ArgumentError)
+        }.must_raise(Encoding::CompatibilityError)
         _(error.message).must_match(/headers/i)
       end
 


### PR DESCRIPTION
- Add Ruby 3.2 to CI.
- rescue compatibility error in addition to argument error
