### PR TITLE
chore: Raise test_gem ruby/setup-ruby version

### DIFF
--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -58,7 +58,7 @@ runs:
     # ...but not for appraisals, sadly.
     - name: Install Ruby ${{ inputs.ruby }} with dependencies
       if: "${{ steps.setup.outputs.appraisals == 'false' }}"
-      uses: ruby/setup-ruby@v1.144.1
+      uses: ruby/setup-ruby@v1.152.0
       with:
         ruby-version: "${{ inputs.ruby }}"
         working-directory: "${{ steps.setup.outputs.gem_dir }}"
@@ -69,7 +69,7 @@ runs:
     # If we're using appraisals, do it all manually.
     - name: Install Ruby ${{ inputs.ruby }} without dependencies
       if: "${{ steps.setup.outputs.appraisals == 'true' }}"
-      uses: ruby/setup-ruby@v1.144.1
+      uses: ruby/setup-ruby@v1.152.0
       with:
         ruby-version: "${{ inputs.ruby }}"
         bundler:  "latest"


### PR DESCRIPTION
I'm trying to use SimpleCov in #1509, but TruffleRuby raises an error about `Coverage.running?` not being implemented. There's a fix for this in TruffleRuby 22. 

TruffleRuby 22 isn't accessible with the `test_gem` action's current version of `ruby/setup-ruby`. However, TruffleRuby 23 is available on the latest `ruby/setup-ruby` version. Using `v1.152.0` fixed the problem.

Example action failure: https://github.com/open-telemetry/opentelemetry-ruby/actions/runs/5744430524/job/15570701339?pr=1509#step:7:150 