### PR TITLE
test: Skip flaky truffleruby test

### DIFF
--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -533,6 +533,9 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
     end
 
     it 'translates all the things' do
+      # TODO: See issue #1507 to fix
+      skip 'Intermittently fails' if RUBY_ENGINE == 'truffleruby'
+
       stub_request(:post, 'http://localhost:4318/v1/traces').to_return(status: 200)
       processor = OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(exporter)
       tracer = OpenTelemetry.tracer_provider.tracer('tracer', 'v0.0.1')


### PR DESCRIPTION
The "OpenTelemetry::Exporter::OTLP::Exporter::#export#test_0017_translates all the things" test is failing on unrelated PRs in TruffleRuby. Issue #1507 exists to resolve the source of the flakiness.