### PR TITLE
fix: require csv for ruby-3.4 compatibility in opentelemetry-exporter-zipkin

### DIFF
--- a/exporter/zipkin/opentelemetry-exporter-zipkin.gemspec
+++ b/exporter/zipkin/opentelemetry-exporter-zipkin.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 3.0'
 
+  spec.add_dependency 'csv' # No longer a built-in library from Ruby 3.4. Ruby 3.3 emits deprecation warnings if this dependency is not declared.
   spec.add_dependency 'opentelemetry-api', '~> 1.1'
   spec.add_dependency 'opentelemetry-common', '~> 0.20'
   spec.add_dependency 'opentelemetry-sdk', '~> 1.2'


### PR DESCRIPTION
Fixes #1563 by adding the required runtime dependency.
