### PR TITLE
fix: spec compliance for span attribute limit

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/span.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span.rb
@@ -347,8 +347,14 @@ module OpenTelemetry
         def trim_span_attributes(attrs)
           return if attrs.nil?
 
-          excess = attrs.size - @span_limits.attribute_count_limit
-          excess.times { attrs.shift } if excess.positive?
+          if attrs.size > @span_limits.attribute_count_limit
+            n = @span_limits.attribute_count_limit
+            attrs.delete_if do |_key, _value|
+              n -= 1
+              n < 0
+            end
+          end
+
           truncate_attribute_values(attrs, @span_limits.attribute_length_limit)
           nil
         end

--- a/sdk/lib/opentelemetry/sdk/trace/span.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span.rb
@@ -351,7 +351,7 @@ module OpenTelemetry
             n = @span_limits.attribute_count_limit
             attrs.delete_if do |_key, _value|
               n -= 1
-              n < 0
+              n.negative?
             end
           end
 

--- a/sdk/test/opentelemetry/sdk/trace/span_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/span_test.rb
@@ -60,10 +60,10 @@ describe OpenTelemetry::SDK::Trace::Span do
       _(span.attributes).must_equal('foo' => 'bar')
     end
 
-    it 'trims the oldest attribute' do
+    it 'trims the newest attribute' do
       span.set_attribute('old', 'oldbar')
       span.set_attribute('foo', 'bar')
-      _(span.attributes).must_equal('foo' => 'bar')
+      _(span.attributes).must_equal('old' => 'oldbar')
     end
 
     it 'truncates attribute value length based if configured' do
@@ -138,10 +138,10 @@ describe OpenTelemetry::SDK::Trace::Span do
       _(span.attributes).must_equal('foo' => 'bar')
     end
 
-    it 'trims the oldest attributes' do
+    it 'trims the newest attributes' do
       span.add_attributes('old' => 'oldbar')
       span.add_attributes('foo' => 'bar', 'bar' => 'baz')
-      _(span.attributes).must_equal('bar' => 'baz')
+      _(span.attributes).must_equal('old' => 'oldbar')
     end
 
     it 'truncates attribute value length based if configured' do

--- a/sdk/test/opentelemetry/sdk/trace/span_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/span_test.rb
@@ -499,22 +499,23 @@ describe OpenTelemetry::SDK::Trace::Span do
     end
 
     it 'trims excess attributes' do
-      attributes = { 'foo': 'bar', 'other': 'attr' }
+      attributes = { 'foo' => 'bar', 'other' => 'attr' }
       span = Span.new(context, Context.empty, OpenTelemetry::Trace::Span::INVALID, 'name', SpanKind::INTERNAL, nil, span_limits,
                       [], attributes, nil, Time.now, nil, nil)
       _(span.to_span_data.total_recorded_attributes).must_equal(2)
       _(span.attributes.length).must_equal(1)
+      _(span.attributes).must_equal('foo' => 'bar')
     end
 
     it 'truncates attributes if configured' do
-      attributes = { 'foo': 'oldbaroldbaroldbaroldbaroldbaroldbar' }
+      attributes = { 'foo' => 'oldbaroldbaroldbaroldbaroldbaroldbar' }
       span = Span.new(context, Context.empty, OpenTelemetry::Trace::Span::INVALID, 'name', SpanKind::INTERNAL, nil, span_limits,
                       [], attributes, nil, Time.now, nil, nil)
-      _(span.attributes[:foo]).must_equal('oldbaroldbaroldbaroldbaroldba...')
+      _(span.attributes["foo"]).must_equal('oldbaroldbaroldbaroldbaroldba...')
     end
 
     it 'counts attributes' do
-      attributes = { 'foo': 'bar', 'other': 'attr' }
+      attributes = { 'foo' => 'bar', 'other' => 'attr' }
       span = Span.new(context, Context.empty, OpenTelemetry::Trace::Span::INVALID, 'name', SpanKind::INTERNAL, nil, span_limits,
                       [], attributes, nil, Time.now, nil, nil)
       _(span.to_span_data.total_recorded_attributes).must_equal(2)

--- a/sdk/test/opentelemetry/sdk/trace/span_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/span_test.rb
@@ -511,7 +511,7 @@ describe OpenTelemetry::SDK::Trace::Span do
       attributes = { 'foo' => 'oldbaroldbaroldbaroldbaroldbaroldbar' }
       span = Span.new(context, Context.empty, OpenTelemetry::Trace::Span::INVALID, 'name', SpanKind::INTERNAL, nil, span_limits,
                       [], attributes, nil, Time.now, nil, nil)
-      _(span.attributes["foo"]).must_equal('oldbaroldbaroldbaroldbaroldba...')
+      _(span.attributes['foo']).must_equal('oldbaroldbaroldbaroldbaroldba...')
     end
 
     it 'counts attributes' do


### PR DESCRIPTION
Fixes #1534

Note: this does not address Event or Link attribute limits (and, indeed, Event and Link limits), at least some of which are similarly non-compliant. I think we should refactor `trim_links` and `append_event` to use the `trim_span_attributes` method, but that needs to be changed to accept the limit as a parameter. I'd prefer to do that in a subsequent PR.

As a side-effect, trimming span attributes is faster. The old `set_attribute` is about 14% slower than the new code in simple benchmarks, and the old `trim_span_attributes` is about 28% slower than the new implementation.