### PR TITLE
fix: update ruby version to 3 and alpine to 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Configuration for Ruby base image
-ARG ALPINE_VERSION=3.10
-ARG RUBY_VERSION=2.6.5
+ARG ALPINE_VERSION=3.13
+ARG RUBY_VERSION=3.0.0
 
 FROM ruby:"${RUBY_VERSION}-alpine${ALPINE_VERSION}" as ruby
 


### PR DESCRIPTION
## Description

Current Dockerfile for building the docker container is 2.6.5-alpine3.10, which doesn't comply the requirement of new opentelemetry component that require ruby > 3.0.0. New contributor probably will have the issue of building the docker image if they run `docker compose run app`. 
```
$ docker compose run app
 > [app 3/6] RUN gem update --system &&     gem install "bundler:2.0.2" &&     gem cleanup:                          
18.00 ERROR:  Error installing rubygems-update:                                                                      
18.00 	There are no versions of rubygems-update (= 3.5.5) compatible with your Ruby & RubyGems
18.00 	rubygems-update requires Ruby version >= 3.0.0. The current ruby version is 2.6.5.114.
18.00 ERROR:  While executing gem ... (NoMethodError)
18.00     undefined method `version' for nil:NilClass
18.02 Updating rubygems-update
```
Proposing to change alpine version to 3.13 and ruby 3.0.0 (the first alpine image with ruby >= 3.0.0), unless there is other consideration on alpine version and/or ruby version.


Related to https://github.com/open-telemetry/opentelemetry-ruby/issues/1526