### PR TITLE
Consider OTLP export failures handleable errors

### DIFF
--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -223,7 +223,7 @@ module OpenTelemetry
             klass_or_nil = ::Google::Protobuf::DescriptorPool.generated_pool.lookup(detail.type_name).msgclass
             detail.unpack(klass_or_nil) if klass_or_nil
           end.compact
-          OpenTelemetry.handle_error(message: "OTLP exporter received rpc.Status{message=#{status.message}, details=#{details}} from #{@uri}")
+          OpenTelemetry.handle_error(message: "OTLP exporter received rpc.Status{message=#{status.message}, details=#{details}} for uri=#{@uri}")
         rescue StandardError => e
           OpenTelemetry.handle_error(exception: e, message: 'unexpected error decoding rpc.Status in OTLP::Exporter#log_status')
         end

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -179,7 +179,7 @@ module OpenTelemetry
               redo if backoff?(retry_after: 0, retry_count: retry_count += 1, reason: response.code)
             else
               @http.finish
-              OpenTelemetry.handle_error(message: "OTLP exporter received http.code=#{response_code} for uri='#{@uri}' in OTLP::Exporter#send_bytes")
+              OpenTelemetry.handle_error(message: "OTLP exporter received http.code=#{response.code} for uri='#{@uri}' in OTLP::Exporter#send_bytes")
               @metrics_reporter.add_to_counter('otel.otlp_exporter.failure', labels: { 'reason' => 'unexpected_response', 'response_code' => response.code })
               FAILURE
             end

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -228,9 +228,9 @@ module OpenTelemetry
           OpenTelemetry.handle_error(exception: e, message: 'unexpected error decoding rpc.Status in OTLP::Exporter#log_status')
         end
 
-        def log_request_failure(response_code, labels = {})
+        def log_request_failure(response_code)
           OpenTelemetry.handle_error(message: "OTLP exporter received http.code=#{response_code} for uri='#{@uri}' in OTLP::Exporter#send_bytes")
-          @metrics_reporter.add_to_counter('otel.otlp_exporter.failure', labels: { 'reason' => response_code }.merge(labels))
+          @metrics_reporter.add_to_counter('otel.otlp_exporter.failure', labels: { 'reason' => response_code })
         end
 
         def measure_request_duration

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -179,8 +179,7 @@ module OpenTelemetry
               redo if backoff?(retry_after: 0, retry_count: retry_count += 1, reason: response.code)
             else
               @http.finish
-              OpenTelemetry.handle_error(message: "OTLP exporter received http.code=#{response.code} for uri='#{@uri}' in OTLP::Exporter#send_bytes")
-              @metrics_reporter.add_to_counter('otel.otlp_exporter.failure', labels: { 'reason' => 'unexpected_response', 'response_code' => response.code })
+              log_request_failure(response.code)
               FAILURE
             end
           rescue Net::OpenTimeout, Net::ReadTimeout

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -179,7 +179,8 @@ module OpenTelemetry
               redo if backoff?(retry_after: 0, retry_count: retry_count += 1, reason: response.code)
             else
               @http.finish
-              log_request_failure(response.code, 'reason': 'unexpected_response')
+              OpenTelemetry.handle_error(message: "OTLP exporter received http.code=#{response_code} for uri='#{@uri}' in OTLP::Exporter#send_bytes")
+              @metrics_reporter.add_to_counter('otel.otlp_exporter.failure', labels: { 'reason' => 'unexpected_response', 'response_code' => response.code })
               FAILURE
             end
           rescue Net::OpenTimeout, Net::ReadTimeout

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -247,7 +247,7 @@ module OpenTelemetry
         end
 
         def backoff?(retry_count:, reason:, retry_after: nil) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
-          log_request_failure(response_code)
+          log_request_failure(reason)
           return false if retry_count > RETRY_COUNT
 
           sleep_interval = nil

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -61,7 +61,6 @@ module OpenTelemetry
           @http = http_connection(@uri, ssl_verify_mode, certificate_file)
 
           @path = @uri.path
-          @uri_string = @uri.to_s
           @headers = prepare_headers(headers)
           @timeout = timeout.to_f
           @compression = compression

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -231,7 +231,7 @@ module OpenTelemetry
         end
 
         def log_request_failure(response_code, labels = {})
-          OpenTelemetry.handle_error(message: "OTLP exporter received http.code=#{response_code} for uri: '#{@uri_string}' in OTLP::Exporter#send_bytes")
+          OpenTelemetry.handle_error(message: "OTLP exporter received http.code=#{response_code} for uri='#{@uri}' in OTLP::Exporter#send_bytes")
           @metrics_reporter.add_to_counter('otel.otlp_exporter.failure', labels: { 'reason' => response_code }.merge(labels))
         end
 

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -225,7 +225,7 @@ module OpenTelemetry
             klass_or_nil = ::Google::Protobuf::DescriptorPool.generated_pool.lookup(detail.type_name).msgclass
             detail.unpack(klass_or_nil) if klass_or_nil
           end.compact
-          OpenTelemetry.handle_error(message: "OTLP exporter received rpc.Status{message=#{status.message}, details=#{details}}, uri #{@uri_string}")
+          OpenTelemetry.handle_error(message: "OTLP exporter received rpc.Status{message=#{status.message}, details=#{details}} from #{@uri}")
         rescue StandardError => e
           OpenTelemetry.handle_error(exception: e, message: 'unexpected error decoding rpc.Status in OTLP::Exporter#log_status')
         end

--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -524,7 +524,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       result = exporter.export([span_data])
 
       _(log_stream.string).must_match(
-        %r{ERROR -- : OpenTelemetry error: OTLP exporter received http\.code=404 for uri: 'http://localhost:4318/v1/traces'}
+        %r{ERROR -- : OpenTelemetry error: OTLP exporter received http\.code=404 for uri='http://localhost:4318/v1/traces'}
       )
 
       _(result).must_equal(FAILURE)

--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -524,7 +524,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       result = exporter.export([span_data])
 
       _(log_stream.string).must_match(
-        %r{ERROR -- : OpenTelemetry error: OTLP exporter received http\.code=404 for uri: '/v1/traces'}
+        %r{ERROR -- : OpenTelemetry error: OTLP exporter received http\.code=404 for uri: 'http://localhost:4318/v1/traces'}
       )
 
       _(result).must_equal(FAILURE)


### PR DESCRIPTION
This PR attempts to address https://github.com/open-telemetry/opentelemetry-ruby/issues/1160.

The general idea is that:

- we can consider OTLP exporter failures to be errors worthy of handling once retries have been exhausted
- we should let the `handle_error` method decide whether or not these particular failures are important
- the uri is useful information in these failures

Not everyone has a metrics reporter installed, so some log-level visibility might be desirable.

Alternatively, we could `OpenTelemetry::Logger.warn` (or `.debug` or `info` whatever) in these scenarios. I'm happy with that outcome too. Or whatever other great ideas folks may have 😄.
 