### PR TITLE
fix: Consistent probability sampler init

### DIFF
--- a/sdk_experimental/lib/opentelemetry/sdk/trace/samplers/consistent_probability_based.rb
+++ b/sdk_experimental/lib/opentelemetry/sdk/trace/samplers/consistent_probability_based.rb
@@ -25,7 +25,7 @@ module OpenTelemetry
             end
 
             @p_floor = (Math.frexp(probability)[1] - 1).abs
-            @p_ceil = @p_floor + 1
+            @p_ceil = @p_floor - 1
             floor = Math.ldexp(1.0, -@p_floor)
             ceil = Math.ldexp(1.0, -@p_ceil)
             @p_ceil_probability = (probability - floor) / (ceil - floor)

--- a/sdk_experimental/test/opentelemetry/sdk/trace/samplers/consistent_probability_based_test.rb
+++ b/sdk_experimental/test/opentelemetry/sdk/trace/samplers/consistent_probability_based_test.rb
@@ -92,6 +92,8 @@ describe OpenTelemetry::SDK::Trace::Samplers::ConsistentProbabilityBased do
       floor_prob = 1 - ceil_prob
       p_floor = sampler.instance_variable_get(:@p_floor)
       p_ceil = sampler.instance_variable_get(:@p_ceil)
+      # Verify that the sampling probability encoded in each `p` adds up to the probability
+      # in the the initializer argument  
       _((2**-p_ceil * ceil_prob) + (2**-p_floor * floor_prob)).must_be_within_epsilon(0.1)
     end
   end

--- a/sdk_experimental/test/opentelemetry/sdk/trace/samplers/consistent_probability_based_test.rb
+++ b/sdk_experimental/test/opentelemetry/sdk/trace/samplers/consistent_probability_based_test.rb
@@ -92,7 +92,7 @@ describe OpenTelemetry::SDK::Trace::Samplers::ConsistentProbabilityBased do
       floor_prob = 1 - ceil_prob
       p_floor = sampler.instance_variable_get(:@p_floor)
       p_ceil = sampler.instance_variable_get(:@p_ceil)
-      _((p_ceil * ceil_prob) + (p_floor * floor_prob)).must_be_within_epsilon(0.1)
+      _((2**-p_ceil * ceil_prob) + (2**-p_floor * floor_prob)).must_be_within_epsilon(0.1)
     end
   end
 end


### PR DESCRIPTION
In the consistent probability sampler, we cache the exponent of the next highest and next lowest negative power-of-two values, and the probability of the highest. E.g. for a probability of 0.1, the next highest negative power-of-two is 2**-3 (0.125) and the next lowest is 2**-4 (0.0625), and the probability of the higher value is the fraction of difference between the 0.0625 and 0.125 that is 0.1 - i.e. 0.1 - 0.0625 / 0.0625 = 0.6.

Unfortunately, we calculated the ceiling incorrectly in the current implementation. Because these are negative power-of-two exponents, the _smaller_ value is the _upper_ bound and the _larger_ value is the _lower_ bound. This corrects that error.

Relevant song: https://www.youtube.com/watch?v=Esdnbq4hxHo