### PR TITLE
chore: Replace positive? with comparison operator

### DIFF
--- a/sdk/.rubocop.yml
+++ b/sdk/.rubocop.yml
@@ -20,3 +20,5 @@ Style/ExplicitBlockArgument:
   Enabled: false
 Style/ModuleFunction:
   Enabled: false
+Style/NumericPredicate:
+  Enabled: false

--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -80,7 +80,7 @@ module OpenTelemetry
             lock do
               reset_on_fork
               n = spans.size + 1 - max_queue_size
-              if n.positive?
+              if n > 0
                 dropped_spans = spans.shift(n)
                 report_dropped_spans(dropped_spans, reason: 'buffer-full', function: __method__.to_s)
               end


### PR DESCRIPTION
Opentelemetry is utilized across numerous projects, and even minor performance variations can have a significant impact.
It's worth noting that the default rubocop style may not have been specifically crafted with performance considerations in mind.

According to benchmarks on my machine M1, it appears that `Numeric#positive?` is approximately 1.32 times slower than using the comparison operator (`number > 0`).

[benchmark script](https://codeberg.org/miry/samples/src/commit/7b250c2df1cc41cc588ff6ff5d2fd7765ffaddcb/ruby/positive.rb)
```
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) +YJIT [arm64-darwin23]
Warming up --------------------------------------
      compare with 0     1.000 i/100ms
           positive?     1.000 i/100ms
Calculating -------------------------------------
      compare with 0      3.153 (± 0.0%) i/s -     95.000 in  30.132600s
           positive?      2.397 (± 0.0%) i/s -     72.000 in  30.042688s

Comparison:
      compare with 0:        3.2 i/s
           positive?:        2.4 i/s - 1.32x  slower
```

The change disables Style/NumericPredicate for rubocop as well for sdk.

Propose to change for sdk gem in `BatchSpanProcessor`.
The number suppose not be a `nil` or BigNumber.

## References

* https://github.com/rubocop/rubocop/issues/5564#issuecomment-364748618
* https://github.com/autolist/autocop/pull/33
* https://rubyapi.org/3.3/o/numeric#method-i-positive-3F