### PR TITLE
fix: require csv for ruby-3.4 compatibility

### DIFF
--- a/exporter/otlp-http/lib/opentelemetry/exporter/otlp/http/trace_exporter.rb
+++ b/exporter/otlp-http/lib/opentelemetry/exporter/otlp/http/trace_exporter.rb
@@ -8,7 +8,6 @@ require 'opentelemetry/common'
 require 'opentelemetry/exporter/otlp/common'
 require 'opentelemetry/sdk'
 require 'net/http'
-require 'csv'
 require 'zlib'
 
 require 'google/rpc/status_pb'

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -7,7 +7,6 @@
 require 'opentelemetry/common'
 require 'opentelemetry/sdk'
 require 'net/http'
-require 'csv'
 require 'zlib'
 
 require 'google/rpc/status_pb'

--- a/exporter/zipkin/opentelemetry-exporter-zipkin.gemspec
+++ b/exporter/zipkin/opentelemetry-exporter-zipkin.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 3.0'
 
+  spec.add_dependency 'csv', '~> 3.1'
   spec.add_dependency 'opentelemetry-api', '~> 1.1'
   spec.add_dependency 'opentelemetry-common', '~> 0.20'
   spec.add_dependency 'opentelemetry-sdk', '~> 1.2'


### PR DESCRIPTION
Loading opentelemetry-exporter-otlp on ruby-3.3 now prints a warning:

    .../lib/opentelemetry/exporter/otlp/exporter.rb:10: warning: csv
    was loaded from the standard library, but will no longer be part
    of the default gems since Ruby 3.4.0. Add csv to your Gemfile or
    gemspec. Also contact author of opentelemetry-exporter-otlp-0.26.1
    to add csv into its gemspec.

This commit fixes that by adding an explicit dependency from opentelemetry-exporter-otlp to the csv gem at version '~> 3.1' (ruby-3.0 bundles csv at 3.1.9).