### PR TITLE
fix: Small perf improvement to generate_r

### DIFF
--- a/api/benchmarks/id_generation_bench.rb
+++ b/api/benchmarks/id_generation_bench.rb
@@ -35,6 +35,16 @@ def generate_span_id_while
   id
 end
 
+def generate_r(trace_id)
+  x = trace_id[8, 8].unpack1('Q>') | 0x3
+  64 - x.bit_length
+end
+
+def generate_r_in_place(trace_id)
+  x = trace_id.unpack1('Q>', offset: 8) | 0x3
+  64 - x.bit_length
+end
+
 Benchmark.ipsa do |x|
   x.report('generate_trace_id') { generate_trace_id }
   x.report('generate_trace_id_while') { generate_trace_id_while }
@@ -44,5 +54,12 @@ end
 Benchmark.ipsa do |x|
   x.report('generate_span_id') { generate_span_id }
   x.report('generate_span_id_while') { generate_span_id_while }
+  x.compare!
+end
+
+Benchmark.ipsa do |x|
+  trace_id = generate_trace_id
+  x.report('generate_r') { generate_r(trace_id) }
+  x.report('generate_r_in_place') { generate_r_in_place(trace_id) }
   x.compare!
 end

--- a/sdk_experimental/lib/opentelemetry/sdk/trace/samplers/consistent_probability_tracestate.rb
+++ b/sdk_experimental/lib/opentelemetry/sdk/trace/samplers/consistent_probability_tracestate.rb
@@ -106,7 +106,7 @@ module OpenTelemetry
           end
 
           def generate_r(trace_id)
-            x = trace_id[8, 8].unpack1('Q>') | 0x3
+            x = trace_id.unpack1('Q>', offset: 8) | 0x3
             64 - x.bit_length
           end
         end


### PR DESCRIPTION
This is a small performance improvement to the `generate_r` method for the consistent-probability sampler. This method generates a `r` value from the `trace_id`. The current implementation unnecessarily allocates a slice of the `trace_id` string. Using the `offset:` argument to `unpack1`, we can avoid this allocation.

Benchmark results:
```
Calculating -------------------------------------
          generate_r      3.920M (± 0.4%) i/s -     19.654M
 generate_r_in_place      4.596M (± 0.5%) i/s -     23.085M

Comparison:
 generate_r_in_place:  4595613.7 i/s
          generate_r:  3920215.1 i/s - 1.17x slower
```