### PR TITLE
chore: Update codeql to v2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
         tools: latest
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
CodeQL V1 has been deprecated. 

Run warnings: https://github.com/open-telemetry/opentelemetry-ruby/actions/runs/7130254094
Blog post: https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/

Failing test fixed in: #1550  