### PR TITLE
don't log failure from backoff?

### DIFF
--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -245,7 +245,7 @@ module OpenTelemetry
         end
 
         def backoff?(retry_count:, reason:, retry_after: nil) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
-          log_request_failure(reason)
+          @metrics_reporter.add_to_counter('otel.otlp_exporter.failure', labels: { 'reason' => reason })
           return false if retry_count > RETRY_COUNT
 
           sleep_interval = nil


### PR DESCRIPTION
Follow-on to https://github.com/open-telemetry/opentelemetry-ruby/pull/1565/files

`backoff?` is called to see if we should retry; we should not be logging a failure from here.

This PR reverts the error reporting of `backoff?` to it's pre-#1165 state.