### PR TITLE
fix: SDK requires opentelemetry-common 0.19.7

### DIFF
--- a/sdk/opentelemetry-sdk.gemspec
+++ b/sdk/opentelemetry-sdk.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'opentelemetry-api', '~> 1.1'
-  spec.add_dependency 'opentelemetry-common', '~> 0.19.3'
+  spec.add_dependency 'opentelemetry-common', '~> 0.19.7'
   spec.add_dependency 'opentelemetry-registry', '~> 0.2'
 
   # This is an intentionally loose dependency, since we want to be able to


### PR DESCRIPTION
In https://github.com/open-telemetry/opentelemetry-ruby/pull/1412, the SDK picked up a dependency on the `untraced?` method in `opentelemetry-common`, which was added in `0.19.7` (same PR) (https://github.com/open-telemetry/opentelemetry-ruby/blob/main/common/CHANGELOG.md#v0197--2023-05-30).