### PR TITLE
fix: in_span performance

### DIFF
--- a/api/lib/opentelemetry/trace/tracer.rb
+++ b/api/lib/opentelemetry/trace/tracer.rb
@@ -31,7 +31,7 @@ module OpenTelemetry
       #
       # @yield [span, context] yields the newly created span and a context containing the
       #   span to the block.
-      def in_span(name, attributes: nil, links: nil, start_timestamp: nil, kind: nil, &block)
+      def in_span(name, attributes: nil, links: nil, start_timestamp: nil, kind: nil)
         span = nil
         span = start_span(name, attributes: attributes, links: links, start_timestamp: start_timestamp, kind: kind)
         Trace.with_span(span) { |s, c| yield s, c }


### PR DESCRIPTION
Follow up fix for https://github.com/open-telemetry/opentelemetry-ruby/pull/1492

```
ruby proc-call-vs-yield.rb
Warming up --------------------------------------
          block.call     1.141M i/100ms
       block + yield     1.202M i/100ms
        unused block     1.495M i/100ms
               yield     1.389M i/100ms
Calculating -------------------------------------
          block.call     11.485M (± 1.4%) i/s -     58.175M in   5.066280s
       block + yield     11.910M (± 1.6%) i/s -     60.089M in   5.046587s
        unused block     14.945M (± 5.4%) i/s -     74.725M in   5.019902s
               yield     14.068M (± 1.0%) i/s -     70.858M in   5.037486s

Comparison:
        unused block: 14945101.0 i/s
               yield: 14067574.6 i/s - same-ish: difference falls within error
       block + yield: 11910103.8 i/s - 1.25x  slower
          block.call: 11485071.3 i/s - 1.30x  slower
```

In the previous PR we went from `block.call` to `block + yield` but I intended for us to go to `yield`
