### PR TITLE
log spanz

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -123,7 +123,7 @@ module OpenTelemetry
               n = spans.size + snapshot.size - max_queue_size
               if n.positive?
                 snapshot.shift(n)
-                report_dropped_spans(n, reason: 'buffer-full', context: "force_flush")
+                report_dropped_spans(n, reason: 'buffer-full', context: 'force_flush')
               end
               spans.unshift(snapshot) unless snapshot.empty?
               @condition.signal if spans.size > max_queue_size / 2

--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -82,7 +82,7 @@ module OpenTelemetry
               n = spans.size + 1 - max_queue_size
               if n.positive?
                 spans.shift(n)
-                report_dropped_spans(n, reason => 'buffer-full', OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION => 'on_finish')
+                report_dropped_spans(n, reason: 'buffer-full', function: 'on_finish')
               end
               spans << span
               @condition.signal if spans.size > batch_size
@@ -123,7 +123,7 @@ module OpenTelemetry
               n = spans.size + snapshot.size - max_queue_size
               if n.positive?
                 snapshot.shift(n)
-                report_dropped_spans(n, reason => 'buffer-full', OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION => 'force_flush')
+                report_dropped_spans(n, reason: 'buffer-full', function: 'force_flush')
               end
               spans.unshift(snapshot) unless snapshot.empty?
               @condition.signal if spans.size > max_queue_size / 2
@@ -204,8 +204,8 @@ module OpenTelemetry
             end
           end
 
-          def report_dropped_spans(count, labels = {})
-            @metrics_reporter.add_to_counter('otel.bsp.dropped_spans', increment: count, labels: labels)
+          def report_dropped_spans(count, reason:, function: nil)
+            @metrics_reporter.add_to_counter('otel.bsp.dropped_spans', increment: count, labels: { 'reason' => reason, OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION => function }.compact )
           end
 
           def fetch_batch

--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -82,7 +82,7 @@ module OpenTelemetry
               n = spans.size + 1 - max_queue_size
               if n.positive?
                 spans.shift(n)
-                report_dropped_spans(n, reason: 'buffer-full', context: 'on_finish')
+                report_dropped_spans(n, reason => 'buffer-full', OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION => 'on_finish')
               end
               spans << span
               @condition.signal if spans.size > batch_size
@@ -123,7 +123,7 @@ module OpenTelemetry
               n = spans.size + snapshot.size - max_queue_size
               if n.positive?
                 snapshot.shift(n)
-                report_dropped_spans(n, reason: 'buffer-full', context: 'force_flush')
+                report_dropped_spans(n, reason => 'buffer-full', OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION => 'force_flush')
               end
               spans.unshift(snapshot) unless snapshot.empty?
               @condition.signal if spans.size > max_queue_size / 2
@@ -204,8 +204,8 @@ module OpenTelemetry
             end
           end
 
-          def report_dropped_spans(count, reason:)
-            @metrics_reporter.add_to_counter('otel.bsp.dropped_spans', increment: count, labels: { 'reason' => reason })
+          def report_dropped_spans(count, labels = {})
+            @metrics_reporter.add_to_counter('otel.bsp.dropped_spans', increment: count, labels: labels)
           end
 
           def fetch_batch

--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -82,7 +82,7 @@ module OpenTelemetry
               n = spans.size + 1 - max_queue_size
               if n.positive?
                 spans.shift(n)
-                report_dropped_spans(n, reason: 'buffer-full')
+                report_dropped_spans(n, reason: 'buffer-full', context: 'on_finish')
               end
               spans << span
               @condition.signal if spans.size > batch_size
@@ -123,7 +123,7 @@ module OpenTelemetry
               n = spans.size + snapshot.size - max_queue_size
               if n.positive?
                 snapshot.shift(n)
-                report_dropped_spans(n, reason: 'buffer-full')
+                report_dropped_spans(n, reason: 'buffer-full', context: "force_flush")
               end
               spans.unshift(snapshot) unless snapshot.empty?
               @condition.signal if spans.size > max_queue_size / 2

--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -205,7 +205,7 @@ module OpenTelemetry
           end
 
           def report_dropped_spans(count, reason:, function: nil)
-            @metrics_reporter.add_to_counter('otel.bsp.dropped_spans', increment: count, labels: { 'reason' => reason, OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION => function }.compact )
+            @metrics_reporter.add_to_counter('otel.bsp.dropped_spans', increment: count, labels: { 'reason' => reason, OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION => function }.compact)
           end
 
           def fetch_batch


### PR DESCRIPTION
- add context to metrics reporting of buffer-full events
- Update sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
- Use semantic convention for code function label
- Kwargs are better; use kwargs
- stray paren
- maybe this
