### PR TITLE
Small perf improvement

### DIFF
--- a/api/lib/opentelemetry/trace/tracestate.rb
+++ b/api/lib/opentelemetry/trace/tracestate.rb
@@ -75,8 +75,8 @@ module OpenTelemetry
       # @return [Tracestate]
       def initialize(hash)
         excess = hash.size - MAX_MEMBER_COUNT
-        hash = Hash[hash.drop(excess)] if excess.positive?
-        @hash = hash.freeze
+        @hash = excess.positive? ? Hash[hash.first(MAX_MEMBER_COUNT)] : hash
+        @hash.freeze
       end
 
       # Returns the value associated with the given key, or nil if the key


### PR DESCRIPTION
I saw this method in a few profiles and used ChatGPT to make it faster. Seems worth the effort.

```
require 'benchmark/ips'

MAX_MEMBER_COUNT = 1000

class OldVersion
  def initialize(hash)
    excess = hash.size - MAX_MEMBER_COUNT
    hash = Hash[hash.drop(excess)] if excess.positive?
    @hash = hash.freeze
  end
end

class NewVersion
  def initialize(hash)
    excess = hash.size - MAX_MEMBER_COUNT
    @hash = excess.positive? ? Hash[hash.first(MAX_MEMBER_COUNT)] : hash
    @hash.freeze
  end
end

small_hash = Hash[(1..500).map { |i| [i, i] }] 
medium_hash = Hash[(1..1500).map { |i| [i, i] }]
large_hash = Hash[(1..5000).map { |i| [i, i] }]


Benchmark.ips do |x|
  x.config(:time => 5, :warmup => 2)
  
  x.report("Old version with small input") do 
    OldVersion.new(small_hash) 
  end

  x.report("New version with small input") do 
    NewVersion.new(small_hash) 
  end

  x.compare!
end

Benchmark.ips do |x|
  x.config(:time => 5, :warmup => 2)

  x.report("Old version with medium input") do 
    OldVersion.new(medium_hash) 
  end

  x.report("New version with medium input") do 
    NewVersion.new(medium_hash) 
  end

  x.compare!
end

Benchmark.ips do |x|
  x.config(:time => 5, :warmup => 2)
  
  x.report("Old version with large input") do 
    OldVersion.new(large_hash) 
  end

  x.report("New version with large input") do 
    NewVersion.new(large_hash) 
  end

  x.compare!
end
```

```
Warming up --------------------------------------
Old version with small input
                       567.474k i/100ms
New version with small input
                       613.909k i/100ms
Calculating -------------------------------------
Old version with small input
                          5.561M (± 3.2%) i/s -     27.806M in   5.005872s
New version with small input
                          6.145M (± 0.7%) i/s -     31.309M in   5.095542s

Comparison:
New version with small input:  6144778.6 i/s
Old version with small input:  5561220.3 i/s - 1.10x  slower

Warming up --------------------------------------
Old version with medium input
                         1.209k i/100ms
New version with medium input
                         1.486k i/100ms
Calculating -------------------------------------
Old version with medium input
                         11.875k (± 2.7%) i/s -     60.450k in   5.094750s
New version with medium input
                         14.949k (± 0.9%) i/s -     75.786k in   5.069964s

Comparison:
New version with medium input:    14949.2 i/s
Old version with medium input:    11874.8 i/s - 1.26x  slower

Warming up --------------------------------------
Old version with large input
                       523.000  i/100ms
New version with large input
                         1.492k i/100ms
Calculating -------------------------------------
Old version with large input
                          5.184k (± 3.2%) i/s -     26.150k in   5.050380s
New version with large input
                         14.630k (± 3.1%) i/s -     74.600k in   5.105030s

Comparison:
New version with large input:    14630.0 i/s
Old version with large input:     5184.2 i/s - 2.82x  slower
```