### PR TITLE
Add context to metrics reporting of buffer-full events

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -82,7 +82,7 @@ module OpenTelemetry
               n = spans.size + 1 - max_queue_size
               if n.positive?
                 spans.shift(n)
-                report_dropped_spans(n, reason: 'buffer-full', function: 'on_finish')
+                report_dropped_spans(n, reason: 'buffer-full', function: __method__)
               end
               spans << span
               @condition.signal if spans.size > batch_size
@@ -205,7 +205,7 @@ module OpenTelemetry
           end
 
           def report_dropped_spans(count, reason:, function: nil)
-            @metrics_reporter.add_to_counter('otel.bsp.dropped_spans', increment: count, labels: { 'reason' => reason, OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION => function }.compact)
+            @metrics_reporter.add_to_counter('otel.bsp.dropped_spans', increment: count, labels: { 'reason' => reason, OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION => __method__ }.compact)
           end
 
           def fetch_batch

--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -147,7 +147,7 @@ module OpenTelemetry
             thread&.join(timeout)
             force_flush(timeout: OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time))
             dropped_spans = lock { spans.shift(spans.length) }
-            report_dropped_spans(dropped_spans, reason: 'terminating') if dropped_spans.positive?
+            report_dropped_spans(dropped_spans, reason: 'terminating') if dropped_spans.any?
             @exporter.shutdown(timeout: OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time))
           end
 

--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -123,7 +123,7 @@ module OpenTelemetry
               n = spans.size + snapshot.size - max_queue_size
               if n.positive?
                 snapshot.shift(n)
-                report_dropped_spans(n, reason: 'buffer-full', function: 'force_flush')
+                report_dropped_spans(n, reason: 'buffer-full', function: __method__)
               end
               spans.unshift(snapshot) unless snapshot.empty?
               @condition.signal if spans.size > max_queue_size / 2
@@ -205,7 +205,7 @@ module OpenTelemetry
           end
 
           def report_dropped_spans(count, reason:, function: nil)
-            @metrics_reporter.add_to_counter('otel.bsp.dropped_spans', increment: count, labels: { 'reason' => reason, OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION => __method__ }.compact)
+            @metrics_reporter.add_to_counter('otel.bsp.dropped_spans', increment: count, labels: { 'reason' => reason, OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION => function }.compact)
           end
 
           def fetch_batch

--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -123,7 +123,7 @@ module OpenTelemetry
               n = spans.size + snapshot.size - max_queue_size
               if n.positive?
                 snapshot.shift(n)
-                report_dropped_spans(n, reason: 'buffer-full', context: "force_flush")
+                report_dropped_spans(n, reason: 'buffer-full', context: 'force_flush')
               end
               spans.unshift(snapshot) unless snapshot.empty?
               @condition.signal if spans.size > max_queue_size / 2

--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -82,7 +82,7 @@ module OpenTelemetry
               n = spans.size + 1 - max_queue_size
               if n.positive?
                 spans.shift(n)
-                report_dropped_spans(n, reason: 'buffer-full', function: __method__)
+                report_dropped_spans(n, reason: 'buffer-full', function: __method__.to_s)
               end
               spans << span
               @condition.signal if spans.size > batch_size
@@ -123,7 +123,7 @@ module OpenTelemetry
               n = spans.size + snapshot.size - max_queue_size
               if n.positive?
                 snapshot.shift(n)
-                report_dropped_spans(n, reason: 'buffer-full', function: __method__)
+                report_dropped_spans(n, reason: 'buffer-full', function: __method__.to_s)
               end
               spans.unshift(snapshot) unless snapshot.empty?
               @condition.signal if spans.size > max_queue_size / 2

--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -82,7 +82,7 @@ module OpenTelemetry
               n = spans.size + 1 - max_queue_size
               if n.positive?
                 spans.shift(n)
-                report_dropped_spans(n, reason => 'buffer-full', OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION => 'on_finish')
+                report_dropped_spans(n, reason: 'buffer-full', function: 'on_finish')
               end
               spans << span
               @condition.signal if spans.size > batch_size
@@ -123,7 +123,7 @@ module OpenTelemetry
               n = spans.size + snapshot.size - max_queue_size
               if n.positive?
                 snapshot.shift(n)
-                report_dropped_spans(n, reason => 'buffer-full', OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION => 'force_flush')
+                report_dropped_spans(n, reason: 'buffer-full', function: 'force_flush')
               end
               spans.unshift(snapshot) unless snapshot.empty?
               @condition.signal if spans.size > max_queue_size / 2
@@ -204,8 +204,8 @@ module OpenTelemetry
             end
           end
 
-          def report_dropped_spans(count, labels = {})
-            @metrics_reporter.add_to_counter('otel.bsp.dropped_spans', increment: count, labels: labels)
+          def report_dropped_spans(count, reason:, function: nil)
+            @metrics_reporter.add_to_counter('otel.bsp.dropped_spans', increment: count, labels: { 'reason' => reason, OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION => function }.compact )
           end
 
           def fetch_batch

--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -81,8 +81,8 @@ module OpenTelemetry
               reset_on_fork
               n = spans.size + 1 - max_queue_size
               if n.positive?
-                spans.shift(n)
-                report_dropped_spans(n, reason: 'buffer-full', function: __method__.to_s)
+                dropped_spans = spans.shift(n)
+                report_dropped_spans(dropped_spans, reason: 'buffer-full', function: __method__.to_s)
               end
               spans << span
               @condition.signal if spans.size > batch_size
@@ -122,8 +122,8 @@ module OpenTelemetry
             lock do
               n = spans.size + snapshot.size - max_queue_size
               if n.positive?
-                snapshot.shift(n)
-                report_dropped_spans(n, reason: 'buffer-full', function: __method__.to_s)
+                dropped_spans = snapshot.shift(n)
+                report_dropped_spans(dropped_spans, reason: 'buffer-full', function: __method__.to_s)
               end
               spans.unshift(snapshot) unless snapshot.empty?
               @condition.signal if spans.size > max_queue_size / 2
@@ -146,7 +146,7 @@ module OpenTelemetry
 
             thread&.join(timeout)
             force_flush(timeout: OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time))
-            dropped_spans = lock { spans.size }
+            dropped_spans = lock { spans.shift(spans.length) }
             report_dropped_spans(dropped_spans, reason: 'terminating') if dropped_spans.positive?
             @exporter.shutdown(timeout: OpenTelemetry::Common::Utilities.maybe_timeout(timeout, start_time))
           end
@@ -200,12 +200,12 @@ module OpenTelemetry
             else
               OpenTelemetry.handle_error(exception: ExportError.new("Unable to export #{batch.size} spans"))
               @metrics_reporter.add_to_counter('otel.bsp.export.failure')
-              report_dropped_spans(batch.size, reason: 'export-failure')
+              report_dropped_spans(batch, reason: 'export-failure')
             end
           end
 
-          def report_dropped_spans(count, reason:, function: nil)
-            @metrics_reporter.add_to_counter('otel.bsp.dropped_spans', increment: count, labels: { 'reason' => reason, OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION => function }.compact)
+          def report_dropped_spans(dropped_spans, reason:, function: nil)
+            @metrics_reporter.add_to_counter('otel.bsp.dropped_spans', increment: dropped_spans.size, labels: { 'reason' => reason, OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION => function }.compact)
           end
 
           def fetch_batch

--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -82,7 +82,7 @@ module OpenTelemetry
               n = spans.size + 1 - max_queue_size
               if n.positive?
                 spans.shift(n)
-                report_dropped_spans(n, reason: 'buffer-full', context: 'on_finish')
+                report_dropped_spans(n, reason => 'buffer-full', OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION => 'on_finish')
               end
               spans << span
               @condition.signal if spans.size > batch_size
@@ -123,7 +123,7 @@ module OpenTelemetry
               n = spans.size + snapshot.size - max_queue_size
               if n.positive?
                 snapshot.shift(n)
-                report_dropped_spans(n, reason: 'buffer-full', context: 'force_flush')
+                report_dropped_spans(n, reason => 'buffer-full', OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION => 'force_flush')
               end
               spans.unshift(snapshot) unless snapshot.empty?
               @condition.signal if spans.size > max_queue_size / 2
@@ -204,8 +204,8 @@ module OpenTelemetry
             end
           end
 
-          def report_dropped_spans(count, reason:)
-            @metrics_reporter.add_to_counter('otel.bsp.dropped_spans', increment: count, labels: { 'reason' => reason })
+          def report_dropped_spans(count, labels = {})
+            @metrics_reporter.add_to_counter('otel.bsp.dropped_spans', increment: count, labels: labels)
           end
 
           def fetch_batch

--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -82,7 +82,7 @@ module OpenTelemetry
               n = spans.size + 1 - max_queue_size
               if n.positive?
                 spans.shift(n)
-                report_dropped_spans(n, reason: 'buffer-full')
+                report_dropped_spans(n, reason: 'buffer-full', context: 'on_finish')
               end
               spans << span
               @condition.signal if spans.size > batch_size
@@ -123,7 +123,7 @@ module OpenTelemetry
               n = spans.size + snapshot.size - max_queue_size
               if n.positive?
                 snapshot.shift(n)
-                report_dropped_spans(n, reason: 'buffer-full')
+                report_dropped_spans(n, reason: 'buffer-full', context: "force_flush")
               end
               spans.unshift(snapshot) unless snapshot.empty?
               @condition.signal if spans.size > max_queue_size / 2

--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -205,7 +205,7 @@ module OpenTelemetry
           end
 
           def report_dropped_spans(count, reason:, function: nil)
-            @metrics_reporter.add_to_counter('otel.bsp.dropped_spans', increment: count, labels: { 'reason' => reason, OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION => function }.compact )
+            @metrics_reporter.add_to_counter('otel.bsp.dropped_spans', increment: count, labels: { 'reason' => reason, OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION => function }.compact)
           end
 
           def fetch_batch

--- a/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
@@ -222,7 +222,7 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
       _(test_exporter.failed_batches.size).must_equal(0)
       _(test_exporter.batches.size).must_equal(0)
 
-      _(bsp.instance_variable_get(:@spans).size).must_equal(1)
+      _(bsp.instance_variable_get(:@spans).size).must_equal(0)
     end
 
     it 'works if the thread is not running' do


### PR DESCRIPTION
We report `buffer-full` dropped spans in two contexts: `on_finish` and `force_flush`. Since `force_flush` is used in specific contexts, I thought it would be useful to supply a label so that users can have visibility into that.

We could alternatively use the `reason` to disambiguate the two scenarios, rather than introducing a new tag.