### PR TITLE
Experiment: Linked list for Context

### DIFF
--- a/api/benchmarks/context_bench.rb
+++ b/api/benchmarks/context_bench.rb
@@ -1,0 +1,269 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'benchmark/ipsa'
+
+class LinkedListContext
+  EMPTY_ENTRIES = {}.freeze
+  STACK_KEY = :__linked_list_context_storage__
+
+  class Token
+    attr_reader :context, :next_token
+    def initialize(context, next_token)
+      @context = context
+      @next_token = next_token
+    end
+  end
+
+  private_constant :EMPTY_ENTRIES, :STACK_KEY, :Token
+
+  DetachError = Class.new(StandardError)
+
+  class << self
+    def current
+      Thread.current[STACK_KEY]&.context || ROOT
+    end
+
+    def attach(context)
+      next_token = Thread.current[STACK_KEY]
+      token = Token.new(context, next_token)
+      Thread.current[STACK_KEY] = token
+      token
+    end
+
+    def detach(token)
+      current = Thread.current[STACK_KEY]
+      calls_matched = (token == current)
+      OpenTelemetry.handle_error(exception: DetachError.new('calls to detach should match corresponding calls to attach.')) unless calls_matched
+
+      Thread.current[STACK_KEY] = current&.next_token
+      calls_matched
+    end
+
+    def with_current(ctx)
+      token = attach(ctx)
+      yield ctx
+    ensure
+      detach(token)
+    end
+
+    def with_value(key, value)
+      ctx = current.set_value(key, value)
+      token = attach(ctx)
+      yield ctx, value
+    ensure
+      detach(token)
+    end
+
+    def with_values(values)
+      ctx = current.set_values(values)
+      token = attach(ctx)
+      yield ctx, values
+    ensure
+      detach(token)
+    end
+    def value(key)
+      current.value(key)
+    end
+
+    def clear
+      Thread.current[STACK_KEY] = nil
+    end
+
+    def empty
+      new(EMPTY_ENTRIES)
+    end
+  end
+
+  def initialize(entries)
+    @entries = entries.freeze
+  end
+
+  def value(key)
+    @entries[key]
+  end
+
+  alias [] value
+
+  def set_value(key, value)
+    new_entries = @entries.dup
+    new_entries[key] = value
+    LinkedListContext.new(new_entries)
+  end
+
+  def set_values(values) # rubocop:disable Naming/AccessorMethodName:
+    LinkedListContext.new(@entries.merge(values))
+  end
+
+  ROOT = empty.freeze
+end
+
+class ArrayContext
+  EMPTY_ENTRIES = {}.freeze
+  STACK_KEY = :__array_context_storage__
+  private_constant :EMPTY_ENTRIES, :STACK_KEY
+
+  DetachError = Class.new(StandardError)
+
+  class << self
+    def current
+      stack.last || ROOT
+    end
+
+    def attach(context)
+      s = stack
+      s.push(context)
+      s.size
+    end
+
+    def detach(token)
+      s = stack
+      calls_matched = (token == s.size)
+      OpenTelemetry.handle_error(exception: DetachError.new('calls to detach should match corresponding calls to attach.')) unless calls_matched
+
+      s.pop
+      calls_matched
+    end
+
+    def with_current(ctx)
+      token = attach(ctx)
+      yield ctx
+    ensure
+      detach(token)
+    end
+
+    def with_value(key, value)
+      ctx = current.set_value(key, value)
+      token = attach(ctx)
+      yield ctx, value
+    ensure
+      detach(token)
+    end
+
+    def with_values(values)
+      ctx = current.set_values(values)
+      token = attach(ctx)
+      yield ctx, values
+    ensure
+      detach(token)
+    end
+
+    def value(key)
+      current.value(key)
+    end
+
+    def clear
+      stack.clear
+    end
+
+    def empty
+      new(EMPTY_ENTRIES)
+    end
+
+    private
+
+    def stack
+      Thread.current[STACK_KEY] ||= []
+    end
+  end
+
+  def initialize(entries)
+    @entries = entries.freeze
+  end
+
+  def value(key)
+    @entries[key]
+  end
+
+  alias [] value
+
+  def set_value(key, value)
+    new_entries = @entries.dup
+    new_entries[key] = value
+    ArrayContext.new(new_entries)
+  end
+
+  def set_values(values) # rubocop:disable Naming/AccessorMethodName:
+    ArrayContext.new(@entries.merge(values))
+  end
+
+  ROOT = empty.freeze
+end
+
+values = { 'key' => 'value' }
+context = LinkedListContext.empty.set_values(values)
+
+Benchmark.ipsa do |x|
+  x.report 'linked list with_value' do
+    LinkedListContext.with_value('key', 'value') { |ctx, value| ctx }
+  end
+
+  x.report 'array with_value' do
+    ArrayContext.with_value('key', 'value') { |ctx, value| ctx }
+  end
+
+  x.compare!
+end
+
+Benchmark.ipsa do |x|
+  x.report 'linked list with_values' do
+    LinkedListContext.with_values(values) { |ctx, values| ctx }
+  end
+
+  x.report 'array with_values' do
+    ArrayContext.with_values(values) { |ctx, values| ctx }
+  end
+
+  x.compare!
+end
+
+Benchmark.ipsa do |x|
+  x.report 'linked list with_value recursive' do
+    LinkedListContext.with_value('key', 'value') do
+      LinkedListContext.with_value('key', 'value') do
+        LinkedListContext.with_value('key', 'value') do
+          LinkedListContext.with_value('key', 'value') do
+            LinkedListContext.with_value('key', 'value') do
+              LinkedListContext.with_value('key', 'value') do
+                LinkedListContext.with_value('key', 'value') do
+                  LinkedListContext.with_value('key', 'value') do
+                    LinkedListContext.with_value('key', 'value') do
+                      LinkedListContext.with_value('key', 'value') do |ctx, value| ctx end
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  x.report 'array with_value recursive' do
+    ArrayContext.with_value('key', 'value') do
+      ArrayContext.with_value('key', 'value') do
+        ArrayContext.with_value('key', 'value') do
+          ArrayContext.with_value('key', 'value') do
+            ArrayContext.with_value('key', 'value') do
+              ArrayContext.with_value('key', 'value') do
+                ArrayContext.with_value('key', 'value') do
+                  ArrayContext.with_value('key', 'value') do
+                    ArrayContext.with_value('key', 'value') do
+                      ArrayContext.with_value('key', 'value') do |ctx, value| ctx end
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  x.compare!
+end


### PR DESCRIPTION
```
bogsanyi@franciss-mbp benchmarks % bundle exec ruby context_bench.rb
Allocations -------------------------------------
linked list with_value
                           4/0  alloc/ret        0/0  strings/ret
    array with_value       4/1  alloc/ret        0/0  strings/ret
Warming up --------------------------------------
linked list with_value
                       103.622k i/100ms
    array with_value   109.858k i/100ms
Calculating -------------------------------------
linked list with_value
                          1.336M (± 0.4%) i/s -      6.735M
    array with_value      1.452M (± 0.3%) i/s -      7.360M

Comparison:
    array with_value:  1452403.1 i/s
linked list with_value:  1335513.3 i/s - 1.09x slower

Allocations -------------------------------------
linked list with_values
                           3/3  alloc/ret        0/0  strings/ret
   array with_values       2/0  alloc/ret        0/0  strings/ret
Warming up --------------------------------------
linked list with_values
                       113.765k i/100ms
   array with_values   123.378k i/100ms
Calculating -------------------------------------
linked list with_values
                          1.520M (± 0.6%) i/s -      7.622M
   array with_values      1.634M (± 0.8%) i/s -      8.266M

Comparison:
   array with_values:  1633881.6 i/s
linked list with_values:  1519551.6 i/s - 1.08x slower

Allocations -------------------------------------
linked list with_value recursive
                          30/3  alloc/ret        0/0  strings/ret
array with_value recursive
                          20/0  alloc/ret        0/0  strings/ret
Warming up --------------------------------------
linked list with_value recursive
                        13.911k i/100ms
array with_value recursive
                        15.145k i/100ms
Calculating -------------------------------------
linked list with_value recursive
                        146.918k (± 0.4%) i/s -    737.283k
array with_value recursive
                        156.918k (± 0.7%) i/s -    787.540k

Comparison:
array with_value recursive:   156917.5 i/s
linked list with_value recursive:   146917.6 i/s - 1.07x slower
```

With yjit:
```
bogsanyi@franciss-mbp benchmarks % bundle exec ruby --yjit context_bench.rb
Allocations -------------------------------------
linked list with_value
                           4/0  alloc/ret        0/0  strings/ret
    array with_value       4/1  alloc/ret        0/0  strings/ret
Warming up --------------------------------------
linked list with_value
                       170.330k i/100ms
    array with_value   187.176k i/100ms
Calculating -------------------------------------
linked list with_value
                          2.940M (± 0.4%) i/s -     14.819M
    array with_value      3.470M (± 1.1%) i/s -     17.407M

Comparison:
    array with_value:  3470179.8 i/s
linked list with_value:  2939828.0 i/s - 1.18x slower

Allocations -------------------------------------
linked list with_values
                           3/0  alloc/ret        0/0  strings/ret
   array with_values       2/0  alloc/ret        0/0  strings/ret
Warming up --------------------------------------
linked list with_values
                       185.121k i/100ms
   array with_values   202.576k i/100ms
Calculating -------------------------------------
linked list with_values
                          3.277M (± 1.4%) i/s -     16.476M
   array with_values      4.054M (± 0.9%) i/s -     20.460M

Comparison:
   array with_values:  4054172.0 i/s
linked list with_values:  3276817.5 i/s - 1.24x slower

Allocations -------------------------------------
linked list with_value recursive
                          30/0  alloc/ret        0/0  strings/ret
array with_value recursive
                          20/0  alloc/ret        0/0  strings/ret
Warming up --------------------------------------
linked list with_value recursive
                        25.197k i/100ms
array with_value recursive
                        29.579k i/100ms
Calculating -------------------------------------
linked list with_value recursive
                        271.735k (± 0.6%) i/s -      1.361M
array with_value recursive
                        316.777k (± 0.9%) i/s -      1.597M

Comparison:
array with_value recursive:   316777.4 i/s
linked list with_value recursive:   271735.4 i/s - 1.17x slower
```