### PR TITLE
feat: Create ConsoleMetricPullExporter

### DIFF
--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/export.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/export.rb
@@ -25,3 +25,4 @@ end
 
 require 'opentelemetry/sdk/metrics/export/metric_reader'
 require 'opentelemetry/sdk/metrics/export/in_memory_metric_pull_exporter'
+require 'opentelemetry/sdk/metrics/export/console_metric_pull_exporter'

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/export/console_metric_pull_exporter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/export/console_metric_pull_exporter.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Metrics
+      module Export
+        # Outputs {MetricData} to the console
+        #
+        # Potentially useful for exploratory purposes.
+        class ConsoleMetricPullExporter < MetricReader
+          def initialize
+            super
+            @stopped = false
+          end
+
+          def pull
+            export(collect)
+          end
+
+          def export(metrics, timeout: nil)
+            return FAILURE if @stopped
+
+            Array(metrics).each { |metric| pp metric }
+
+            SUCCESS
+          end
+
+          def force_flush(timeout: nil)
+            SUCCESS
+          end
+
+          def shutdown(timeout: nil)
+            @stopped = true
+            SUCCESS
+          end
+        end
+      end
+    end
+  end
+end

--- a/metrics_sdk/test/integration/console_metric_pull_exporter.rb
+++ b/metrics_sdk/test/integration/console_metric_pull_exporter.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require_relative '../test_helper'
+
+describe OpenTelemetry::SDK do
+  describe '#configure' do
+    export = OpenTelemetry::SDK::Metrics::Export
+
+    let(:captured_stdout) { StringIO.new }
+    let(:metric_data1) { OpenTelemetry::SDK::Metrics::State::MetricData.new({ name: 'name1' }) }
+    let(:metric_data2) { OpenTelemetry::SDK::Metrics::State::MetricData.new({ name: 'name2' }) }
+    let(:metrics)      { [metric_data1, metric_data2] }
+    let(:exporter)     { export::ConsoleMetricPullExporter.new }
+
+    before do
+      reset_metrics_sdk
+      @original_stdout = $stdout
+      $stdout = captured_stdout
+    end
+
+    after do
+      $stdout = @original_stdout
+    end
+
+    it 'accepts an Array of MetricData as arg to #export and succeeds' do
+      _(exporter.export(metrics)).must_equal export::SUCCESS
+    end
+
+    it 'accepts an Enumerable of MetricData as arg to #export and succeeds' do
+      enumerable = Struct.new(:metric0, :metric1).new(metrics[0], metrics[1])
+
+      _(exporter.export(enumerable)).must_equal export::SUCCESS
+    end
+
+    it 'outputs to console on export (stdout)' do
+      exporter.export(metrics)
+
+      _(captured_stdout.string).must_match(/#<struct OpenTelemetry::SDK::Metrics::State::MetricData/)
+    end
+
+    it 'outputs to console using pull (stdout)' do
+      OpenTelemetry::SDK.configure
+      OpenTelemetry.meter_provider.add_metric_reader(exporter)
+      meter = OpenTelemetry.meter_provider.meter('test')
+      counter = meter.create_counter('counter', unit: 'smidgen', description: 'a small amount of something')
+
+      counter.add(1)
+      counter.add(2, attributes: { 'a' => 'b' })
+      counter.add(2, attributes: { 'a' => 'b' })
+      counter.add(3, attributes: { 'b' => 'c' })
+      counter.add(4, attributes: { 'd' => 'e' })
+      exporter.pull
+
+      output = captured_stdout.string
+
+      _(output).wont_be_empty
+      _(output).must_match(/name="counter"/)
+      _(output).must_match(/unit="smidgen"/)
+      _(output).must_match(/description="a small amount of something"/)
+      _(output).must_match(/OpenTelemetry::SDK::InstrumentationScope name="test"/)
+      _(output).must_match(/#<struct OpenTelemetry::SDK::Metrics::Aggregation::NumberDataPoint/)
+    end
+
+    it 'accepts calls to #force_flush' do
+      exporter.force_flush
+    end
+
+    it 'accepts calls to #shutdown' do
+      exporter.shutdown
+    end
+
+    it 'fails to export after shutdown' do
+      exporter.shutdown
+
+      _(exporter.export(metrics)).must_equal export::FAILURE
+    end
+  end
+end


### PR DESCRIPTION
Similar to the `OpenTelemetry::Trace::Export::ConsoleSpanExporter`, this PR creates a pull exporter for metrics that will output the exported data to the console. 

This export may be helpful when running an experiment in a development environment to inspect the data that would have been sent to an OTLP endpoint. This should not be used in production environments.

~~**Note:** One test will fail until #1532 is merged, but the tests will not run in the CI until #1546 is merged.~~