### PR TITLE
Reverse the require order so that the VERSION is available to the exporter

### DIFF
--- a/exporter/otlp/lib/opentelemetry/exporter/otlp.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp.rb
@@ -4,8 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'opentelemetry/exporter/otlp/exporter'
-require 'opentelemetry/exporter/otlp/version'
+require "opentelemetry/exporter/otlp/version"
+require "opentelemetry/exporter/otlp/exporter"
 
 # OpenTelemetry is an open source observability framework, providing a
 # general-purpose API, SDK, and related tools required for the instrumentation

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp.rb
@@ -4,8 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require "opentelemetry/exporter/otlp/version"
-require "opentelemetry/exporter/otlp/exporter"
+require 'opentelemetry/exporter/otlp/version'
+require 'opentelemetry/exporter/otlp/exporter'
 
 # OpenTelemetry is an open source observability framework, providing a
 # general-purpose API, SDK, and related tools required for the instrumentation


### PR DESCRIPTION
Potentially fixes https://github.com/open-telemetry/opentelemetry-ruby/issues/1457

`rake test` is failing for me on `main`

```
opentelemetry-ruby/exporter/otlp git/main
❯ rake test
/Users/jmorrell/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/google-protobuf-3.23.2-arm64-darwin/lib/google/protobuf/any_pb.rb:15: warning: assigned but unused variable - e
Coverage report generated for Unit Tests to /Users/jmorrell/workspace/opentelemetry-ruby/exporter/otlp/coverage. 161 / 353 LOC (45.61%) covered.
Stopped processing SimpleCov as a previous error not related to SimpleCov has been detected
/Users/jmorrell/workspace/opentelemetry-ruby/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb:38:in `<class:Exporter>': uninitialized constant OpenTelemetry::Exporter::OTLP::VERSION (NameError)

        DEFAULT_USER_AGENT = "OTel-OTLP-Exporter-Ruby/#{OpenTelemetry::Exporter::OTLP::VERSION} Ruby/#{RUBY_VERSION} (#{RUBY_PLATFORM}; #{RUBY_ENGINE}/#{RUBY_ENGINE_VERSION})"
                                                                                     ^^^^^^^^^
	from /Users/jmorrell/workspace/opentelemetry-ruby/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb:24:in `<module:OTLP>'
	from /Users/jmorrell/workspace/opentelemetry-ruby/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb:22:in `<module:Exporter>'
	from /Users/jmorrell/workspace/opentelemetry-ruby/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb:21:in `<module:OpenTelemetry>'
	from /Users/jmorrell/workspace/opentelemetry-ruby/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb:20:in `<top (required)>'
	from <internal:/Users/jmorrell/.rbenv/versions/3.2.1/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:88:in `require'
	from <internal:/Users/jmorrell/.rbenv/versions/3.2.1/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:88:in `require'
	from /Users/jmorrell/workspace/opentelemetry-ruby/exporter/otlp/lib/opentelemetry/exporter/otlp.rb:7:in `<top (required)>'
	from <internal:/Users/jmorrell/.rbenv/versions/3.2.1/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:88:in `require'
	from <internal:/Users/jmorrell/.rbenv/versions/3.2.1/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:88:in `require'
	from /Users/jmorrell/workspace/opentelemetry-ruby/exporter/otlp/test/test_helper.rb:13:in `<top (required)>'
	from <internal:/Users/jmorrell/.rbenv/versions/3.2.1/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:88:in `require'
	from <internal:/Users/jmorrell/.rbenv/versions/3.2.1/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:88:in `require'
	from /Users/jmorrell/workspace/opentelemetry-ruby/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb:6:in `<top (required)>'
	from <internal:/Users/jmorrell/.rbenv/versions/3.2.1/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:88:in `require'
	from <internal:/Users/jmorrell/.rbenv/versions/3.2.1/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:88:in `require'
	from /Users/jmorrell/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:21:in `block in <main>'
	from /Users/jmorrell/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:6:in `select'
	from /Users/jmorrell/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:6:in `<main>'
rake aborted!
Command failed with status (1)

Tasks: TOP => test
(See full trace by running task with --trace)
```

After swapping the statements:

```
❯ rake test
/Users/jmorrell/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/google-protobuf-3.23.2-arm64-darwin/lib/google/protobuf/any_pb.rb:15: warning: assigned but unused variable - e
/Users/jmorrell/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/google-protobuf-3.23.2-arm64-darwin/lib/google/protobuf/wrappers_pb.rb:15: warning: assigned but unused variable - e
/Users/jmorrell/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/google-protobuf-3.23.2-arm64-darwin/lib/google/protobuf/duration_pb.rb:15: warning: assigned but unused variable - e
/Users/jmorrell/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/google-protobuf-3.23.2-arm64-darwin/lib/google/protobuf/field_mask_pb.rb:15: warning: assigned but unused variable - e
/Users/jmorrell/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/google-protobuf-3.23.2-arm64-darwin/lib/google/protobuf/struct_pb.rb:15: warning: assigned but unused variable - e
/Users/jmorrell/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/google-protobuf-3.23.2-arm64-darwin/lib/google/protobuf/timestamp_pb.rb:15: warning: assigned but unused variable - e
Run options: --seed 42950

# Running:

....................S...................

Finished in 0.132498s, 301.8913 runs/s, 913.2213 assertions/s.
40 runs, 121 assertions, 0 failures, 0 errors, 1 skips

You have skipped tests. Run with --verbose for details.
Coverage report generated for Unit Tests to /Users/jmorrell/workspace/opentelemetry-ruby/exporter/otlp/coverage. 330 / 357 LOC (92.44%) covered.
```