### PR TITLE
feat: Create Logs SDK LoggerProvider

### DIFF
--- a/logs_sdk/Gemfile
+++ b/logs_sdk/Gemfile
@@ -7,3 +7,8 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'opentelemetry-api', path: '../api'
+gem 'opentelemetry-logs-api', path: '../logs_api'
+gem 'opentelemetry-sdk', path: '../sdk'
+gem 'opentelemetry-test-helpers', path: '../test_helpers'

--- a/logs_sdk/lib/opentelemetry-logs-sdk.rb
+++ b/logs_sdk/lib/opentelemetry-logs-sdk.rb
@@ -4,6 +4,5 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'opentelemetry'
 require 'opentelemetry/sdk'
 require 'opentelemetry/sdk/logs'

--- a/logs_sdk/lib/opentelemetry-logs-sdk.rb
+++ b/logs_sdk/lib/opentelemetry-logs-sdk.rb
@@ -4,5 +4,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require 'opentelemetry'
+require 'opentelemetry/sdk'
 require 'opentelemetry/sdk/logs'
-require 'opentelemetry/sdk/logs/version'

--- a/logs_sdk/lib/opentelemetry/sdk/logs.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs.rb
@@ -5,6 +5,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require_relative 'logs/version'
+require_relative 'logs/logger'
+require_relative 'logs/logger_provider'
+require_relative 'logs/log_record_processor'
+require_relative 'logs/export'
 
 module OpenTelemetry
   module SDK

--- a/logs_sdk/lib/opentelemetry/sdk/logs/export.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/export.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Logs
+      # The export module contains result codes for LoggerProvider#force_flush
+      # and LoggerProvider#shutdown
+      module Export
+        # The operation finished successfully.
+        SUCCESS = 0
+
+        # The operation finished with an error.
+        FAILURE = 1
+
+        # The operation timed out.
+        TIMEOUT = 2
+      end
+    end
+  end
+end

--- a/logs_sdk/lib/opentelemetry/sdk/logs/export.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/export.rb
@@ -7,8 +7,7 @@
 module OpenTelemetry
   module SDK
     module Logs
-      # The export module contains result codes for LoggerProvider#force_flush
-      # and LoggerProvider#shutdown
+      # The Export module contains result codes for exporters
       module Export
         # The operation finished successfully.
         SUCCESS = 0

--- a/logs_sdk/lib/opentelemetry/sdk/logs/log_record_processor.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/log_record_processor.rb
@@ -26,7 +26,7 @@ module OpenTelemetry
         # the process after an invocation, but before the `Processor` exports
         # the completed spans.
         #
-        # @param [optional Numeric] timeout An optional timeout in seconds.
+        # @param [Numeric] timeout An optional timeout in seconds.
         # @return [Integer] Export::SUCCESS if no error occurred, Export::FAILURE if
         #   a non-specific failure occurred, Export::TIMEOUT if a timeout occurred.
         def force_flush(timeout: nil)
@@ -35,7 +35,7 @@ module OpenTelemetry
 
         # Called when {LoggerProvider#shutdown} is called.
         #
-        # @param [optional Numeric] timeout An optional timeout in seconds.
+        # @param [Numeric] timeout An optional timeout in seconds.
         # @return [Integer] Export::SUCCESS if no error occurred, Export::FAILURE if
         #   a non-specific failure occurred, Export::TIMEOUT if a timeout occurred.
         def shutdown(timeout: nil)

--- a/logs_sdk/lib/opentelemetry/sdk/logs/log_record_processor.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/log_record_processor.rb
@@ -7,15 +7,15 @@
 module OpenTelemetry
   module SDK
     module Logs
-      # LogRecordProcessor describes a duck type and provides synchronous no-op hooks for when a
-      # {LogRecord} is started or when a {LogRecord} is ended. It is not required to subclass this
+      # LogRecordProcessor describes a duck type and provides a synchronous no-op hook for when a
+      # {LogRecord} is emitted. It is not required to subclass this
       # class to provide an implementation of LogRecordProcessor, provided the interface is
       # satisfied.
       class LogRecordProcessor
         # Called when a {LogRecord} is emitted. Subsequent calls are not
         # permitted after shutdown is called.
         # @param [LogRecord] log_record The emitted {LogRecord}
-        # @param [Context] context The resolved Context (the explicitly passed Context or the current Context)
+        # @param [Context] context The {Context}
         def on_emit(log_record, context); end
 
         # Export all log records to the configured `Exporter` that have not yet

--- a/logs_sdk/lib/opentelemetry/sdk/logs/log_record_processor.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/log_record_processor.rb
@@ -15,7 +15,7 @@ module OpenTelemetry
         # Called when a {LogRecord} is emitted. Subsequent calls are not
         # permitted after shutdown is called.
         # @param [LogRecord] log_record The emitted {LogRecord}
-        # @param [Context] context The resolved Context
+        # @param [Context] context The resolved Context (the explicitly passed Context or the current Context)
         def on_emit(log_record, context); end
 
         # Export all log records to the configured `Exporter` that have not yet

--- a/logs_sdk/lib/opentelemetry/sdk/logs/log_record_processor.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/log_record_processor.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Logs
+      # LogRecordProcessor describes a duck type and provides synchronous no-op hooks for when a
+      # {LogRecord} is started or when a {LogRecord} is ended. It is not required to subclass this
+      # class to provide an implementation of LogRecordProcessor, provided the interface is
+      # satisfied.
+      class LogRecordProcessor
+        # Called when a {LogRecord} is emitted. Subsequent calls are not
+        # permitted after shutdown is called.
+        # @param [LogRecord] log_record The emitted {LogRecord}
+        # @param [Context] context The resolved Context
+        def on_emit(log_record, context); end
+
+        # Export all log records to the configured `Exporter` that have not yet
+        # been exported.
+        #
+        # This method should only be called in cases where it is absolutely
+        # necessary, such as when using some FaaS providers that may suspend
+        # the process after an invocation, but before the `Processor` exports
+        # the completed spans.
+        #
+        # @param [optional Numeric] timeout An optional timeout in seconds.
+        # @return [Integer] Export::SUCCESS if no error occurred, Export::FAILURE if
+        #   a non-specific failure occurred, Export::TIMEOUT if a timeout occurred.
+        def force_flush(timeout: nil)
+          Export::SUCCESS
+        end
+
+        # Called when {LoggerProvider#shutdown} is called.
+        #
+        # @param [optional Numeric] timeout An optional timeout in seconds.
+        # @return [Integer] Export::SUCCESS if no error occurred, Export::FAILURE if
+        #   a non-specific failure occurred, Export::TIMEOUT if a timeout occurred.
+        def shutdown(timeout: nil)
+          Export::SUCCESS
+        end
+      end
+    end
+  end
+end

--- a/logs_sdk/lib/opentelemetry/sdk/logs/logger.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/logger.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Logs
+      # The SDK implementation of OpenTelemetry::Logs::Logger
+      class Logger < OpenTelemetry::Logs::Logger
+        attr_reader :instrumentation_scope, :logger_provider
+
+        # @api private
+        #
+        # Returns a new {OpenTelemetry::SDK::Logs::Logger} instance. This should
+        # not be called directly. New loggers should be created using
+        # {LoggerProvider#logger}.
+        #
+        # @param [String] name Instrumentation package name
+        # @param [String] version Instrumentation package version
+        # @param [LoggerProvider] logger_provider The {LoggerProvider} that
+        #   initialized the logger
+        #
+        # @return [OpenTelemetry::SDK::Logs::Logger]
+        def initialize(name, version, logger_provider)
+          @instrumentation_scope = InstrumentationScope.new(name, version)
+          @logger_provider = logger_provider
+        end
+      end
+    end
+  end
+end

--- a/logs_sdk/lib/opentelemetry/sdk/logs/logger.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/logger.rb
@@ -9,8 +9,6 @@ module OpenTelemetry
     module Logs
       # The SDK implementation of OpenTelemetry::Logs::Logger
       class Logger < OpenTelemetry::Logs::Logger
-        attr_reader :instrumentation_scope, :logger_provider
-
         # @api private
         #
         # Returns a new {OpenTelemetry::SDK::Logs::Logger} instance. This should

--- a/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
@@ -29,7 +29,7 @@ module OpenTelemetry
           @stopped = false
         end
 
-        # Creates an {OpenTelemetry::SDK::Logs::Logger} instance.
+        # Returns an {OpenTelemetry::SDK::Logs::Logger} instance.
         #
         # @param [String] name Instrumentation package name
         # @param [String] version Optional instrumentation package version
@@ -43,7 +43,7 @@ module OpenTelemetry
               "invalid name. Name provided: #{name.inspect}")
           end
 
-          OpenTelemetry::SDK::Logs::Logger.new(name, version, self)
+         Logger.new(name, version, self)
         end
 
         # Adds a new log record processor to this LoggerProvider's
@@ -78,19 +78,19 @@ module OpenTelemetry
           @mutex.synchronize do
             if @stopped
               OpenTelemetry.logger.warn('LoggerProvider#shutdown called multiple times.')
-              return OpenTelemetry::SDK::Logs::Export::FAILURE
+              return Export::FAILURE
             end
 
             start_time = OpenTelemetry::Common::Utilities.timeout_timestamp
             results = @log_record_processors.map do |processor|
               remaining_timeout = OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time)
-              break [OpenTelemetry::SDK::Logs::Export::TIMEOUT] if remaining_timeout&.zero?
+              break [Export::TIMEOUT] if remaining_timeout&.zero?
 
               processor.shutdown(timeout: remaining_timeout)
             end
 
             @stopped = true
-            results.max || OpenTelemetry::SDK::Logs::Export::SUCCESS
+            results.max || Export::SUCCESS
           end
         end
 

--- a/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Logs
+      # The SDK implementation of OpenTelemetry::Logs::LoggerProvider.
+      class LoggerProvider < OpenTelemetry::Logs::LoggerProvider
+        attr_reader :resource, :log_record_processors
+
+        UNEXPECTED_ERROR_MESSAGE = 'unexpected error in ' \
+          'OpenTelemetry::SDK::Logs::LoggerProvider#%s'
+        # Returns a new LoggerProvider instance.
+        #
+        # @param [optional Resource] resource The resource to associate with
+        #   new LogRecords created by {Logger}s created by this LoggerProvider.
+        # @param [optional Array] log_record_processors The
+        #   {LogRecordProcessor}s to associate with this LoggerProvider.
+        #
+        # @return [OpenTelemetry::SDK::Logs::LoggerProvider]
+        def initialize(
+          resource: OpenTelemetry::SDK::Resources::Resource.create,
+          log_record_processors: []
+        )
+          @log_record_processors = log_record_processors
+          @mutex = Mutex.new
+          @resource = resource
+          @stopped = false
+        end
+
+        # Creates an {OpenTelemetry::SDK::Logs::Logger} instance.
+        #
+        # @param [optional String] name Instrumentation package name
+        # @param [optional String] version Instrumentation package version
+        #
+        # @return [OpenTelemetry::SDK::Logs::Logger]
+        def logger(name = nil, version = nil)
+          name ||= ''
+          version ||= ''
+
+          OpenTelemetry.logger.warn('LoggerProvider#logger called without providing a logger name.') if name.empty?
+
+          OpenTelemetry::SDK::Logs::Logger.new(name, version, self)
+        end
+
+        # Adds a new log record processor to this LoggerProvider's
+        # log_record_processors.
+        #
+        # @param [LogRecordProcessor] log_record_processor The
+        #   {LogRecordProcessor} to add to this LoggerProvider.
+        def add_log_record_processor(log_record_processor)
+          @mutex.synchronize do
+            @log_record_processors = log_record_processors.dup.push(log_record_processor)
+          end
+        end
+
+        # Attempts to stop all the activity for this LoggerProvider. Calls
+        # {LogRecordProcessor#shutdown} for all registered {LogRecordProcessor}s.
+        #
+        # This operation may block until all log records are processed. Must
+        # be called before turning off the main application to ensure all data
+        # are processed and exported.
+        #
+        # After this is called all newly created {LogRecord}s will be no-op.
+        #
+        # @param [optional Numeric] timeout An optional timeout in seconds.
+        # @return [Integer] Export::SUCCESS if no error occurred, Export::FAILURE if
+        #   a non-specific failure occurred, Export::TIMEOUT if a timeout occurred.
+        def shutdown(timeout: nil)
+          @mutex.synchronize do
+            if @stopped
+              OpenTelemetry.logger.warn('LoggerProvider#shutdown called multiple times.')
+              return OpenTelemetry::SDK::Logs::Export::FAILURE
+            end
+
+            start_time = OpenTelemetry::Common::Utilities.timeout_timestamp
+            results = log_record_processors.map do |processor|
+              remaining_timeout = OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time)
+              break [OpenTelemetry::SDK::Logs::Export::TIMEOUT] if remaining_timeout&.zero?
+
+              processor.shutdown(timeout: remaining_timeout)
+            end
+
+            @stopped = true
+            results.max || OpenTelemetry::SDK::Logs::Export::SUCCESS
+          end
+        rescue StandardError => e
+          OpenTelemetry.handle_error(exception: e, message: UNEXPECTED_ERROR_MESSAGE % __method__)
+          Export::FAILURE
+        end
+
+        # Immediately export all {LogRecord}s that have not yet been exported
+        # for all the registered {LogRecordProcessor}s.
+        #
+        # This method should only be called in cases where it is absolutely
+        # necessary, such as when using some FaaS providers that may suspend
+        # the process after an invocation, but before the {LogRecordProcessor}
+        # exports the completed {LogRecord}s.
+        #
+        # @param [optional Numeric] timeout An optional timeout in seconds.
+        # @return [Integer] Export::SUCCESS if no error occurred, Export::FAILURE if
+        #   a non-specific failure occurred, Export::TIMEOUT if a timeout occurred.
+        def force_flush(timeout: nil)
+          @mutex.synchronize do
+            return Export::SUCCESS if @stopped
+
+            start_time = OpenTelemetry::Common::Utilities.timeout_timestamp
+            results = log_record_processors.map do |processor|
+              remaining_timeout = OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time)
+              return Export::TIMEOUT if remaining_timeout&.zero?
+
+              processor.force_flush(timeout: remaining_timeout)
+            end
+
+            results.max || Export::SUCCESS
+          end
+        rescue StandardError => e
+          OpenTelemetry.handle_error(exception: e, message: UNEXPECTED_ERROR_MESSAGE % __method__)
+          Export::FAILURE
+        end
+      end
+    end
+  end
+end

--- a/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
@@ -53,6 +53,11 @@ module OpenTelemetry
         #   {LogRecordProcessor} to add to this LoggerProvider.
         def add_log_record_processor(log_record_processor)
           @mutex.synchronize do
+            if @stopped
+              OpenTelemetry.logger.warn('calling LoggerProvider#' \
+                'add_log_record_processor after shutdown.')
+              return
+            end
             @log_record_processors = @log_record_processors.dup.push(log_record_processor)
           end
         end

--- a/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
@@ -18,7 +18,7 @@ module OpenTelemetry
 
         # Returns a new LoggerProvider instance.
         #
-        # @param [Resource] resource An optional resource to associate with
+        # @param [optional Resource] resource The resource to associate with
         #   new LogRecords created by {Logger}s created by this LoggerProvider.
         #
         # @return [OpenTelemetry::SDK::Logs::LoggerProvider]
@@ -32,7 +32,7 @@ module OpenTelemetry
         # Returns an {OpenTelemetry::SDK::Logs::Logger} instance.
         #
         # @param [String] name Instrumentation package name
-        # @param [String] version Optional instrumentation package version
+        # @param [optional String] version Instrumentation package version
         #
         # @return [OpenTelemetry::SDK::Logs::Logger]
         def logger(name:, version: nil)
@@ -71,7 +71,7 @@ module OpenTelemetry
         #
         # After this is called all newly created {LogRecord}s will be no-op.
         #
-        # @param [Numeric] timeout An optional timeout in seconds.
+        # @param [optional Numeric] timeout An optional timeout in seconds.
         # @return [Integer] Export::SUCCESS if no error occurred, Export::FAILURE if
         #   a non-specific failure occurred, Export::TIMEOUT if a timeout occurred.
         def shutdown(timeout: nil)
@@ -102,7 +102,7 @@ module OpenTelemetry
         # the process after an invocation, but before the {LogRecordProcessor}
         # exports the completed {LogRecord}s.
         #
-        # @param [Numeric] timeout An optional timeout in seconds.
+        # @param [optional Numeric] timeout An optional timeout in seconds.
         # @return [Integer] Export::SUCCESS if no error occurred, Export::FAILURE if
         #   a non-specific failure occurred, Export::TIMEOUT if a timeout occurred.
         def force_flush(timeout: nil)

--- a/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
@@ -28,15 +28,17 @@ module OpenTelemetry
 
         # Creates an {OpenTelemetry::SDK::Logs::Logger} instance.
         #
-        # @param [optional String] name Instrumentation package name
+        # @param [String] name Instrumentation package name
         # @param [optional String] version Instrumentation package version
         #
         # @return [OpenTelemetry::SDK::Logs::Logger]
-        def logger(name = nil, version = nil)
-          name ||= ''
+        def logger(name:, version: nil)
           version ||= ''
 
-          OpenTelemetry.logger.warn('LoggerProvider#logger called without providing a logger name.') if name.empty?
+          if !name.is_a?(String) || name.empty?
+            OpenTelemetry.logger.warn('LoggerProvider#logger called with an ' \
+              "invalid name. Name provided: #{name.inspect}")
+          end
 
           OpenTelemetry::SDK::Logs::Logger.new(name, version, self)
         end

--- a/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
@@ -13,6 +13,9 @@ module OpenTelemetry
 
         UNEXPECTED_ERROR_MESSAGE = 'unexpected error in ' \
           'OpenTelemetry::SDK::Logs::LoggerProvider#%s'
+
+        private_constant :UNEXPECTED_ERROR_MESSAGE
+
         # Returns a new LoggerProvider instance.
         #
         # @param [optional Resource] resource The resource to associate with

--- a/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
@@ -87,9 +87,6 @@ module OpenTelemetry
             @stopped = true
             results.max || OpenTelemetry::SDK::Logs::Export::SUCCESS
           end
-        rescue StandardError => e
-          OpenTelemetry.handle_error(exception: e, message: UNEXPECTED_ERROR_MESSAGE % __method__)
-          Export::FAILURE
         end
 
         # Immediately export all {LogRecord}s that have not yet been exported
@@ -117,9 +114,6 @@ module OpenTelemetry
 
             results.max || Export::SUCCESS
           end
-        rescue StandardError => e
-          OpenTelemetry.handle_error(exception: e, message: UNEXPECTED_ERROR_MESSAGE % __method__)
-          Export::FAILURE
         end
       end
     end

--- a/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
@@ -18,7 +18,7 @@ module OpenTelemetry
 
         # Returns a new LoggerProvider instance.
         #
-        # @param [optional Resource] resource The resource to associate with
+        # @param [Resource] resource An optional resource to associate with
         #   new LogRecords created by {Logger}s created by this LoggerProvider.
         #
         # @return [OpenTelemetry::SDK::Logs::LoggerProvider]

--- a/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/logger_provider.rb
@@ -32,7 +32,7 @@ module OpenTelemetry
         # Creates an {OpenTelemetry::SDK::Logs::Logger} instance.
         #
         # @param [String] name Instrumentation package name
-        # @param [optional String] version Instrumentation package version
+        # @param [String] version Optional instrumentation package version
         #
         # @return [OpenTelemetry::SDK::Logs::Logger]
         def logger(name:, version: nil)
@@ -71,7 +71,7 @@ module OpenTelemetry
         #
         # After this is called all newly created {LogRecord}s will be no-op.
         #
-        # @param [optional Numeric] timeout An optional timeout in seconds.
+        # @param [Numeric] timeout An optional timeout in seconds.
         # @return [Integer] Export::SUCCESS if no error occurred, Export::FAILURE if
         #   a non-specific failure occurred, Export::TIMEOUT if a timeout occurred.
         def shutdown(timeout: nil)
@@ -102,7 +102,7 @@ module OpenTelemetry
         # the process after an invocation, but before the {LogRecordProcessor}
         # exports the completed {LogRecord}s.
         #
-        # @param [optional Numeric] timeout An optional timeout in seconds.
+        # @param [Numeric] timeout An optional timeout in seconds.
         # @return [Integer] Export::SUCCESS if no error occurred, Export::FAILURE if
         #   a non-specific failure occurred, Export::TIMEOUT if a timeout occurred.
         def force_flush(timeout: nil)

--- a/logs_sdk/opentelemetry-logs-sdk.gemspec
+++ b/logs_sdk/opentelemetry-logs-sdk.gemspec
@@ -24,15 +24,18 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 3.0'
 
-  spec.add_dependency 'opentelemetry-logs-api', '~> 0.1.0'
+  spec.add_dependency 'opentelemetry-api', '~> 1.2'
+  spec.add_dependency 'opentelemetry-logs-api', '~> 0.1'
+  spec.add_dependency 'opentelemetry-sdk', '~> 1.3'
 
   spec.add_development_dependency 'bundler', '>= 1.17'
-  spec.add_development_dependency 'minitest', '~> 5.0'
-  spec.add_development_dependency 'rake', '~> 12.0'
-  spec.add_development_dependency 'rubocop', '~> 1.51.0'
-  spec.add_development_dependency 'simplecov', '~> 0.17'
+  spec.add_development_dependency 'minitest', '~> 5.19'
+  spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.4'
+  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'rubocop', '~> 1.56'
+  spec.add_development_dependency 'simplecov', '~> 0.22'
   spec.add_development_dependency 'yard', '~> 0.9'
-  spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
+  spec.add_development_dependency 'yard-doctest', '~> 0.1.17'
 
   if spec.respond_to?(:metadata)
     spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-logs-sdk/v#{OpenTelemetry::SDK::Logs::VERSION}/file.CHANGELOG.html"

--- a/logs_sdk/test/.rubocop.yml
+++ b/logs_sdk/test/.rubocop.yml
@@ -1,24 +1,8 @@
-# inherit_from: .rubocop_todo.yml
+inherit_from: ../.rubocop.yml
 
-AllCops:
-  TargetRubyVersion: '3.0'
-
-Lint/UnusedMethodArgument:
-  Enabled: false
-Metrics/AbcSize:
+Metrics/BlockLength:
   Enabled: false
 Metrics/LineLength:
   Enabled: false
-Metrics/MethodLength:
-  Max: 50
-Metrics/PerceivedComplexity:
-  Max: 30
-Metrics/CyclomaticComplexity:
-  Max: 20
-Metrics/ParameterLists:
-  Enabled: false
-Naming/FileName:
-  Exclude:
-    - 'lib/opentelemetry-logs-sdk.rb'
-Style/ModuleFunction:
+Metrics/AbcSize:
   Enabled: false

--- a/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
@@ -31,6 +31,25 @@ describe OpenTelemetry::SDK::Logs::LoggerProvider do
       logger_provider.add_log_record_processor(mock_log_record_processor)
       assert_equal(1, logger_provider.instance_variable_get(:@log_record_processors).length)
     end
+
+    describe 'when stopped' do
+      before { logger_provider.instance_variable_set(:@stopped, true) }
+
+      it 'does not add the processor' do
+        assert_equal(0, logger_provider.instance_variable_get(:@log_record_processors).length)
+
+        logger_provider.add_log_record_processor(mock_log_record_processor)
+        assert_equal(0, logger_provider.instance_variable_get(:@log_record_processors).length)
+      end
+
+      it 'logs a warning' do
+        OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
+          logger_provider.add_log_record_processor(mock_log_record_processor)
+          assert_match(/calling LoggerProvider#add_log_record_processor after shutdown/,
+            log_stream.string)
+        end
+      end
+    end
   end
 
   describe '#logger' do

--- a/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
@@ -26,10 +26,10 @@ describe OpenTelemetry::SDK::Logs::LoggerProvider do
 
   describe '#add_log_record_processor' do
     it "adds the processor to the logger provider's processors" do
-      assert_equal(0, logger_provider.log_record_processors.length)
+      assert_equal(0, logger_provider.instance_variable_get(:@log_record_processors).length)
 
       logger_provider.add_log_record_processor(mock_log_record_processor)
-      assert_equal(1, logger_provider.log_record_processors.length)
+      assert_equal(1, logger_provider.instance_variable_get(:@log_record_processors).length)
     end
   end
 

--- a/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
@@ -65,7 +65,6 @@ describe OpenTelemetry::SDK::Logs::LoggerProvider do
       assert_equal(logger.instance_variable_get(:@instrumentation_scope).version, version)
     end
   end
-  end
 
   describe '#shutdown' do
     it 'logs a warning if called twice' do
@@ -115,21 +114,6 @@ describe OpenTelemetry::SDK::Logs::LoggerProvider do
         assert_equal(OpenTelemetry::SDK::Logs::Export::TIMEOUT, logger_provider.shutdown)
       end
     end
-
-    it 'logs an error when error is raised' do
-      OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
-        OpenTelemetry::Common::Utilities.stub :timeout_timestamp, -> { raise StandardError.new, 'fail' } do
-          logger_provider.shutdown
-          assert_match(/LoggerProvider#shutdown/, log_stream.string)
-        end
-      end
-    end
-
-    it 'returns a failure code when an error is raised' do
-      OpenTelemetry::Common::Utilities.stub :timeout_timestamp, -> { raise StandardError.new, 'fail' } do
-        assert_equal(OpenTelemetry::SDK::Logs::Export::FAILURE, logger_provider.shutdown)
-      end
-    end
   end
 
   describe '#force_flush' do
@@ -164,21 +148,6 @@ describe OpenTelemetry::SDK::Logs::LoggerProvider do
       OpenTelemetry::Common::Utilities.stub :maybe_timeout, 0 do
         logger_provider.add_log_record_processor(mock_log_record_processor)
         assert_equal(OpenTelemetry::SDK::Logs::Export::TIMEOUT, logger_provider.force_flush)
-      end
-    end
-
-    it 'returns a failure code when an error is raised' do
-      OpenTelemetry::Common::Utilities.stub :timeout_timestamp, -> { raise StandardError.new, 'fail' } do
-        assert_equal(OpenTelemetry::SDK::Logs::Export::FAILURE, logger_provider.force_flush)
-      end
-    end
-
-    it 'logs an error when error is raised' do
-      OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
-        OpenTelemetry::Common::Utilities.stub :timeout_timestamp, -> { raise StandardError.new, 'fail' } do
-          logger_provider.shutdown
-          assert_match(/LoggerProvider#shutdown/, log_stream.string)
-        end
       end
     end
   end

--- a/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
@@ -54,16 +54,17 @@ describe OpenTelemetry::SDK::Logs::LoggerProvider do
       # :version is nil by default, but explicitly setting it here
       # to make the test easier to read
       logger = logger_provider.logger(name: 'name', version: nil)
-      assert_equal(logger.instrumentation_scope.version, '')
+      assert_equal(logger.instance_variable_get(:@instrumentation_scope).version, '')
     end
 
     it 'creates a new logger with the passed-in name and version' do
       name = 'name'
       version = 'version'
       logger = logger_provider.logger(name: name, version: version)
-      assert_equal(logger.instrumentation_scope.name, name)
-      assert_equal(logger.instrumentation_scope.version, version)
+      assert_equal(logger.instance_variable_get(:@instrumentation_scope).name, name)
+      assert_equal(logger.instance_variable_get(:@instrumentation_scope).version, version)
     end
+  end
   end
 
   describe '#shutdown' do

--- a/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+describe OpenTelemetry::SDK::Logs::LoggerProvider do
+  let(:logger_provider) { OpenTelemetry::SDK::Logs::LoggerProvider.new }
+  let(:mock_log_record_processor)  { Minitest::Mock.new }
+  let(:mock_log_record_processor2) { Minitest::Mock.new }
+
+  describe 'resource association' do
+    let(:resource) { OpenTelemetry::SDK::Resources::Resource.create('hi' => 1) }
+    let(:logger_provider) do
+      OpenTelemetry::SDK::Logs::LoggerProvider.new(resource: resource)
+    end
+
+    it 'allows a resource to be associated with the logger provider' do
+      assert_instance_of(
+        OpenTelemetry::SDK::Resources::Resource, logger_provider.resource
+      )
+    end
+  end
+
+  describe '#add_log_record_processor' do
+    it "adds the processor to the logger provider's processors" do
+      assert_equal(0, logger_provider.log_record_processors.length)
+
+      logger_provider.add_log_record_processor(mock_log_record_processor)
+      assert_equal(1, logger_provider.log_record_processors.length)
+    end
+  end
+
+  describe '#logger' do
+    let(:error_text) { /LoggerProvider#logger called without providing a logger name/ }
+
+    it 'logs a warning if name is nil' do
+      OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
+        logger_provider.logger(nil)
+        assert_match(error_text, log_stream.string)
+      end
+    end
+
+    it 'logs a warning if name is an empty string' do
+      OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
+        logger_provider.logger('')
+        assert_match(error_text, log_stream.string)
+      end
+    end
+
+    it 'sets name to an empty string if nil' do
+      logger = logger_provider.logger(nil)
+      assert_equal(logger.instrumentation_scope.name, '')
+    end
+
+    it 'sets version to an empty string if nil' do
+      logger = logger_provider.logger('name', nil)
+      assert_equal(logger.instrumentation_scope.version, '')
+    end
+
+    it 'creates a new logger with the passed-in name and version' do
+      name = 'name'
+      version = 'version'
+      logger = logger_provider.logger(name, version)
+      assert_equal(logger.instrumentation_scope.name, name)
+      assert_equal(logger.instrumentation_scope.version, version)
+    end
+
+    it 'creates a new logger when name and version are missing' do
+      logger = logger_provider.logger
+      logger2 = logger_provider.logger
+
+      refute_same(logger, logger2)
+      assert_instance_of(OpenTelemetry::SDK::Logs::Logger, logger)
+    end
+  end
+
+  describe '#shutdown' do
+    it 'logs a warning if called twice' do
+      OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
+        logger_provider.shutdown
+        assert logger_provider.instance_variable_get(:@stopped)
+        assert_empty(log_stream.string)
+        logger_provider.shutdown
+        assert_match(/.* called multiple times/, log_stream.string)
+      end
+    end
+
+    it 'sends shutdown to the processor' do
+      mock_log_record_processor.expect(:shutdown, nil, timeout: nil)
+      logger_provider.add_log_record_processor(mock_log_record_processor)
+      logger_provider.shutdown
+      mock_log_record_processor.verify
+    end
+
+    it 'sends shutdown to multiple processors' do
+      mock_log_record_processor.expect(:shutdown, nil, timeout: nil)
+      mock_log_record_processor2.expect(:shutdown, nil, timeout: nil)
+
+      logger_provider.instance_variable_set(
+        :@log_record_processors,
+        [mock_log_record_processor, mock_log_record_processor2]
+      )
+      logger_provider.shutdown
+
+      mock_log_record_processor.verify
+      mock_log_record_processor2.verify
+    end
+
+    it 'does not allow subsequent shutdown attempts to reach the processor' do
+      mock_log_record_processor.expect(:shutdown, nil, timeout: nil)
+
+      logger_provider.add_log_record_processor(mock_log_record_processor)
+      logger_provider.shutdown
+      logger_provider.shutdown
+
+      mock_log_record_processor.verify
+    end
+
+    it 'returns a timeout code if the countdown reaches zero' do
+      OpenTelemetry::Common::Utilities.stub :maybe_timeout, 0 do
+        logger_provider.add_log_record_processor(mock_log_record_processor)
+        assert_equal(OpenTelemetry::SDK::Logs::Export::TIMEOUT, logger_provider.shutdown)
+      end
+    end
+
+    it 'logs an error when error is raised' do
+      OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
+        OpenTelemetry::Common::Utilities.stub :timeout_timestamp, -> { raise StandardError.new, 'fail' } do
+          logger_provider.shutdown
+          assert_match(/LoggerProvider#shutdown/, log_stream.string)
+        end
+      end
+    end
+
+    it 'returns a failure code when an error is raised' do
+      OpenTelemetry::Common::Utilities.stub :timeout_timestamp, -> { raise StandardError.new, 'fail' } do
+        assert_equal(OpenTelemetry::SDK::Logs::Export::FAILURE, logger_provider.shutdown)
+      end
+    end
+  end
+
+  describe '#force_flush' do
+    it 'notifies the log record processor' do
+      mock_log_record_processor.expect(:force_flush, nil, timeout: nil)
+
+      logger_provider.add_log_record_processor(mock_log_record_processor)
+      logger_provider.force_flush
+
+      mock_log_record_processor.verify
+    end
+
+    it 'supports multiple log record processors' do
+      mock_log_record_processor.expect(:force_flush, nil, timeout: nil)
+      mock_log_record_processor2.expect(:force_flush, nil, timeout: nil)
+
+      logger_provider.add_log_record_processor(mock_log_record_processor)
+      logger_provider.add_log_record_processor(mock_log_record_processor2)
+      logger_provider.force_flush
+
+      mock_log_record_processor.verify
+      mock_log_record_processor2.verify
+    end
+
+    it 'returns a success status code if called while stopped' do
+      logger_provider.add_log_record_processor(mock_log_record_processor)
+      logger_provider.instance_variable_set(:@stopped, true)
+      assert_equal(OpenTelemetry::SDK::Logs::Export::SUCCESS, logger_provider.force_flush)
+    end
+
+    it 'returns a timeout code when the timeout countdown reaches zero' do
+      OpenTelemetry::Common::Utilities.stub :maybe_timeout, 0 do
+        logger_provider.add_log_record_processor(mock_log_record_processor)
+        assert_equal(OpenTelemetry::SDK::Logs::Export::TIMEOUT, logger_provider.force_flush)
+      end
+    end
+
+    it 'returns a failure code when an error is raised' do
+      OpenTelemetry::Common::Utilities.stub :timeout_timestamp, -> { raise StandardError.new, 'fail' } do
+        assert_equal(OpenTelemetry::SDK::Logs::Export::FAILURE, logger_provider.force_flush)
+      end
+    end
+
+    it 'logs an error when error is raised' do
+      OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
+        OpenTelemetry::Common::Utilities.stub :timeout_timestamp, -> { raise StandardError.new, 'fail' } do
+          logger_provider.shutdown
+          assert_match(/LoggerProvider#shutdown/, log_stream.string)
+        end
+      end
+    end
+  end
+end

--- a/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
@@ -34,46 +34,35 @@ describe OpenTelemetry::SDK::Logs::LoggerProvider do
   end
 
   describe '#logger' do
-    let(:error_text) { /LoggerProvider#logger called without providing a logger name/ }
+    let(:error_text) { /LoggerProvider#logger called with an invalid name/ }
 
     it 'logs a warning if name is nil' do
       OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
-        logger_provider.logger(nil)
+        logger_provider.logger(name: nil)
         assert_match(error_text, log_stream.string)
       end
     end
 
     it 'logs a warning if name is an empty string' do
       OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
-        logger_provider.logger('')
+        logger_provider.logger(name: '')
         assert_match(error_text, log_stream.string)
       end
     end
 
-    it 'sets name to an empty string if nil' do
-      logger = logger_provider.logger(nil)
-      assert_equal(logger.instrumentation_scope.name, '')
-    end
-
     it 'sets version to an empty string if nil' do
-      logger = logger_provider.logger('name', nil)
+      # :version is nil by default, but explicitly setting it here
+      # to make the test easier to read
+      logger = logger_provider.logger(name: 'name', version: nil)
       assert_equal(logger.instrumentation_scope.version, '')
     end
 
     it 'creates a new logger with the passed-in name and version' do
       name = 'name'
       version = 'version'
-      logger = logger_provider.logger(name, version)
+      logger = logger_provider.logger(name: name, version: version)
       assert_equal(logger.instrumentation_scope.name, name)
       assert_equal(logger.instrumentation_scope.version, version)
-    end
-
-    it 'creates a new logger when name and version are missing' do
-      logger = logger_provider.logger
-      logger2 = logger_provider.logger
-
-      refute_same(logger, logger2)
-      assert_instance_of(OpenTelemetry::SDK::Logs::Logger, logger)
     end
   end
 

--- a/logs_sdk/test/test_helper.rb
+++ b/logs_sdk/test/test_helper.rb
@@ -9,6 +9,8 @@ SimpleCov.start { enable_coverage :branch }
 SimpleCov.minimum_coverage 85
 
 require 'opentelemetry-logs-api'
+require 'opentelemetry-logs-sdk'
+require 'opentelemetry-test-helpers'
 require 'minitest/autorun'
 
 OpenTelemetry.logger = Logger.new(File::NULL)


### PR DESCRIPTION
Fulfills the [Logs SDK specs for Logger Provider](https://opentelemetry.io/docs/specs/otel/logs/sdk/#loggerprovider)

The Logger Provider implementation is drawn mainly from the Tracer Provider implementation, as they have very similar specs.

* [Tracer Provider specs](https://opentelemetry.io/docs/specs/otel/trace/sdk/#tracer-provider)
* [TracerProvider class](https://github.com/open-telemetry/opentelemetry-ruby/blob/main/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb) 

If merged, this PR would fulfill the following elements on the [spec-compliance-matrix for Logs](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md#logs)

- [ ] LoggerProvider.GetLogger
- [ ] LoggerProvider.GetLogger accepts attributes
- [ ] LoggerProvider.Shutdown
- [ ] LoggerProvider.ForceFlush

Here are some other implementations of LoggerProvider for comparison:
* [Java (stable)](https://github.com/open-telemetry/opentelemetry-java/blob/90ab3665dc0fb56598fcf9b9c15941eedb3822f8/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/SdkLoggerProvider.java)
* [JS (experimental)](https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/sdk-logs/src/LoggerProvider.ts)
* [PHP (stable)](https://github.com/open-telemetry/opentelemetry-php/blob/main/src/SDK/Logs/LoggerProvider.php)
* [Python (experimental)](https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py#L581)


Resolves #1483 