### PR TITLE
Re-add spans to bsp @spans using splat operator

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -125,7 +125,7 @@ module OpenTelemetry
                 dropped_spans = snapshot.shift(n)
                 report_dropped_spans(dropped_spans, reason: 'buffer-full', function: __method__.to_s)
               end
-              spans.unshift(snapshot) unless snapshot.empty?
+              spans.unshift(*snapshot) unless snapshot.empty?
               @condition.signal if spans.size > max_queue_size / 2
             end
           end

--- a/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
@@ -201,6 +201,7 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
       test_exporter = TestExporter.new
       bsp = BatchSpanProcessor.new(test_exporter)
       bsp.on_finish(TestSpan.new)
+      bsp.on_finish(TestSpan.new)
       result = bsp.force_flush(timeout: 0)
 
       _(result).must_equal(TIMEOUT)
@@ -208,7 +209,7 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
       _(test_exporter.failed_batches.size).must_equal(0)
       _(test_exporter.batches.size).must_equal(0)
 
-      _(bsp.instance_variable_get(:@spans).size).must_equal(1)
+      _(bsp.instance_variable_get(:@spans).size).must_equal(2)
     end
   end
 


### PR DESCRIPTION
When we requeue spans for export after a timeout, we can inadvertently create a nested array in `@spans`. I believe that this behavior is unintentional, but I could be wrong.

An IRB session that sorta explains what I mean:

```irb
irb(main):001:0> x = [1,2]
=> [1, 2]
irb(main):002:0> x.unshift(*[3,4])
=> [3, 4, 1, 2]
irb(main):003:0> x.unshift([5,6])
=> [[5, 6], 3, 4, 1, 2]


```

