### PR TITLE
chore: Update ruby/setup-ruby to 1.165.1

### DIFF
--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -58,7 +58,7 @@ runs:
     # ...but not for appraisals, sadly.
     - name: Install Ruby ${{ inputs.ruby }} with dependencies
       if: "${{ steps.setup.outputs.appraisals == 'false' }}"
-      uses: ruby/setup-ruby@v1.152.0
+      uses: ruby/setup-ruby@v1.165.1
       with:
         ruby-version: "${{ inputs.ruby }}"
         working-directory: "${{ steps.setup.outputs.gem_dir }}"
@@ -69,7 +69,7 @@ runs:
     # If we're using appraisals, do it all manually.
     - name: Install Ruby ${{ inputs.ruby }} without dependencies
       if: "${{ steps.setup.outputs.appraisals == 'true' }}"
-      uses: ruby/setup-ruby@v1.152.0
+      uses: ruby/setup-ruby@v1.165.1
       with:
         ruby-version: "${{ inputs.ruby }}"
         bundler:  "latest"

--- a/.github/workflows/release-hook-on-closed.yml
+++ b/.github/workflows/release-hook-on-closed.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.165.1
         with:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo

--- a/.github/workflows/release-hook-on-push.yml
+++ b/.github/workflows/release-hook-on-push.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.165.1
         with:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo

--- a/.github/workflows/release-perform.yml
+++ b/.github/workflows/release-perform.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.165.1
         with:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo

--- a/.github/workflows/release-request.yml
+++ b/.github/workflows/release-request.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.165.1
         with:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo

--- a/.github/workflows/release-retry.yml
+++ b/.github/workflows/release-retry.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.165.1
         with:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo


### PR DESCRIPTION
This PR updates the ruby/setup-ruby action to the latest version, 1.165.1, in hopes that it'll unblock truffleruby installation issues in the CI. This also clears the path to add test runs for Ruby 3.3.

Related to #1558 