### PR TITLE
chore(deps): Allow google-protobuf `~> 3.14`

### DIFF
--- a/exporter/otlp/Appraisals
+++ b/exporter/otlp/Appraisals
@@ -4,11 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-appraise "google-protobuf-3.14" do
-  gem 'google-protobuf', "3.14"
-end
-
-(16..23).each do |i|
+(14..23).each do |i|
   version = "3.#{i}"
   appraise "google-protobuf-#{version}" do
     gem 'google-protobuf', "~> #{version}"

--- a/exporter/otlp/Appraisals
+++ b/exporter/otlp/Appraisals
@@ -4,7 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-(19..23).each do |i|
+appraise "google-protobuf-3.14" do
+  gem 'google-protobuf', "3.14"
+end
+
+(16..23).each do |i|
   version = "3.#{i}"
   appraise "google-protobuf-#{version}" do
     gem 'google-protobuf', "~> #{version}"

--- a/exporter/otlp/opentelemetry-exporter-otlp.gemspec
+++ b/exporter/otlp/opentelemetry-exporter-otlp.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'googleapis-common-protos-types', '~> 1.3'
-  spec.add_dependency 'google-protobuf', '~> 3.19'
+  spec.add_dependency 'google-protobuf', '~> 3.14', '!= 3.15'
   spec.add_dependency 'opentelemetry-api', '~> 1.1'
   spec.add_dependency 'opentelemetry-common', '~> 0.20'
   spec.add_dependency 'opentelemetry-sdk', '~> 1.2'

--- a/exporter/otlp/opentelemetry-exporter-otlp.gemspec
+++ b/exporter/otlp/opentelemetry-exporter-otlp.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
 
   spec.add_dependency 'googleapis-common-protos-types', '~> 1.3'
-  spec.add_dependency 'google-protobuf', '~> 3.14', '!= 3.15'
+  spec.add_dependency 'google-protobuf', '~> 3.14'
   spec.add_dependency 'opentelemetry-api', '~> 1.1'
   spec.add_dependency 'opentelemetry-common', '~> 0.20'
   spec.add_dependency 'opentelemetry-sdk', '~> 1.2'


### PR DESCRIPTION
GitHub still uses legacy versions of the protobuf gem. This makes it challenging to
upgrade to newer versions of the OTLP Exporter which only supports versions `~> 3.19`.

This change loosens the restrictions to allow GitHub to adopt newer versions of the protobuf
definitions using an older verson of the library.

~~This change explicitly skips 3.15 due to bugs like https://github.com/protocolbuffers/protobuf/issues/8337~~

