### PR TITLE
chore: Add .tool-versions to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ instrumentation/active_record/db
 # IDE Settings
 /.idea/
 
+# asdf configuration
+.tool-versions
+
 # rbenv configuration
 .ruby-version
 


### PR DESCRIPTION
Hi! I'm using [`asdf`] and it uses the `.tool-versions` file to keep
track of the Ruby version, similar to `.ruby-version`.

Is it okay to add it to `.gitignore` as well?

[`asdf`]: https://asdf-vm.com/