### PR TITLE
feat!: Remove support for EoL Ruby 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,6 @@ jobs:
         with:
           gem: "${{ matrix.gem }}"
           ruby: "3.0"
-      - name: "Test Ruby 2.7"
-        if: "${{ matrix.os == 'ubuntu-latest' }}"
-        uses: ./.github/actions/test_gem
-        with:
-          gem: "${{ matrix.gem }}"
-          ruby: "2.7"
           yard: true
           rubocop: true
           build: true
@@ -111,12 +105,6 @@ jobs:
         with:
           gem: "${{ matrix.gem }}"
           ruby: "3.0"
-      - name: "Test Ruby 2.7"
-        if: "${{ matrix.os == 'ubuntu-latest' }}"
-        uses: ./.github/actions/test_gem
-        with:
-          gem: "${{ matrix.gem }}"
-          ruby: "2.7"
           yard: true
           rubocop: true
           build: true
@@ -184,12 +172,6 @@ jobs:
         with:
           gem: "${{ matrix.gem }}"
           ruby: "3.0"
-      - name: "Test Ruby 2.7"
-        if: "${{ matrix.os == 'ubuntu-latest' }}"
-        uses: ./.github/actions/test_gem
-        with:
-          gem: "${{ matrix.gem }}"
-          ruby: "2.7"
           yard: true
           rubocop: true
           build: true

--- a/.github/workflows/release-hook-on-closed.yml
+++ b/.github/workflows/release-hook-on-closed.yml
@@ -8,7 +8,7 @@ jobs:
   release-process-request:
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby' }}
     env:
-      ruby_version: "2.7"
+      ruby_version: "3.0"
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}

--- a/.github/workflows/release-hook-on-push.yml
+++ b/.github/workflows/release-hook-on-push.yml
@@ -9,7 +9,7 @@ jobs:
   release-update-open-requests:
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby' }}
     env:
-      ruby_version: "2.7"
+      ruby_version: "3.0"
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}

--- a/.github/workflows/release-perform.yml
+++ b/.github/workflows/release-perform.yml
@@ -18,7 +18,7 @@ jobs:
   release-perform:
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby' }}
     env:
-      ruby_version: "2.7"
+      ruby_version: "3.0"
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}

--- a/.github/workflows/release-request.yml
+++ b/.github/workflows/release-request.yml
@@ -12,7 +12,7 @@ jobs:
   release-request:
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby' }}
     env:
-      ruby_version: "2.7"
+      ruby_version: "3.0"
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}

--- a/.github/workflows/release-retry.yml
+++ b/.github/workflows/release-retry.yml
@@ -15,7 +15,7 @@ jobs:
   release-retry:
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby' }}
     env:
-      ruby_version: "2.7"
+      ruby_version: "3.0"
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}

--- a/.toys/release/.data/templates/release-hook-on-closed.yml.erb
+++ b/.toys/release/.data/templates/release-hook-on-closed.yml.erb
@@ -8,7 +8,7 @@ jobs:
   release-process-request:
     if: ${{ github.repository == '<%= @settings.repo_path %>' }}
     env:
-      ruby_version: "2.7"
+      ruby_version: "3.0"
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}

--- a/.toys/release/.data/templates/release-hook-on-open.yml.erb
+++ b/.toys/release/.data/templates/release-hook-on-open.yml.erb
@@ -8,7 +8,7 @@ jobs:
   release-check-commits:
     if: ${{ github.repository == '<%= @settings.repo_path %>' }}
     env:
-      ruby_version: "2.7"
+      ruby_version: "3.0"
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}

--- a/.toys/release/.data/templates/release-hook-on-push.yml.erb
+++ b/.toys/release/.data/templates/release-hook-on-push.yml.erb
@@ -9,7 +9,7 @@ jobs:
   release-update-open-requests:
     if: ${{ github.repository == '<%= @settings.repo_path %>' }}
     env:
-      ruby_version: "2.7"
+      ruby_version: "3.0"
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}

--- a/.toys/release/.data/templates/release-perform.yml.erb
+++ b/.toys/release/.data/templates/release-perform.yml.erb
@@ -18,7 +18,7 @@ jobs:
   release-perform:
     if: ${{ github.repository == '<%= @settings.repo_path %>' }}
     env:
-      ruby_version: "2.7"
+      ruby_version: "3.0"
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}

--- a/.toys/release/.data/templates/release-request.yml.erb
+++ b/.toys/release/.data/templates/release-request.yml.erb
@@ -12,7 +12,7 @@ jobs:
   release-request:
     if: ${{ github.repository == '<%= @settings.repo_path %>' }}
     env:
-      ruby_version: "2.7"
+      ruby_version: "3.0"
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}

--- a/.toys/release/.data/templates/release-retry.yml.erb
+++ b/.toys/release/.data/templates/release-retry.yml.erb
@@ -15,7 +15,7 @@ jobs:
   release-retry:
     if: ${{ github.repository == '<%= @settings.repo_path %>' }}
     env:
-      ruby_version: "2.7"
+      ruby_version: "3.0"
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}

--- a/api/.rubocop.yml
+++ b/api/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: "2.6.0"
+  TargetRubyVersion: "3.0"
 
 Lint/UnusedMethodArgument:
   Enabled: false

--- a/api/lib/opentelemetry/trace/propagation/trace_context/trace_parent.rb
+++ b/api/lib/opentelemetry/trace/propagation/trace_context/trace_parent.rb
@@ -22,7 +22,7 @@ module OpenTelemetry
           MAX_VERSION = 254
           private_constant :MAX_VERSION
 
-          REGEXP = /^(?<version>[A-Fa-f0-9]{2})-(?<trace_id>[A-Fa-f0-9]{32})-(?<span_id>[A-Fa-f0-9]{16})-(?<flags>[A-Fa-f0-9]{2})(?<ignored>-.*)?$/.freeze
+          REGEXP = /^(?<version>[A-Fa-f0-9]{2})-(?<trace_id>[A-Fa-f0-9]{32})-(?<span_id>[A-Fa-f0-9]{16})-(?<flags>[A-Fa-f0-9]{2})(?<ignored>-.*)?$/
           private_constant :REGEXP
 
           INVALID_TRACE_ID = OpenTelemetry::Trace::SpanContext::INVALID.hex_trace_id

--- a/api/lib/opentelemetry/trace/tracestate.rb
+++ b/api/lib/opentelemetry/trace/tracestate.rb
@@ -63,7 +63,7 @@ module OpenTelemetry
 
       MAX_MEMBER_COUNT = 32 # Defined by https://www.w3.org/TR/trace-context/
       VALID_KEY = Regexp.union(%r(^[a-z][a-z0-9_\-*/]{,255}$), %r(^[a-z0-9][a-z0-9_\-*/]{,240}@[a-z][a-z0-9_\-*/]{,13}$)).freeze
-      VALID_VALUE = /^[ -~&&[^,=]]{,255}[!-~&&[^,=]]$/.freeze
+      VALID_VALUE = /^[ -~&&[^,=]]{,255}[!-~&&[^,=]]$/
       private_constant(:MAX_MEMBER_COUNT, :VALID_KEY, :VALID_VALUE)
 
       # @api private

--- a/api/opentelemetry-api.gemspec
+++ b/api/opentelemetry-api.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                ::Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_development_dependency 'benchmark-ipsa', '~> 0.2.0'
   spec.add_development_dependency 'bundler', '>= 1.17'

--- a/common/.rubocop.yml
+++ b/common/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: '2.6.0'
+  TargetRubyVersion: '3.0'
   NewCops: disable
   SuggestExtensions: false
 

--- a/common/opentelemetry-common.gemspec
+++ b/common/opentelemetry-common.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                ::Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
 

--- a/exporter/jaeger/.rubocop.yml
+++ b/exporter/jaeger/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: "2.6.0"
+  TargetRubyVersion: "3.0"
   NewCops: disable
   SuggestExtensions: false
   Exclude:

--- a/exporter/jaeger/opentelemetry-exporter-jaeger.gemspec
+++ b/exporter/jaeger/opentelemetry-exporter-jaeger.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
                ::Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.1'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.6'

--- a/exporter/otlp-common/.rubocop.yml
+++ b/exporter/otlp-common/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: "2.6.0"
+  TargetRubyVersion: "3.0"
   Exclude:
     - "lib/opentelemetry/proto/**/*"
     - "vendor/**/*"
@@ -11,7 +11,11 @@ Metrics/AbcSize:
 Metrics/LineLength:
   Enabled: false
 Metrics/MethodLength:
-  Max: 21
+  Enabled: false
+Metrics/PerceivedComplexity:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
 Metrics/ParameterLists:
   Enabled: false
 Naming/FileName:

--- a/exporter/otlp-common/lib/opentelemetry/exporter/otlp/common.rb
+++ b/exporter/otlp-common/lib/opentelemetry/exporter/otlp/common.rb
@@ -43,7 +43,7 @@ module OpenTelemetry
         #
         # @return [Opentelemetry::Proto::Collector::Trace::V1::ExportTraceServiceRequest]
         #   returns an ETSR of the provided span data
-        def as_etsr(span_data) # rubocop:disable Metrics/MethodLength
+        def as_etsr(span_data)
           Opentelemetry::Proto::Collector::Trace::V1::ExportTraceServiceRequest.new(
             resource_spans: span_data
               .group_by(&:resource)
@@ -70,7 +70,7 @@ module OpenTelemetry
 
         private
 
-        def as_otlp_span(span_data) # rubocop:disable Metrics/MethodLength
+        def as_otlp_span(span_data)
           Opentelemetry::Proto::Trace::V1::Span.new(
             trace_id: span_data.trace_id,
             span_id: span_data.span_id,

--- a/exporter/otlp-common/opentelemetry-exporter-otlp-common.gemspec
+++ b/exporter/otlp-common/opentelemetry-exporter-otlp-common.gemspec
@@ -25,8 +25,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 3.0'
 
-  spec.add_dependency 'google-protobuf', '~> 3.19'
   spec.add_dependency 'googleapis-common-protos-types', '~> 1.3'
+  spec.add_dependency 'google-protobuf', '~> 3.19'
   spec.add_dependency 'opentelemetry-api', '~> 1.1'
 
   spec.add_development_dependency 'bundler', '>= 1.17'
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
   spec.add_development_dependency 'rake', '~> 12.0'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.51.0'
   spec.add_development_dependency 'simplecov', '~> 0.17'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/exporter/otlp-common/opentelemetry-exporter-otlp-common.gemspec
+++ b/exporter/otlp-common/opentelemetry-exporter-otlp-common.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                ::Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'google-protobuf', '~> 3.19'
   spec.add_dependency 'googleapis-common-protos-types', '~> 1.3'

--- a/exporter/otlp-grpc/.rubocop.yml
+++ b/exporter/otlp-grpc/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: "2.5.0"
+  TargetRubyVersion: "3.0"
 
 Lint/UnusedMethodArgument:
   Enabled: false

--- a/exporter/otlp-grpc/opentelemetry-exporter-otlp-grpc.gemspec
+++ b/exporter/otlp-grpc/opentelemetry-exporter-otlp-grpc.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                ::Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.5.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'grpc'
   spec.add_dependency 'opentelemetry-api', '~> 1.1'

--- a/exporter/otlp-grpc/opentelemetry-exporter-otlp-grpc.gemspec
+++ b/exporter/otlp-grpc/opentelemetry-exporter-otlp-grpc.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
   spec.add_development_dependency 'rake', '~> 12.0'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.51.0'
   spec.add_development_dependency 'simplecov', '~> 0.17'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/exporter/otlp-grpc/test/opentelemetry/exporter/otlp/grpc/trace_exporter_test.rb
+++ b/exporter/otlp-grpc/test/opentelemetry/exporter/otlp/grpc/trace_exporter_test.rb
@@ -6,8 +6,8 @@
 require 'test_helper'
 
 describe OpenTelemetry::Exporter::OTLP::GRPC::TraceExporter do
-  SUCCESS = OpenTelemetry::SDK::Trace::Export::SUCCESS
-  FAILURE = OpenTelemetry::SDK::Trace::Export::FAILURE
+  let(:success) { OpenTelemetry::SDK::Trace::Export::SUCCESS }
+  let(:failure) { OpenTelemetry::SDK::Trace::Export::FAILURE }
 
   describe '#exporter' do
     it 'integrates with collector' do
@@ -15,7 +15,7 @@ describe OpenTelemetry::Exporter::OTLP::GRPC::TraceExporter do
       span_data = OpenTelemetry::TestHelpers.create_span_data
       exporter = OpenTelemetry::Exporter::OTLP::GRPC::TraceExporter.new(endpoint: 'http://localhost:4317')
       result = exporter.export([span_data])
-      _(result).must_equal(SUCCESS)
+      _(result).must_equal(success)
     end
   end
 end

--- a/exporter/otlp-grpc/test/opentelemetry/exporter/otlp/grpc/trace_exporter_test.rb
+++ b/exporter/otlp-grpc/test/opentelemetry/exporter/otlp/grpc/trace_exporter_test.rb
@@ -7,7 +7,6 @@ require 'test_helper'
 
 describe OpenTelemetry::Exporter::OTLP::GRPC::TraceExporter do
   let(:success) { OpenTelemetry::SDK::Trace::Export::SUCCESS }
-  let(:failure) { OpenTelemetry::SDK::Trace::Export::FAILURE }
 
   describe '#exporter' do
     it 'integrates with collector' do

--- a/exporter/otlp-http/.rubocop.yml
+++ b/exporter/otlp-http/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: "2.6.0"
+  TargetRubyVersion: "3.0"
   Exclude:
     - "lib/opentelemetry/proto/**/*"
     - "vendor/**/*"
@@ -7,6 +7,10 @@ AllCops:
 Lint/UnusedMethodArgument:
   Enabled: false
 Metrics/AbcSize:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/PerceivedComplexity:
   Enabled: false
 Metrics/LineLength:
   Enabled: false

--- a/exporter/otlp-http/lib/opentelemetry/exporter/otlp/http/trace_exporter.rb
+++ b/exporter/otlp-http/lib/opentelemetry/exporter/otlp/http/trace_exporter.rb
@@ -32,7 +32,7 @@ module OpenTelemetry
           ERROR_MESSAGE_INVALID_HEADERS = 'headers must be a String with comma-separated URL Encoded UTF-8 k=v pairs or a Hash'
           private_constant(:ERROR_MESSAGE_INVALID_HEADERS)
 
-          def initialize(endpoint: OpenTelemetry::Common::Utilities.config_opt('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', 'OTEL_EXPORTER_OTLP_ENDPOINT', default: 'http://localhost:4318/v1/traces'), # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+          def initialize(endpoint: OpenTelemetry::Common::Utilities.config_opt('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', 'OTEL_EXPORTER_OTLP_ENDPOINT', default: 'http://localhost:4318/v1/traces'),
                          certificate_file: OpenTelemetry::Common::Utilities.config_opt('OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE', 'OTEL_EXPORTER_OTLP_CERTIFICATE'),
                          ssl_verify_mode: fetch_ssl_verify_mode,
                          headers: OpenTelemetry::Common::Utilities.config_opt('OTEL_EXPORTER_OTLP_TRACES_HEADERS', 'OTEL_EXPORTER_OTLP_HEADERS', default: {}),
@@ -125,10 +125,10 @@ module OpenTelemetry
           # and override this method's behaviour to explicitly trace the HTTP request.
           # This would allow you to trace your export pipeline.
           def around_request
-            OpenTelemetry::Common::Utilities.untraced { yield }
+            OpenTelemetry::Common::Utilities.untraced { yield } # rubocop:disable Style/ExplicitBlockArgument
           end
 
-          def send_bytes(bytes, timeout:) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+          def send_bytes(bytes, timeout:) # rubocop:disable Metrics/MethodLength
             return FAILURE if bytes.nil?
 
             retry_count = 0
@@ -236,7 +236,7 @@ module OpenTelemetry
             end
           end
 
-          def backoff?(retry_after: nil, retry_count:, reason:)
+          def backoff?(retry_count:, reason:, retry_after: nil)
             @metrics_reporter.add_to_counter('otel.otlp_exporter.failure', labels: { 'reason' => reason })
             return false if retry_count > RETRY_COUNT
 

--- a/exporter/otlp-http/opentelemetry-exporter-otlp-http.gemspec
+++ b/exporter/otlp-http/opentelemetry-exporter-otlp-http.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
   spec.add_development_dependency 'rake', '~> 12.0'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.51.0'
   spec.add_development_dependency 'simplecov', '~> 0.17'
   spec.add_development_dependency 'webmock', '~> 3.7.6'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/exporter/otlp-http/opentelemetry-exporter-otlp-http.gemspec
+++ b/exporter/otlp-http/opentelemetry-exporter-otlp-http.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                ::Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.1'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.6'

--- a/exporter/otlp/.rubocop.yml
+++ b/exporter/otlp/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: "2.6.0"
+  TargetRubyVersion: "3.0"
   NewCops: disable
   SuggestExtensions: false
   Exclude:

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -35,7 +35,7 @@ module OpenTelemetry
         ERROR_MESSAGE_INVALID_HEADERS = 'headers must be a String with comma-separated URL Encoded UTF-8 k=v pairs or a Hash'
         private_constant(:ERROR_MESSAGE_INVALID_HEADERS)
 
-        DEFAULT_USER_AGENT = "OTel-OTLP-Exporter-Ruby/#{OpenTelemetry::Exporter::OTLP::VERSION} Ruby/#{RUBY_VERSION} (#{RUBY_PLATFORM}; #{RUBY_ENGINE}/#{RUBY_ENGINE_VERSION})"
+        DEFAULT_USER_AGENT = "OTel-OTLP-Exporter-Ruby/#{OpenTelemetry::Exporter::OTLP::VERSION} Ruby/#{RUBY_VERSION} (#{RUBY_PLATFORM}; #{RUBY_ENGINE}/#{RUBY_ENGINE_VERSION})".freeze
 
         def self.ssl_verify_mode
           if ENV.key?('OTEL_RUBY_EXPORTER_OTLP_SSL_VERIFY_PEER')

--- a/exporter/otlp/opentelemetry-exporter-otlp.gemspec
+++ b/exporter/otlp/opentelemetry-exporter-otlp.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                ::Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'googleapis-common-protos-types', '~> 1.3'
   spec.add_dependency 'google-protobuf', '~> 3.19'

--- a/exporter/zipkin/.rubocop.yml
+++ b/exporter/zipkin/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: "2.6.0"
+  TargetRubyVersion: "3.0"
   Exclude:
     - "thrift/**/*"
     - "vendor/**/*"

--- a/exporter/zipkin/opentelemetry-exporter-zipkin.gemspec
+++ b/exporter/zipkin/opentelemetry-exporter-zipkin.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
                ::Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.1'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.6'

--- a/metrics_api/.rubocop.yml
+++ b/metrics_api/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: "2.6.0"
+  TargetRubyVersion: "3.0"
 
 Lint/UnusedMethodArgument:
   Enabled: false

--- a/metrics_api/lib/opentelemetry/metrics/meter.rb
+++ b/metrics_api/lib/opentelemetry/metrics/meter.rb
@@ -15,7 +15,7 @@ module OpenTelemetry
       UP_DOWN_COUNTER = Instrument::UpDownCounter.new
       OBSERVABLE_UP_DOWN_COUNTER = Instrument::ObservableUpDownCounter.new
 
-      NAME_REGEX = /^[a-zA-Z][-.\w]{0,62}$/.freeze
+      NAME_REGEX = /^[a-zA-Z][-.\w]{0,62}$/
 
       private_constant(:COUNTER, :OBSERVABLE_COUNTER, :HISTOGRAM, :OBSERVABLE_GAUGE, :UP_DOWN_COUNTER, :OBSERVABLE_UP_DOWN_COUNTER)
 

--- a/metrics_api/opentelemetry-metrics-api.gemspec
+++ b/metrics_api/opentelemetry-metrics-api.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
                ::Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
 

--- a/metrics_sdk/.rubocop.yml
+++ b/metrics_sdk/.rubocop.yml
@@ -1,11 +1,14 @@
 AllCops:
-  TargetRubyVersion: "2.6.0"
-
+  TargetRubyVersion: "3.0"
+  NewCops: disable
+  SuggestExtensions: false
+Lint/MissingSuper:
+  Enabled: false
 Lint/UnusedMethodArgument:
   Enabled: false
 Metrics/AbcSize:
   Max: 30
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 Metrics/MethodLength:
   Max: 50

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/aggregation/explicit_bucket_histogram.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/aggregation/explicit_bucket_histogram.rb
@@ -32,7 +32,7 @@ module OpenTelemetry
           def collect(start_time, end_time)
             if @aggregation_temporality == :delta
               # Set timestamps and 'move' data point values to result.
-              hdps = @data_points.values.each do |hdp|
+              hdps = @data_points.each_value do |hdp|
                 hdp.start_time_unix_nano = start_time
                 hdp.time_unix_nano = end_time
               end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/aggregation/histogram_data_point.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/aggregation/histogram_data_point.rb
@@ -8,6 +8,8 @@ module OpenTelemetry
   module SDK
     module Metrics
       module Aggregation
+        # TODO: Deal with this later
+        # rubocop:disable Lint/StructNewOverride
         HistogramDataPoint = Struct.new(:attributes,            # optional Hash{String => String, Numeric, Boolean, Array<String, Numeric, Boolean>}
                                         :start_time_unix_nano,  # Integer nanoseconds since Epoch
                                         :time_unix_nano,        # Integer nanoseconds since Epoch
@@ -18,6 +20,7 @@ module OpenTelemetry
                                         :exemplars,             # optional List of exemplars collected from measurements that were used to form the data point
                                         :min,                   # optional Float min is the minimum value over (start_time, end_time].
                                         :max)                   # optional Float max is the maximum value over (start_time, end_time].
+        # rubocop:enable Lint/StructNewOverride
       end
     end
   end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/aggregation/sum.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/aggregation/sum.rb
@@ -19,7 +19,7 @@ module OpenTelemetry
           def collect(start_time, end_time)
             if @aggregation_temporality == :delta
               # Set timestamps and 'move' data point values to result.
-              ndps = @data_points.values.each do |ndp|
+              ndps = @data_points.each_value do |ndp|
                 ndp.start_time_unix_nano = start_time
                 ndp.time_unix_nano = end_time
               end

--- a/metrics_sdk/opentelemetry-metrics-sdk.gemspec
+++ b/metrics_sdk/opentelemetry-metrics-sdk.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rake', '~> 12.0'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.51.0'
   spec.add_development_dependency 'simplecov', '~> 0.17'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/metrics_sdk/opentelemetry-metrics-sdk.gemspec
+++ b/metrics_sdk/opentelemetry-metrics-sdk.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                ::Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.1'
   spec.add_dependency 'opentelemetry-metrics-api'

--- a/metrics_sdk/test/.rubocop.yml
+++ b/metrics_sdk/test/.rubocop.yml
@@ -2,5 +2,5 @@ inherit_from: ../.rubocop.yml
 
 Metrics/BlockLength:
   Enabled: false
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false

--- a/propagator/b3/.rubocop.yml
+++ b/propagator/b3/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: '2.6.0'
+  TargetRubyVersion: '3.0'
 Lint/UnusedMethodArgument:
   Enabled: false
 Metrics/AbcSize:

--- a/propagator/b3/lib/opentelemetry/propagator/b3/text_map_extractor.rb
+++ b/propagator/b3/lib/opentelemetry/propagator/b3/text_map_extractor.rb
@@ -17,9 +17,9 @@ module OpenTelemetry
     module B3
       # Extracts trace context using the b3 single or multi header formats, favouring b3 single header.
       module TextMapExtractor
-        B3_CONTEXT_REGEX = /\A(?<trace_id>(?:[0-9a-f]{16}){1,2})-(?<span_id>[0-9a-f]{16})(?:-(?<sampling_state>[01d](?![0-9a-f])))?(?:-(?<parent_span_id>[0-9a-f]{16}))?\z/.freeze
-        B3_TRACE_ID_REGEX = /\A(?:[0-9a-f]{16}){1,2}\z/.freeze
-        B3_SPAN_ID_REGEX = /\A[0-9a-f]{16}\z/.freeze
+        B3_CONTEXT_REGEX = /\A(?<trace_id>(?:[0-9a-f]{16}){1,2})-(?<span_id>[0-9a-f]{16})(?:-(?<sampling_state>[01d](?![0-9a-f])))?(?:-(?<parent_span_id>[0-9a-f]{16}))?\z/
+        B3_TRACE_ID_REGEX = /\A(?:[0-9a-f]{16}){1,2}\z/
+        B3_SPAN_ID_REGEX = /\A[0-9a-f]{16}\z/
         SAMPLED_VALUES = %w[1 true].freeze
 
         B3_CONTEXT_KEY = 'b3'

--- a/propagator/b3/opentelemetry-propagator-b3.gemspec
+++ b/propagator/b3/opentelemetry-propagator-b3.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
                ::Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.1'
 

--- a/propagator/jaeger/.rubocop.yml
+++ b/propagator/jaeger/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: '2.6.0'
+  TargetRubyVersion: '3.0'
 Lint/UnusedMethodArgument:
   Enabled: false
 Metrics/AbcSize:

--- a/propagator/jaeger/lib/opentelemetry/propagator/jaeger/text_map_propagator.rb
+++ b/propagator/jaeger/lib/opentelemetry/propagator/jaeger/text_map_propagator.rb
@@ -24,8 +24,8 @@ module OpenTelemetry
         SAMPLED_FLAG_BIT = 0x01
         DEBUG_FLAG_BIT   = 0x02
         FIELDS = [IDENTITY_KEY].freeze
-        TRACE_SPAN_IDENTITY_REGEX = /\A(?<trace_id>(?:[0-9a-f]){1,32}):(?<span_id>([0-9a-f]){1,16}):[0-9a-f]{1,16}:(?<sampling_flags>[0-9a-f]{1,2})\z/.freeze
-        ZERO_ID_REGEX = /^0+$/.freeze
+        TRACE_SPAN_IDENTITY_REGEX = /\A(?<trace_id>(?:[0-9a-f]){1,32}):(?<span_id>([0-9a-f]){1,16}):[0-9a-f]{1,16}:(?<sampling_flags>[0-9a-f]{1,2})\z/
+        ZERO_ID_REGEX = /^0+$/
 
         private_constant \
           :IDENTITY_KEY, :DEFAULT_FLAG_BIT, :SAMPLED_FLAG_BIT, :DEBUG_FLAG_BIT,

--- a/propagator/jaeger/opentelemetry-propagator-jaeger.gemspec
+++ b/propagator/jaeger/opentelemetry-propagator-jaeger.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
                ::Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.1'
 

--- a/registry/.rubocop.yml
+++ b/registry/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: "2.6.0"
+  TargetRubyVersion: "3.0"
   NewCops: disable
   SuggestExtensions: false
 

--- a/registry/opentelemetry-registry.gemspec
+++ b/registry/opentelemetry-registry.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                ::Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.1'
 

--- a/sdk/.rubocop.yml
+++ b/sdk/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: "2.6.0"
+  TargetRubyVersion: "3.0"
 
 Lint/UnusedMethodArgument:
   Enabled: false

--- a/sdk/opentelemetry-sdk.gemspec
+++ b/sdk/opentelemetry-sdk.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                ::Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.1'
   spec.add_dependency 'opentelemetry-common', '~> 0.19.3'

--- a/sdk_experimental/.rubocop.yml
+++ b/sdk_experimental/.rubocop.yml
@@ -1,7 +1,9 @@
 AllCops:
-  TargetRubyVersion: "2.6.0"
+  TargetRubyVersion: "3.0"
 
 Lint/UnusedMethodArgument:
+  Enabled: false
+Naming/MethodParameterName:
   Enabled: false
 Metrics/AbcSize:
   Max: 30

--- a/sdk_experimental/lib/opentelemetry/sdk/trace/samplers/consistent_probability_tracestate.rb
+++ b/sdk_experimental/lib/opentelemetry/sdk/trace/samplers/consistent_probability_tracestate.rb
@@ -13,7 +13,7 @@ module OpenTelemetry
         # The ConsistentProbabilityTraceState module implements Tracestate parsing,
         # validation and manipulation for the consistent probability-based samplers.
         module ConsistentProbabilityTraceState
-          DECIMAL = /\A\d+\z/.freeze
+          DECIMAL = /\A\d+\z/
           MAX_LIST_LENGTH = 256 # Defined by https://www.w3.org/TR/trace-context/
           private_constant(:DECIMAL, :MAX_LIST_LENGTH)
 
@@ -77,7 +77,7 @@ module OpenTelemetry
             yield(p, r, rest)
           end
 
-          def update_tracestate(tracestate, p, r, rest) # rubocop:disable Naming/UncommunicativeMethodParamName
+          def update_tracestate(tracestate, p, r, rest)
             if p.nil? && r.nil? && rest.nil?
               tracestate.delete('ot')
             elsif p.nil? && r.nil?
@@ -97,7 +97,7 @@ module OpenTelemetry
             end
           end
 
-          def invariant(p, r, sampled) # rubocop:disable Naming/UncommunicativeMethodParamName
+          def invariant(p, r, sampled)
             ((p <= r) == sampled) || (sampled && (p == 63))
           end
 
@@ -107,8 +107,7 @@ module OpenTelemetry
 
           def generate_r(trace_id)
             x = trace_id[8, 8].unpack1('Q>') | 0x3
-            clz = 64 - x.bit_length
-            clz
+            64 - x.bit_length
           end
         end
       end

--- a/sdk_experimental/opentelemetry-sdk-experimental.gemspec
+++ b/sdk_experimental/opentelemetry-sdk-experimental.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                ::Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.1'
   spec.add_dependency 'opentelemetry-sdk', '~> 1.2'

--- a/sdk_experimental/opentelemetry-sdk-experimental.gemspec
+++ b/sdk_experimental/opentelemetry-sdk-experimental.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rake', '~> 12.0'
-  spec.add_development_dependency 'rubocop', '~> 0.73.0'
+  spec.add_development_dependency 'rubocop', '~> 1.51.0'
   spec.add_development_dependency 'simplecov', '~> 0.17'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'

--- a/sdk_experimental/test/opentelemetry/sdk/trace/samplers/consistent_probability_based_test.rb
+++ b/sdk_experimental/test/opentelemetry/sdk/trace/samplers/consistent_probability_based_test.rb
@@ -86,7 +86,7 @@ describe OpenTelemetry::SDK::Trace::Samplers::ConsistentProbabilityBased do
       p_values.zip(probabilities).each do |p, probability|
         sampler = OpenTelemetry::SDK::Trace::Samplers::ConsistentProbabilityBased.new(probability)
         _(sampler.instance_variable_get(:@p_floor)).must_equal(p)
-        _(sampler.instance_variable_get(:@p_ceil)).must_equal(p-1)
+        _(sampler.instance_variable_get(:@p_ceil)).must_equal(p - 1)
         _(sampler.instance_variable_get(:@p_ceil_probability)).must_equal(0)
       end
     end

--- a/sdk_experimental/test/test_helper.rb
+++ b/sdk_experimental/test/test_helper.rb
@@ -30,7 +30,7 @@ def trace_id(id)
   [first, second].pack('Q>Q>')
 end
 
-def parent_context(trace_id: nil, sampled: false, ot: nil) # rubocop:disable Naming/UncommunicativeMethodParamName
+def parent_context(trace_id: nil, sampled: false, ot: nil)
   span_context = OpenTelemetry::Trace::SpanContext.new(
     trace_id: trace_id || OpenTelemetry::Trace.generate_trace_id,
     trace_flags: sampled ? OpenTelemetry::Trace::TraceFlags::SAMPLED : OpenTelemetry::Trace::TraceFlags::DEFAULT,

--- a/semantic_conventions/.rubocop.yml
+++ b/semantic_conventions/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: '2.6.0'
+  TargetRubyVersion: '3.0'
   NewCops: enable
 
 Bundler/OrderedGems:

--- a/semantic_conventions/opentelemetry-semantic_conventions.gemspec
+++ b/semantic_conventions/opentelemetry-semantic_conventions.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
 

--- a/test_helpers/.rubocop.yml
+++ b/test_helpers/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: "2.6.0"
+  TargetRubyVersion: "3.0"
 
 Lint/UnusedMethodArgument:
   Enabled: false
@@ -15,8 +15,6 @@ Naming/FileName:
   Exclude:
     - "lib/opentelemetry-test-helpers.rb"
 Style/ModuleFunction:
-  Enabled: false
-Gemspec/DevelopmentDependencies:
   Enabled: false
 Gemspec/RequireMFA:
   Enabled: false

--- a/test_helpers/opentelemetry-test-helpers.gemspec
+++ b/test_helpers/opentelemetry-test-helpers.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
                Dir.glob('*.md') +
                ['LICENSE', '.yardopts']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.0'
 
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'minitest', '~> 5.0'


### PR DESCRIPTION
Following suite of https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/389

> Ruby 2.7
> status: security maintenance
> release date: 2019-12-25
> normal maintenance until: 2022-04-01
> EOL: 2023-03-31 (expected)