### PR TITLE
Add kaylareopelle to approvers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd
+* @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @kaylareopelle

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Approvers ([@open-telemetry/ruby-approvers](https://github.com/orgs/open-telemet
 - [Andrew Hayworth](https://github.com/ahayworth), Shopify
 - [Sam Handler](https://github.com/plantfansam), Shopify
 - [Robb Kidd](https://github.com/robbkidd), Honeycomb
+- [Kayla Reopelle](https://github.com/kaylareopelle), New Relic
 
 *Find more about the approver role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver).*
 


### PR DESCRIPTION
@kaylareopelle has made a number of valuable contributions to opentelemetry-ruby and we'd like to promote her to approver. Here is a summary of her work:

- [PRs authored](https://github.com/open-telemetry/opentelemetry-ruby/pulls?q=author%3Akaylareopelle+is%3Apr)
- [PRs commented upon](https://github.com/open-telemetry/opentelemetry-ruby/issues?q=commenter%3Akaylareopelle++)
- [Issues opened](https://github.com/open-telemetry/opentelemetry-ruby/issues?q=is%3Aissue+author%3Akaylareopelle+)
- [Issues commented upon](https://github.com/open-telemetry/opentelemetry-ruby/issues?q=is%3Aissue+commenter%3Akaylareopelle+)