### PR TITLE
fix: Ruby 3.0 compatibility for generate_r

### DIFF
--- a/sdk_experimental/lib/opentelemetry/sdk/trace/samplers/consistent_probability_tracestate.rb
+++ b/sdk_experimental/lib/opentelemetry/sdk/trace/samplers/consistent_probability_tracestate.rb
@@ -106,7 +106,7 @@ module OpenTelemetry
           end
 
           def generate_r(trace_id)
-            x = trace_id.unpack1('Q>', offset: 8) | 0x3
+            x = trace_id.unpack1('@8Q>') | 0x3
             64 - x.bit_length
           end
         end


### PR DESCRIPTION
Fixes Ruby 3.0 compatibility for `generate_r` accidentally added in #1522 and pointed out by @casperisfine in https://github.com/open-telemetry/opentelemetry-ruby/pull/1522#pullrequestreview-1676776723