### PR TITLE
fix: Warning messages from gem build

### DIFF
--- a/metrics_api/opentelemetry-metrics-api.gemspec
+++ b/metrics_api/opentelemetry-metrics-api.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
 
   spec.add_development_dependency 'benchmark-ipsa', '~> 0.2.0'
-  spec.add_development_dependency 'bundler', '~> 1.17'
+  spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'faraday', '~> 0.13'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3.0'

--- a/metrics_api/opentelemetry-metrics-api.gemspec
+++ b/metrics_api/opentelemetry-metrics-api.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |spec|
   spec.email       = ['cncf-opentelemetry-contributors@lists.cncf.io']
 
   spec.summary     = 'A stats collection and distributed tracing framework'
-  spec.description = 'A stats collection and distributed tracing framework'
   spec.homepage    = 'https://github.com/open-telemetry/opentelemetry-ruby'
   spec.license     = 'Apache-2.0'
 
@@ -28,10 +27,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
 
   spec.add_development_dependency 'benchmark-ipsa', '~> 0.2.0'
-  spec.add_development_dependency 'bundler', '>= 1.17'
+  spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'faraday', '~> 0.13'
   spec.add_development_dependency 'minitest', '~> 5.0'
-  spec.add_development_dependency 'opentelemetry-test-helpers'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3.0'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rubocop', '~> 0.73.0'
   spec.add_development_dependency 'simplecov', '~> 0.17'

--- a/semantic_conventions/.rubocop.yml
+++ b/semantic_conventions/.rubocop.yml
@@ -38,3 +38,5 @@ Layout/TrailingEmptyLines:
   Enabled: false
 Gemspec/RequireMFA:
   Enabled: false
+Gemspec/DevelopmentDependencies:
+  Enabled: false

--- a/semantic_conventions/.rubocop.yml
+++ b/semantic_conventions/.rubocop.yml
@@ -5,11 +5,27 @@ AllCops:
 Bundler/OrderedGems:
   Exclude:
     - gemfiles/**/*
-Lint/UnusedMethodArgument:
+
+Gemspec/DevelopmentDependencies:
   Enabled: false
-Metrics/AbcSize:
+Gemspec/RequireMFA:
+  Enabled: false
+
+Layout/EmptyLinesAroundModuleBody:
   Enabled: false
 Layout/LineLength:
+  Enabled: false
+Layout/TrailingEmptyLines:
+  Enabled: false
+Layout/TrailingWhitespace:
+  Enabled: false
+
+Lint/UnusedMethodArgument:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+Metrics/BlockLength:
   Enabled: false
 Metrics/MethodLength:
   Max: 20
@@ -17,6 +33,11 @@ Metrics/ModuleLength:
   Enabled: false
 Metrics/ParameterLists:
   Enabled: false
+
+Naming/FileName:
+  Exclude:
+    - lib/opentelemetry-semantic_conventions.rb
+
 Style/FrozenStringLiteralComment:
   Exclude:
     - gemfiles/**/*
@@ -25,18 +46,3 @@ Style/ModuleFunction:
 Style/StringLiterals:
   Exclude:
     - gemfiles/**/*
-Metrics/BlockLength:
-  Enabled: false
-Naming/FileName:
-  Exclude:
-    - "lib/opentelemetry-semantic_conventions.rb"
-Layout/EmptyLinesAroundModuleBody:
-  Enabled: false
-Layout/TrailingWhitespace:
-  Enabled: false
-Layout/TrailingEmptyLines:
-  Enabled: false
-Gemspec/RequireMFA:
-  Enabled: false
-Gemspec/DevelopmentDependencies:
-  Enabled: false


### PR DESCRIPTION
When running `gem build opentelemetry-metrics-api.gemspec` locally
I was getting the following warning messages:

    WARNING:  description and summary are identical
    WARNING:  open-ended dependency on bundler (>= 1.17, development) is not recommended
      if bundler is semantically versioned, use:
        add_development_dependency 'bundler', '~> 1.17'
    WARNING:  open-ended dependency on opentelemetry-test-helpers (>= 0, development)
      is not recommended
      use a bounded requirement, such as '~> x.y'
    WARNING:  See https://guides.rubygems.org/specification-reference/ for help
      Successfully built RubyGem
      Name: opentelemetry-metrics-api
      Version: 0.0.1
      File: opentelemetry-metrics-api-0.0.1.gem

This commit intends to fix them.

Also,
- Disable Gemspec/DevelopmentDependencies rubocop rule in semantic_conventions
- Sort semantic_conventions' .rubocop.yml file