### PR TITLE
ci: Run metrics_sdk tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           - opentelemetry-common
           - opentelemetry-logs-api
           - opentelemetry-metrics-api
+          - opentelemetry-metrics-sdk
           - opentelemetry-registry
           - opentelemetry-sdk
           - opentelemetry-sdk-experimental


### PR DESCRIPTION
While reviewing some of the recent PRs related to metrics, I noticed the metrics_sdk specs aren't running on the ci.

This will not pass until #1532 is merged.