### PR TITLE
test: Add tests for MeterProvider API

### DIFF
--- a/metrics_api/lib/opentelemetry/metrics/meter_provider.rb
+++ b/metrics_api/lib/opentelemetry/metrics/meter_provider.rb
@@ -10,11 +10,11 @@ module OpenTelemetry
     class MeterProvider
       # Returns a {Meter} instance.
       #
-      # @param [optional String] name Instrumentation package name
+      # @param [String] name Instrumentation package name
       # @param [optional String] version Instrumentation package version
       #
       # @return [Meter]
-      def meter(name = nil, version = nil)
+      def meter(name, version = nil)
         @meter ||= Meter.new
       end
     end

--- a/metrics_api/test/opentelemetry/metrics/meter_provider_test.rb
+++ b/metrics_api/test/opentelemetry/metrics/meter_provider_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+describe OpenTelemetry::Metrics::MeterProvider do
+  describe '#meter' do
+    it 'requires a name' do
+      meter_provider = build_meter_provider
+
+      _(-> { meter_provider.meter }).must_raise(ArgumentError)
+    end
+
+    it 'returns an instance of Meter' do
+      meter_provider = build_meter_provider
+
+      assert(meter_provider.meter('test', '1.0.0').is_a?(OpenTelemetry::Metrics::Meter))
+    end
+  end
+
+  def build_meter_provider
+    OpenTelemetry::Metrics::MeterProvider.new
+  end
+end

--- a/metrics_api/test/opentelemetry/opentelemetry_test.rb
+++ b/metrics_api/test/opentelemetry/opentelemetry_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+describe OpenTelemetry do
+  after do
+    # TODO: After Metrics SDK is incoporated into OpenTelemetry SDK, move this
+    # to OpenTelemetry::TestHelpers.reset_opentelemetry
+    OpenTelemetry.instance_variable_set(
+      :@meter_provider,
+      OpenTelemetry::Internal::ProxyMeterProvider.new
+    )
+  end
+
+  describe '#meter_provider and #meter_provider=' do
+    it 'initializes with a global instance of ProxyMeterProvider' do
+      assert(OpenTelemetry.meter_provider.is_a?(OpenTelemetry::Internal::ProxyMeterProvider))
+    end
+
+    it 'sets global MeterProvider to the given meter_provider' do
+      new_meter_provider = OpenTelemetry::Metrics::MeterProvider.new
+
+      OpenTelemetry.meter_provider = new_meter_provider
+
+      assert(OpenTelemetry.meter_provider.object_id == new_meter_provider.object_id)
+    end
+
+    describe 'when global MeterProvider is an instance of Internal::ProxyMeterProvider' do
+      it 'sets ProxyMeterProvider#delegate to the given meter_provider and logs a debug message' do
+        proxy_meter_provider = OpenTelemetry.meter_provider
+        new_meter_provider = OpenTelemetry::Metrics::MeterProvider.new
+
+        OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
+          OpenTelemetry.meter_provider = new_meter_provider
+
+          assert(proxy_meter_provider.instance_variable_get(:@delegate).object_id == new_meter_provider.object_id)
+          assert(OpenTelemetry.meter_provider.object_id == new_meter_provider.object_id)
+          assert(log_stream.string.match?(/Upgrading default proxy meter provider to #{new_meter_provider.class}/i))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Make `name` a required argument
- Add test for `MeterProvider#meter`
- Add test for `OpenTelemetry.{meter_provider,meter_provider=}`