### PR TITLE
fix(exporter/otlp): align endpoint environment varaible handling with spec

### DIFF
--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -395,6 +395,8 @@ module OpenTelemetry
           elsif !ENV['OTEL_EXPORTER_OTLP_ENDPOINT'].nil?
             # Append v1/traces only if the non-signal specific env var is set.
             non_signal_specific_endpoint = ENV['OTEL_EXPORTER_OTLP_ENDPOINT']
+            # append '/' if not present
+            non_signal_specific_endpoint += '/' unless non_signal_specific_endpoint.end_with?('/')
             begin
               URI.join(non_signal_specific_endpoint, 'v1/traces')
             rescue URI::InvalidURIError

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -54,11 +54,7 @@ module OpenTelemetry
                        compression: OpenTelemetry::Common::Utilities.config_opt('OTEL_EXPORTER_OTLP_TRACES_COMPRESSION', 'OTEL_EXPORTER_OTLP_COMPRESSION', default: 'gzip'),
                        timeout: OpenTelemetry::Common::Utilities.config_opt('OTEL_EXPORTER_OTLP_TRACES_TIMEOUT', 'OTEL_EXPORTER_OTLP_TIMEOUT', default: 10),
                        metrics_reporter: nil)
-          @uri = begin
-            prepare_endpoint(endpoint)
-          rescue ArgumentError => e
-            raise ArgumentError, e.message
-          end
+          @uri = prepare_endpoint(endpoint)
 
           raise ArgumentError, "unsupported compression key #{compression}" unless compression.nil? || %w[gzip none].include?(compression)
 


### PR DESCRIPTION
This PR fixes the non spec compliant behavior outlined in #1505 :slightly_smiling_face: 

Fixes #1505