### PR TITLE
fix: Optimize span and trace ID generation

### DIFF
--- a/api/benchmarks/id_generation_bench.rb
+++ b/api/benchmarks/id_generation_bench.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'benchmark/ipsa'
+
+INVALID_SPAN_ID = ("\0" * 8).b
+INVALID_TRACE_ID = ("\0" * 16).b
+
+def generate_trace_id
+  loop do
+    id = Random.bytes(16)
+    return id unless id == INVALID_TRACE_ID
+  end
+end
+
+def generate_trace_id_while
+  id = Random.bytes(16)
+  id = Random.bytes(16) while id == INVALID_TRACE_ID
+  id
+end
+
+def generate_span_id
+  loop do
+    id = Random.bytes(8)
+    return id unless id == INVALID_SPAN_ID
+  end
+end
+
+def generate_span_id_while
+  id = Random.bytes(8)
+  id = Random.bytes(8) while id == INVALID_SPAN_ID
+  id
+end
+
+Benchmark.ipsa do |x|
+  x.report('generate_trace_id') { generate_trace_id }
+  x.report('generate_trace_id_while') { generate_trace_id_while }
+  x.compare!
+end
+
+Benchmark.ipsa do |x|
+  x.report('generate_span_id') { generate_span_id }
+  x.report('generate_span_id_while') { generate_span_id_while }
+  x.compare!
+end

--- a/api/lib/opentelemetry/trace.rb
+++ b/api/lib/opentelemetry/trace.rb
@@ -26,10 +26,9 @@ module OpenTelemetry
     #
     # @return [String] a valid trace ID.
     def generate_trace_id
-      loop do
-        id = Random.bytes(16)
-        return id unless id == INVALID_TRACE_ID
-      end
+      id = Random.bytes(16)
+      id = Random.bytes(16) while id == INVALID_TRACE_ID
+      id
     end
 
     # Generates a valid span identifier, an 8-byte string with at least one
@@ -37,10 +36,9 @@ module OpenTelemetry
     #
     # @return [String] a valid span ID.
     def generate_span_id
-      loop do
-        id = Random.bytes(8)
-        return id unless id == INVALID_SPAN_ID
-      end
+      id = Random.bytes(8)
+      id = Random.bytes(8) while id == INVALID_SPAN_ID
+      id
     end
 
     # Returns the current span from the current or provided context


### PR DESCRIPTION
This improves the performance of span and trace ID generation by avoiding the loop overhead in the common case of `rand` returning a valid ID.

Benchmark results:
```
Comparison:
generate_trace_id_while:  8023027.6 i/s
   generate_trace_id:  4328017.1 i/s - 1.85x slower
...
Comparison:
generate_span_id_while:  8364182.8 i/s
    generate_span_id:  4382207.1 i/s - 1.91x slower
```