### PR TITLE
test: Skip flaky truffleruby tests

### DIFF
--- a/exporter/otlp-common/test/opentelemetry/exporter/otlp/common/common_test.rb
+++ b/exporter/otlp-common/test/opentelemetry/exporter/otlp/common/common_test.rb
@@ -41,6 +41,9 @@ describe OpenTelemetry::Exporter::OTLP::Common do
     end
 
     it 'translates all the things' do
+      # TODO: See issue #1507 to fix
+      skip 'Intermittently fails' if RUBY_ENGINE == 'truffleruby'
+
       OpenTelemetry.tracer_provider = OpenTelemetry::SDK::Trace::TracerProvider.new(resource: OpenTelemetry::SDK::Resources::Resource.telemetry_sdk)
       tracer = OpenTelemetry.tracer_provider.tracer('tracer', 'v0.0.1')
       other_tracer = OpenTelemetry.tracer_provider.tracer('other_tracer')

--- a/exporter/otlp-http/test/opentelemetry/exporter/otlp/http/trace_exporter_test.rb
+++ b/exporter/otlp-http/test/opentelemetry/exporter/otlp/http/trace_exporter_test.rb
@@ -468,6 +468,9 @@ describe OpenTelemetry::Exporter::OTLP::HTTP::TraceExporter do
     end
 
     it 'translates all the things' do
+      # TODO: See issue #1507 to fix
+      skip 'Intermittently fails' if RUBY_ENGINE == 'truffleruby'
+
       stub_request(:post, 'http://localhost:4318/v1/traces').to_return(status: 200)
       processor = OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(exporter)
       tracer = OpenTelemetry.tracer_provider.tracer('tracer', 'v0.0.1')


### PR DESCRIPTION
This test is failing on unrelated PRs. Issue #1507 is created to resolve the source of the flakiness.

A test identical to the one fixed in #1512 has started failing in the `otlp-http suite. Since this test also exists in `otlp-common`, I've pre-emptively skipped it for truffleruby.