### PR TITLE
chore(rubocop): Style/InverseMethods

### DIFF
--- a/exporter/jaeger/lib/opentelemetry/exporter/jaeger/encoder.rb
+++ b/exporter/jaeger/lib/opentelemetry/exporter/jaeger/encoder.rb
@@ -35,9 +35,9 @@ module OpenTelemetry
 
         def encoded_process(resource)
           service_name = DEFAULT_SERVICE_NAME
-          tags = resource&.attribute_enumerator&.select do |key, value|
+          tags = resource&.attribute_enumerator&.reject do |key, value|
             service_name = value if key == 'service.name'
-            key != 'service.name'
+            key == 'service.name'
           end
           tags = encoded_tags(tags)
           Thrift::Process.new('serviceName' => service_name, 'tags' => tags)


### PR DESCRIPTION
'Use reject instead of inverting select' on Encoder#encoded_process.

Discovered by a [failing job](https://github.com/open-telemetry/opentelemetry-ruby/actions/runs/7103999448/job/19337989114?pr=1548#step:5:335) in #1547 and #1548.