### PR TITLE
chore: Rubocop alignment update

### DIFF
--- a/registry/lib/opentelemetry/instrumentation/registry.rb
+++ b/registry/lib/opentelemetry/instrumentation/registry.rb
@@ -71,7 +71,7 @@ module OpenTelemetry
 
       def find_instrumentation(instrumentation_name)
         @instrumentation.detect { |a| a.instance.name == instrumentation_name }
-                   &.instance
+                        &.instance
       end
 
       def install_instrumentation(instrumentation, config)


### PR DESCRIPTION
This PR resolves the following Rubocop offense:
```
lib/opentelemetry/instrumentation/registry.rb:74:20: C: [Correctable] Layout/MultilineMethodCallIndentation: Align &.instance with .detect on line 73.
                   &.instance
                   ^^^^^^^^^^
```