### PR TITLE
fix: Replace Context stack on clear

### DIFF
--- a/api/lib/opentelemetry/context.rb
+++ b/api/lib/opentelemetry/context.rb
@@ -113,6 +113,9 @@ module OpenTelemetry
         current.value(key)
       end
 
+      # Clears the fiber-local Context stack. This allocates a new array for the
+      # stack, which is important in some use-cases to avoid sharing the backing
+      # array between fibers.
       def clear
         Thread.current[STACK_KEY] = []
       end

--- a/api/lib/opentelemetry/context.rb
+++ b/api/lib/opentelemetry/context.rb
@@ -114,7 +114,7 @@ module OpenTelemetry
       end
 
       def clear
-        stack.clear
+        Thread.current[STACK_KEY] = []
       end
 
       def empty


### PR DESCRIPTION
As identified in https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/772, Rails copies _all_ thread-local variables in `ActionController::Live`. Our use of an array to back the `Context` stack results in two threads sharing the same stack. `Context.clear` only clears the array, but continues to share it (in fact, its effect is visible to _both_ threads), so there is no way to cleanly separate the thread's `Context` stacks using the public API.

This PR replaces the `stack.clear` call with assignment of a new array to the thread-local. This allows a pattern like:

```ruby
locals = Thread.current.keys.map { |key| [key, t1[key]] }
Thread.new do
  t2 = Thread.current
  locals.each { |k, v| t2[k] = v }
  # Context stack is shared between parent and t2 here.
  # This is racy and requires something like a semaphore to avoid concurrent mutation.
  current_context = OpenTelemetry::Context.current
  OpenTelemetry::Context.clear
  # Context stacks are now independent. Signal semaphore.
  OpenTelemetry::Context.attach(current_context)
  ...
end
```