### PR TITLE
chore: Pin toys and toys release scripts to a known good version

### DIFF
--- a/.github/workflows/release-hook-on-closed.yml
+++ b/.github/workflows/release-hook-on-closed.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Install Toys
-        run: "gem install --no-document toys"
+        run: "gem install --no-document toys -v 0.15.5"
       - name: Process release request
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-hook-on-push.yml
+++ b/.github/workflows/release-hook-on-push.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Install Toys
-        run: "gem install --no-document toys"
+        run: "gem install --no-document toys -v 0.15.5"
       - name: Update open releases
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-perform.yml
+++ b/.github/workflows/release-perform.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Install Toys
-        run: "gem install --no-document toys"
+        run: "gem install --no-document toys -v 0.15.5"
       - name: Perform release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-request.yml
+++ b/.github/workflows/release-request.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Install Toys
-        run: "gem install --no-document toys"
+        run: "gem install --no-document toys -v 0.15.5"
       - name: Open release pull request
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-retry.yml
+++ b/.github/workflows/release-retry.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Install Toys
-        run: "gem install --no-document toys"
+        run: "gem install --no-document toys -v 0.15.5"
       - name: Retry release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.toys/.toys.rb
+++ b/.toys/.toys.rb
@@ -1,6 +1,7 @@
-toys_version! ">= 0.14.5"
+toys_version! ">= 0.15.5"
 
 load_git remote: "https://github.com/dazuma/toys.git",
          path: ".toys/release",
          as: "release",
+         commit: "common-tools/v0.15.5.1",
          update: 3600


### PR DESCRIPTION
Protects the release process from unexpected changes upstream by pinning the tools. These versions can be updated explicitly if we need future upstream updates.