### PR TITLE
feat: add basic support for metrics exemplar

### DIFF
--- a/metrics_api/lib/opentelemetry/internal/proxy_instrument.rb
+++ b/metrics_api/lib/opentelemetry/internal/proxy_instrument.rb
@@ -8,19 +8,21 @@ module OpenTelemetry
   module Internal
     # @api private
     class ProxyInstrument
-      def initialize(kind, name, unit, desc, callable)
+      def initialize(kind, name, unit, desc, callable, exemplar_filter, exemplar_reservoir)
         @kind = kind
         @name = name
         @unit = unit
         @desc = desc
         @callable = callable
+        @exemplar_filter    = exemplar_filter
+        @exemplar_reservoir = exemplar_reservoir
         @delegate = nil
       end
 
       def upgrade_with(meter)
         @delegate = case @kind
                     when :counter, :histogram, :up_down_counter
-                      meter.send("create_#{@kind}", @name, unit: @unit, description: @desc)
+                      meter.send("create_#{@kind}", @name, unit: @unit, description: @desc, exemplar_filter: @exemplar_filter, exemplar_reservoir: @exemplar_reservoir)
                     when :observable_counter, :observable_gauge, :observable_up_down_counter
                       meter.send("create_#{@kind}", @name, unit: @unit, description: @desc, callback: @callback)
                     end

--- a/metrics_api/lib/opentelemetry/internal/proxy_meter.rb
+++ b/metrics_api/lib/opentelemetry/internal/proxy_meter.rb
@@ -38,14 +38,14 @@ module OpenTelemetry
 
       private
 
-      def create_instrument(kind, name, unit, description, callback)
+      def create_instrument(kind, name, unit, description, callback, exemplar_filter, exemplar_reservoir)
         super do
-          next ProxyInstrument.new(kind, name, unit, description, callback) if @delegate.nil?
+          next ProxyInstrument.new(kind, name, unit, description, callback, exemplar_filter, exemplar_reservoir) if @delegate.nil?
 
           case kind
-          when :counter then @delegate.create_counter(name, unit: unit, description: description)
-          when :histogram then @delegate.create_histogram(name, unit: unit, description: description)
-          when :up_down_counter then @delegate.create_up_down_counter(name, unit: unit, description: description)
+          when :counter then @delegate.create_counter(name, unit: unit, description: description, exemplar_filter: exemplar_filter, exemplar_reservoir: exemplar_reservoir)
+          when :histogram then @delegate.create_histogram(name, unit: unit, description: description, exemplar_filter: exemplar_filter, exemplar_reservoir: exemplar_reservoir)
+          when :up_down_counter then @delegate.create_up_down_counter(name, unit: unit, description: description, exemplar_filter: exemplar_filter, exemplar_reservoir: exemplar_reservoir)
           when :observable_counter then @delegate.create_observable_counter(name, unit: unit, description: description, callback: callback)
           when :observable_gauge then @delegate.create_observable_gauge(name, unit: unit, description: description, callback: callback)
           when :observable_up_down_counter then @delegate.create_observable_up_down_counter(name, unit: unit, description: description, callback: callback)

--- a/metrics_api/lib/opentelemetry/metrics/meter.rb
+++ b/metrics_api/lib/opentelemetry/metrics/meter.rb
@@ -29,16 +29,16 @@ module OpenTelemetry
         @instrument_registry = {}
       end
 
-      def create_counter(name, unit: nil, description: nil)
-        create_instrument(:counter, name, unit, description, nil) { COUNTER }
+      def create_counter(name, unit: nil, description: nil, exemplar_filter: nil, exemplar_reservoir: nil)
+        create_instrument(:counter, name, unit, description, nil, exemplar_filter, exemplar_reservoir) { COUNTER }
       end
 
-      def create_histogram(name, unit: nil, description: nil)
-        create_instrument(:histogram, name, unit, description, nil) { HISTOGRAM }
+      def create_histogram(name, unit: nil, description: nil, exemplar_filter: nil, exemplar_reservoir: nil)
+        create_instrument(:histogram, name, unit, description, nil, exemplar_filter, exemplar_reservoir) { HISTOGRAM }
       end
 
-      def create_up_down_counter(name, unit: nil, description: nil)
-        create_instrument(:up_down_counter, name, unit, description, nil) { UP_DOWN_COUNTER }
+      def create_up_down_counter(name, unit: nil, description: nil, exemplar_filter: nil, exemplar_reservoir: nil)
+        create_instrument(:up_down_counter, name, unit, description, nil, exemplar_filter, exemplar_reservoir) { UP_DOWN_COUNTER }
       end
 
       def create_observable_counter(name, callback:, unit: nil, description: nil)
@@ -55,7 +55,7 @@ module OpenTelemetry
 
       private
 
-      def create_instrument(kind, name, unit, description, callback)
+      def create_instrument(kind, name, unit, description, callback, exemplar_filter, exemplar_reservoir)
         raise InstrumentNameError if name.nil?
         raise InstrumentNameError if name.empty?
         raise InstrumentNameError unless NAME_REGEX.match?(name)

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics.rb
@@ -13,6 +13,7 @@ module OpenTelemetry
   end
 end
 
+require 'opentelemetry/sdk/metrics/exemplar'
 require 'opentelemetry/sdk/metrics/aggregation'
 require 'opentelemetry/sdk/metrics/configuration_patch'
 require 'opentelemetry/sdk/metrics/export'

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/aggregation/sum.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/aggregation/sum.rb
@@ -17,7 +17,7 @@ module OpenTelemetry
           attr_reader :aggregation_temporality
 
           def initialize(aggregation_temporality: ENV.fetch('OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE', :delta),
-                          exemplar_reservoir: DEFAULT_RESERVOIR)
+                         exemplar_reservoir: DEFAULT_RESERVOIR)
             # TODO: the default should be :cumulative, see issue #1555
             @aggregation_temporality = aggregation_temporality
             @data_points = {}
@@ -51,7 +51,7 @@ module OpenTelemetry
               nil,
               nil,
               0,
-              # will this cause the reservoir overloaded with old exemplars? 
+              # will this cause the reservoir overloaded with old exemplars?
               @exemplar_reservoir.collect(attributes: attributes, aggregation_temporality: @aggregation_temporality) # exemplar
             )
 

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Metrics
+      # The Exemplar module contains the OpenTelemetry metrics reference
+      # exemplar implementations.
+      module Exemplar
+      end
+    end
+  end
+end
+
+require 'opentelemetry/sdk/metrics/exemplar/exemplar'
+require 'opentelemetry/sdk/metrics/exemplar/exemplar_filter'
+require 'opentelemetry/sdk/metrics/exemplar/exemplar_reservoir'
+require 'opentelemetry/sdk/metrics/exemplar/always_off_exemplar_filter'
+require 'opentelemetry/sdk/metrics/exemplar/always_on_exemplar_filter'
+require 'opentelemetry/sdk/metrics/exemplar/trace_based_exemplar_filter'
+require 'opentelemetry/sdk/metrics/exemplar/noop_exemplar_reservoir'
+require 'opentelemetry/sdk/metrics/exemplar/fixed_size_exemplar_reservoir'
+require 'opentelemetry/sdk/metrics/exemplar/histogram_exemplar_reservoir'

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/always_off_exemplar_filter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/always_off_exemplar_filter.rb
@@ -8,6 +8,8 @@ module OpenTelemetry
   module SDK
     module Metrics
       module Exemplar
+        # AlwaysOffExemplarFilter makes no measurements eligible for being an Exemplar.
+        # Using this ExemplarFilter is as good as disabling Exemplar feature.
         class AlwaysOffExemplarFilter < ExemplarFilter
           def self.should_sample?(value, timestamp, attributes, context)
             false

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/always_off_exemplar_filter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/always_off_exemplar_filter.rb
@@ -9,7 +9,7 @@ module OpenTelemetry
     module Metrics
       module Exemplar
         class AlwaysOffExemplarFilter < ExemplarFilter
-          def should_sample?(value, timestamp, attributes, context)
+          def self.should_sample?(value, timestamp, attributes, context)
             false
           end
         end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/always_off_exemplar_filter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/always_off_exemplar_filter.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Metrics
+      module Exemplar
+        class AlwaysOffExemplarFilter < ExemplarFilter
+          def should_sample?(value, timestamp, attributes, context)
+            false
+          end
+        end
+      end
+    end
+  end
+end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/always_on_exemplar_filter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/always_on_exemplar_filter.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Metrics
+      module Exemplar
+        class AlwaysOnExemplarFilter < ExemplarFilter
+          def should_sample?(value, timestamp, attributes, context)
+            true
+          end
+        end
+      end
+    end
+  end
+end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/always_on_exemplar_filter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/always_on_exemplar_filter.rb
@@ -9,7 +9,7 @@ module OpenTelemetry
     module Metrics
       module Exemplar
         class AlwaysOnExemplarFilter < ExemplarFilter
-          def should_sample?(value, timestamp, attributes, context)
+          def self.should_sample?(value, timestamp, attributes, context)
             true
           end
         end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/always_on_exemplar_filter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/always_on_exemplar_filter.rb
@@ -8,6 +8,7 @@ module OpenTelemetry
   module SDK
     module Metrics
       module Exemplar
+        # AlwaysOnExemplarFilter
         class AlwaysOnExemplarFilter < ExemplarFilter
           def self.should_sample?(value, timestamp, attributes, context)
             true

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/exemplar.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/exemplar.rb
@@ -9,12 +9,14 @@ module OpenTelemetry
     module Metrics
       module Exemplar
         class Exemplar
-          def initialize(value, time_unix_nano, attributes)
+          attr_reader :value, :time_unix_nano, :attributes, :span_id, :trace_id
+
+          def initialize(value, time_unix_nano, attributes, span_id, trace_id)
             @value = value
             @time_unix_nano = time_unix_nano
             @attributes = attributes
-            @span_id  = nil
-            @trace_id = nil
+            @span_id  = span_id
+            @trace_id = trace_id
           end
         end
       end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/exemplar.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/exemplar.rb
@@ -8,6 +8,7 @@ module OpenTelemetry
   module SDK
     module Metrics
       module Exemplar
+        # Exemplar
         class Exemplar
           attr_reader :value, :time_unix_nano, :attributes, :span_id, :trace_id
 

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/exemplar.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/exemplar.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Metrics
+      module Exemplar
+        class Exemplar
+          def initialize(value, time_unix_nano, attributes)
+            @value = value
+            @time_unix_nano = time_unix_nano
+            @attributes = attributes
+            @span_id  = nil
+            @trace_id = nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/exemplar_filter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/exemplar_filter.rb
@@ -16,7 +16,7 @@ module OpenTelemetry
           # @param [Context] context Context of the measurement, which covers the Baggage and the current active Span.
           #
           # @return [Boolean]
-          def should_sample?(value, attributes, context); end
+          def self.should_sample?(value, attributes, context); end
         end
       end
     end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/exemplar_filter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/exemplar_filter.rb
@@ -8,6 +8,7 @@ module OpenTelemetry
   module SDK
     module Metrics
       module Exemplar
+        # ExemplarFilter
         class ExemplarFilter
           # Returns a {Boolean} value.
           #

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/exemplar_filter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/exemplar_filter.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Metrics
+      module Exemplar
+        class ExemplarFilter
+          # Returns a {Boolean} value.
+          #
+          # @param [Integer] value Value of the measurement
+          # @param [Hash] attributes Complete set of Attributes of the measurement
+          # @param [Context] context Context of the measurement, which covers the Baggage and the current active Span.
+          #
+          # @return [Boolean]
+          def should_sample?(value, attributes, context); end
+        end
+      end
+    end
+  end
+end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/exemplar_reservoir.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/exemplar_reservoir.rb
@@ -9,18 +9,42 @@ module OpenTelemetry
     module Metrics
       module Exemplar
         class ExemplarReservoir
-
-          def initialize(value, timestamp, attributes, context)
-            @value      = value
-            @timestamp  = timestamp
-            @attributes = attributes
-            @context    = context
+          def initialize
+            @exemplars = []
           end
 
-          def offer; end
+          # Store the info into exemplars bucket
+          #
+          # @param [Integer] value Value of the measurement
+          # @param [Integer] timestamp Time of recording
+          # @param [Hash] attributes Complete set of Attributes of the measurement
+          # @param [Context] context SpanContext of the measurement, which covers the Baggage and the current active Span.
+          #
+          # @return [Nil]
+          def offer(value: nil, timestamp: nil, attributes: nil, context: nil)
+            span_context = current_span_context(context)
+            @exemplars << Exemplar.new(value, timestamp, attributes, span_context.hex_span_id, span_context.hex_trace_id)
+            nil
+          end
 
-          # return Exemplar
-          def collect; end
+          # return list of Exemplars based on given attributes
+          #
+          # @param [Hash] attributes Value of the measurement
+          # @param [Boolean] aggregation_temporality Should remove the original exemplars or not, default delta
+          # 
+          # @return [Array] exemplars Array of exemplars
+          def collect(attributes: nil, aggregation_temporality: :delta)
+            exemplars = []
+            @exemplars.each do |exemplar|
+              exemplars << exemplar if exemplar # TODO Addition operation on selecting exemplar
+            end
+            @exemplars.clear if aggregation_temporality == :delta
+            exemplars
+          end
+
+          def current_span_context(context)
+            ::OpenTelemetry::Trace.current_span(context).context
+          end
         end
       end
     end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/exemplar_reservoir.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/exemplar_reservoir.rb
@@ -8,6 +8,7 @@ module OpenTelemetry
   module SDK
     module Metrics
       module Exemplar
+        # ExemplarReservoir
         class ExemplarReservoir
           def initialize
             @exemplars = []
@@ -31,13 +32,11 @@ module OpenTelemetry
           #
           # @param [Hash] attributes Value of the measurement
           # @param [Boolean] aggregation_temporality Should remove the original exemplars or not, default delta
-          # 
+          #
           # @return [Array] exemplars Array of exemplars
           def collect(attributes: nil, aggregation_temporality: :delta)
             exemplars = []
-            @exemplars.each do |exemplar|
-              exemplars << exemplar if exemplar # TODO Addition operation on selecting exemplar
-            end
+            @exemplars.each { |exemplar| exemplars << exemplar if exemplar } # TODO: Addition operation on selecting exemplar
             @exemplars.clear if aggregation_temporality == :delta
             exemplars
           end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/exemplar_reservoir.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/exemplar_reservoir.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Metrics
+      module Exemplar
+        class ExemplarReservoir
+
+          def initialize(value, timestamp, attributes, context)
+            @value      = value
+            @timestamp  = timestamp
+            @attributes = attributes
+            @context    = context
+          end
+
+          def offer; end
+
+          # return Exemplar
+          def collect; end
+        end
+      end
+    end
+  end
+end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/fixed_size_exemplar_reservoir.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/fixed_size_exemplar_reservoir.rb
@@ -9,9 +9,27 @@ module OpenTelemetry
     module Metrics
       module Exemplar
         class FixedSizeExemplarReservoir < ExemplarReservoir
-          MAX_BUCKET_SIZE = 20
+          MAX_BUCKET_SIZE = 1
+          
+          def initialize(max_size: nil)
+            super()
+            @max_size = max_size || MAX_BUCKET_SIZE
+          end
 
-          def collect
+          # MUST use an uniformly-weighted sampling algorithm based on the number of samples the reservoir
+          def offer(value: nil, timestamp: nil, attributes: nil, context: nil)
+            span_context = current_span_context(context)
+            if @exemplars.size >= @max_size
+              rand_index = rand(0..@max_size-1)
+              @exemplars[rand_index] = Exemplar.new(value, timestamp, attributes, span_context.hex_span_id, span_context.hex_trace_id)
+              nil
+            else
+              super(value: value, timestamp: timestamp, attributes: attributes, context: context)
+            end
+          end
+
+          def collect(attributes: nil, aggregation_temporality: nil)
+            super(attributes: attributes, aggregation_temporality: aggregation_temporality)
           end
         end
       end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/fixed_size_exemplar_reservoir.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/fixed_size_exemplar_reservoir.rb
@@ -8,9 +8,10 @@ module OpenTelemetry
   module SDK
     module Metrics
       module Exemplar
+        # FixedSizeExemplarReservoir
         class FixedSizeExemplarReservoir < ExemplarReservoir
           MAX_BUCKET_SIZE = 1
-          
+
           def initialize(max_size: nil)
             super()
             @max_size = max_size || MAX_BUCKET_SIZE
@@ -20,7 +21,7 @@ module OpenTelemetry
           def offer(value: nil, timestamp: nil, attributes: nil, context: nil)
             span_context = current_span_context(context)
             if @exemplars.size >= @max_size
-              rand_index = rand(0..@max_size-1)
+              rand_index = rand(0..@max_size - 1)
               @exemplars[rand_index] = Exemplar.new(value, timestamp, attributes, span_context.hex_span_id, span_context.hex_trace_id)
               nil
             else

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/fixed_size_exemplar_reservoir.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/fixed_size_exemplar_reservoir.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Metrics
+      module Exemplar
+        class FixedSizeExemplarReservoir < ExemplarReservoir
+          MAX_BUCKET_SIZE = 20
+
+          def collect
+          end
+        end
+      end
+    end
+  end
+end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/histogram_exemplar_reservoir.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/histogram_exemplar_reservoir.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Metrics
+      module Exemplar
+        class HistogramExemplarReservoir < ExemplarReservoir
+
+          # return Exemplar
+          def collect
+          end
+        end
+      end
+    end
+  end
+end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/histogram_exemplar_reservoir.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/histogram_exemplar_reservoir.rb
@@ -8,10 +8,35 @@ module OpenTelemetry
   module SDK
     module Metrics
       module Exemplar
+        # same as AlignedHistogramBucketExemplarReservoir
         class HistogramExemplarReservoir < ExemplarReservoir
 
+          DEFAULT_BOUNDARIES = [0, 5, 10, 25, 50, 75, 100, 250, 500, 1000].freeze
+          private_constant :DEFAULT_BOUNDARIES
+
+          def initialize(boundaries: nil)
+            super()
+            @boundaries = boundaries || DEFAULT_BOUNDARIES
+          end
+
+          # TODO: align with the requirements of alignedhistogrambucketexemplarreservoir for offering
+          # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#alignedhistogrambucketexemplarreservoir
+          # Assumption: each boundary should have one exemplar measurement
+          def offer(value: nil, timestamp: nil, attributes: nil, context: nil)
+            bucket = find_histogram_bucket(value)
+            if bucket < @boundaries.size
+              span_context = current_span_context(context)
+              @exemplars[bucket] = Exemplar.new(value, timestamp, attributes, span_context.hex_span_id, span_context.hex_trace_id)
+            end
+          end
+
           # return Exemplar
-          def collect
+          def collect(attributes: nil, aggregation_temporality: nil)
+            super(attributes: attributes, aggregation_temporality: aggregation_temporality)
+          end
+
+          def find_histogram_bucket(value)
+            @boundaries.bsearch_index { |i| i >= value } || @boundaries.size
           end
         end
       end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/histogram_exemplar_reservoir.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/histogram_exemplar_reservoir.rb
@@ -10,7 +10,6 @@ module OpenTelemetry
       module Exemplar
         # same as AlignedHistogramBucketExemplarReservoir
         class HistogramExemplarReservoir < ExemplarReservoir
-
           DEFAULT_BOUNDARIES = [0, 5, 10, 25, 50, 75, 100, 250, 500, 1000].freeze
           private_constant :DEFAULT_BOUNDARIES
 
@@ -24,10 +23,10 @@ module OpenTelemetry
           # Assumption: each boundary should have one exemplar measurement
           def offer(value: nil, timestamp: nil, attributes: nil, context: nil)
             bucket = find_histogram_bucket(value)
-            if bucket < @boundaries.size
-              span_context = current_span_context(context)
-              @exemplars[bucket] = Exemplar.new(value, timestamp, attributes, span_context.hex_span_id, span_context.hex_trace_id)
-            end
+            return unless bucket < @boundaries.size
+
+            span_context = current_span_context(context)
+            @exemplars[bucket] = Exemplar.new(value, timestamp, attributes, span_context.hex_span_id, span_context.hex_trace_id)
           end
 
           # return Exemplar

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/noop_exemplar_reservoir.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/noop_exemplar_reservoir.rb
@@ -8,13 +8,14 @@ module OpenTelemetry
   module SDK
     module Metrics
       module Exemplar
+        # NoopExemplarReservoir
         class NoopExemplarReservoir < ExemplarReservoir
           def initialize; end
 
           def offer(value: nil, timestamp: nil, attributes: nil, context: nil); end
 
           def collect(attributes: nil, aggregation_temporality: :delta)
-            Array.new
+            []
           end
         end
       end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/noop_exemplar_reservoir.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/noop_exemplar_reservoir.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Metrics
+      module Exemplar
+        class NoopExemplarReservoir < ExemplarReservoir
+          def initialize; end
+
+          def offer(value: nil, timestamp: nil, attributes: nil, context: nil); end
+
+          def collect(attributes: nil, aggregation_temporality: :delta)
+            Array.new
+          end
+        end
+      end
+    end
+  end
+end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/trace_based_exemplar_filter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/trace_based_exemplar_filter.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Metrics
+      module Exemplar
+        class AlwaysOffExemplarFilter < ExemplarFilter
+          def should_sample?(value, timestamp, attributes, context)
+            OpenTelemetry.current_span(context).context.trace_flags.sampled?
+          end
+        end
+      end
+    end
+  end
+end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/trace_based_exemplar_filter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/trace_based_exemplar_filter.rb
@@ -8,6 +8,7 @@ module OpenTelemetry
   module SDK
     module Metrics
       module Exemplar
+        # TraceBasedExemplarFilter
         class TraceBasedExemplarFilter < ExemplarFilter
           def self.should_sample?(value, timestamp, attributes, context)
             ::OpenTelemetry::Trace.current_span(context).context.trace_flags.sampled?

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/trace_based_exemplar_filter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/trace_based_exemplar_filter.rb
@@ -8,9 +8,9 @@ module OpenTelemetry
   module SDK
     module Metrics
       module Exemplar
-        class AlwaysOffExemplarFilter < ExemplarFilter
-          def should_sample?(value, timestamp, attributes, context)
-            OpenTelemetry.current_span(context).context.trace_flags.sampled?
+        class TraceBasedExemplarFilter < ExemplarFilter
+          def self.should_sample?(value, timestamp, attributes, context)
+            ::OpenTelemetry::Trace.current_span(context).context.trace_flags.sampled?
           end
         end
       end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/counter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/counter.rb
@@ -31,7 +31,7 @@ module OpenTelemetry
             if increment.negative?
               OpenTelemetry.logger.warn("#{@name} received a negative value")
             else
-              exemplar_offer(increment, attributes) if @meter_provider.exemplar_filter
+              exemplar_offer(increment, attributes)
               update(increment, attributes)
             end
             nil

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/counter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/counter.rb
@@ -31,6 +31,7 @@ module OpenTelemetry
             if increment.negative?
               OpenTelemetry.logger.warn("#{@name} received a negative value")
             else
+              exemplar_offer(increment, attributes) if @meter_provider.exemplar_filter
               update(increment, attributes)
             end
             nil
@@ -42,7 +43,7 @@ module OpenTelemetry
           private
 
           def default_aggregation
-            OpenTelemetry::SDK::Metrics::Aggregation::Sum.new
+            OpenTelemetry::SDK::Metrics::Aggregation::Sum.new(exemplar_reservoir: @exemplar_reservoir)
           end
         end
       end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/histogram.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/histogram.rb
@@ -25,6 +25,9 @@ module OpenTelemetry
           #   Array values must not contain nil elements and all elements must be of
           #   the same basic type (string, numeric, boolean).
           def record(amount, attributes: nil)
+            
+            # this should probably put in SynchronousInstrument class
+            exemplar_offer(amount, attributes) if @meter_provider.exemplar_filter
             update(amount, attributes)
             nil
           rescue StandardError => e
@@ -35,7 +38,9 @@ module OpenTelemetry
           private
 
           def default_aggregation
-            OpenTelemetry::SDK::Metrics::Aggregation::ExplicitBucketHistogram.new
+            # TODO: at this point, histogram always take the default DEFAULT_BOUNDARIES. In future, the histogram should be able to
+            # define the custom boundaries so for exemplar_reservoir can also takes the bounaries as parameter
+            OpenTelemetry::SDK::Metrics::Aggregation::ExplicitBucketHistogram.new(exemplar_reservoir: @exemplar_reservoir)
           end
         end
       end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/histogram.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/histogram.rb
@@ -25,9 +25,7 @@ module OpenTelemetry
           #   Array values must not contain nil elements and all elements must be of
           #   the same basic type (string, numeric, boolean).
           def record(amount, attributes: nil)
-            
-            # this should probably put in SynchronousInstrument class
-            exemplar_offer(amount, attributes) if @meter_provider.exemplar_filter
+            exemplar_offer(amount, attributes)
             update(amount, attributes)
             nil
           rescue StandardError => e

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/synchronous_instrument.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/synchronous_instrument.rb
@@ -11,13 +11,17 @@ module OpenTelemetry
         # {SynchronousInstrument} contains the common functionality shared across
         # the synchronous instruments SDK instruments.
         class SynchronousInstrument
-          def initialize(name, unit, description, instrumentation_scope, meter_provider)
+          NOOP_EXEMPLAR_RESERVOIR = Exemplar::NoopExemplarReservoir.new
+
+          def initialize(name, unit, description, instrumentation_scope, meter_provider, exemplar_filter, exemplar_reservoir)
             @name = name
             @unit = unit
             @description = description
             @instrumentation_scope = instrumentation_scope
             @meter_provider = meter_provider
             @metric_streams = []
+            @exemplar_filter    = exemplar_filter || meter_provider.exemplar_filter
+            @exemplar_reservoir = exemplar_reservoir || NOOP_EXEMPLAR_RESERVOIR
 
             meter_provider.register_synchronous_instrument(self)
           end
@@ -41,6 +45,14 @@ module OpenTelemetry
 
           def update(value, attributes)
             @metric_streams.each { |ms| ms.update(value, attributes) }
+          end
+
+          def exemplar_offer(value, attributes)
+            context = OpenTelemetry::Context.current
+            time = (Time.now.to_r * 1_000_000).to_i
+            if @exemplar_filter.should_sample?(value, time, attributes, context)
+              @exemplar_reservoir.offer(value: value, timestamp: time, attributes: attributes, context: context) # this create an exemplar object in reservoir
+            end
           end
         end
       end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/synchronous_instrument.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/synchronous_instrument.rb
@@ -20,7 +20,7 @@ module OpenTelemetry
             @instrumentation_scope = instrumentation_scope
             @meter_provider = meter_provider
             @metric_streams = []
-            @exemplar_filter    = exemplar_filter || meter_provider.exemplar_filter
+            @exemplar_filter = exemplar_filter || meter_provider.exemplar_filter
             @exemplar_reservoir = exemplar_reservoir || NOOP_EXEMPLAR_RESERVOIR
 
             meter_provider.register_synchronous_instrument(self)
@@ -47,12 +47,14 @@ module OpenTelemetry
             @metric_streams.each { |ms| ms.update(value, attributes) }
           end
 
+          # Adding the exemplar to reservoir
+          #
           def exemplar_offer(value, attributes)
             context = OpenTelemetry::Context.current
             time = (Time.now.to_r * 1_000_000).to_i
-            if @exemplar_filter.should_sample?(value, time, attributes, context)
-              @exemplar_reservoir.offer(value: value, timestamp: time, attributes: attributes, context: context) # this create an exemplar object in reservoir
-            end
+            return unless @exemplar_filter.should_sample?(value, time, attributes, context)
+
+            @exemplar_reservoir.offer(value: value, timestamp: time, attributes: attributes, context: context)
           end
         end
       end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/up_down_counter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/up_down_counter.rb
@@ -25,7 +25,7 @@ module OpenTelemetry
           #   Array values must not contain nil elements and all elements must be of
           #   the same basic type (string, numeric, boolean).
           def add(amount, attributes: nil)
-            exemplar_offer(increment, attributes) if @meter_provider.exemplar_filter
+            exemplar_offer(amount, attributes)
             update(amount, attributes)
             nil
           rescue StandardError => e

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/up_down_counter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/up_down_counter.rb
@@ -25,6 +25,7 @@ module OpenTelemetry
           #   Array values must not contain nil elements and all elements must be of
           #   the same basic type (string, numeric, boolean).
           def add(amount, attributes: nil)
+            exemplar_offer(increment, attributes) if @meter_provider.exemplar_filter
             update(amount, attributes)
             nil
           rescue StandardError => e
@@ -35,7 +36,7 @@ module OpenTelemetry
           private
 
           def default_aggregation
-            OpenTelemetry::SDK::Metrics::Aggregation::Sum.new
+            OpenTelemetry::SDK::Metrics::Aggregation::Sum.new(exemplar_reservoir: @exemplar_reservoir)
           end
         end
       end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/meter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/meter.rb
@@ -33,14 +33,14 @@ module OpenTelemetry
           end
         end
 
-        def create_instrument(kind, name, unit, description, callback)
+        def create_instrument(kind, name, unit, description, callback, exemplar_filter, exemplar_reservoir)
           super do
             case kind
-            when :counter then OpenTelemetry::SDK::Metrics::Instrument::Counter.new(name, unit, description, @instrumentation_scope, @meter_provider)
+            when :counter then OpenTelemetry::SDK::Metrics::Instrument::Counter.new(name, unit, description, @instrumentation_scope, @meter_provider, exemplar_filter, exemplar_reservoir)
             when :observable_counter then OpenTelemetry::SDK::Metrics::Instrument::ObservableCounter.new(name, unit, description, callback, @instrumentation_scope, @meter_provider)
-            when :histogram then OpenTelemetry::SDK::Metrics::Instrument::Histogram.new(name, unit, description, @instrumentation_scope, @meter_provider)
+            when :histogram then OpenTelemetry::SDK::Metrics::Instrument::Histogram.new(name, unit, description, @instrumentation_scope, @meter_provider, exemplar_filter, exemplar_reservoir)
             when :observable_gauge then OpenTelemetry::SDK::Metrics::Instrument::ObservableGauge.new(name, unit, description, callback, @instrumentation_scope, @meter_provider)
-            when :up_down_counter then OpenTelemetry::SDK::Metrics::Instrument::UpDownCounter.new(name, unit, description, @instrumentation_scope, @meter_provider)
+            when :up_down_counter then OpenTelemetry::SDK::Metrics::Instrument::UpDownCounter.new(name, unit, description, @instrumentation_scope, @meter_provider, exemplar_filter, exemplar_reservoir)
             when :observable_up_down_counter then OpenTelemetry::SDK::Metrics::Instrument::ObservableUpDownCounter.new(name, unit, description, callback, @instrumentation_scope, @meter_provider)
             end
           end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/meter_provider.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/meter_provider.rb
@@ -22,6 +22,7 @@ module OpenTelemetry
           @stopped = false
           @metric_readers = []
           @resource = resource
+          @exempler_filter = DEFAULT_EXEMPLAR_FITLER
         end
 
         # Returns a {Meter} instance.
@@ -123,6 +124,10 @@ module OpenTelemetry
               instrument.register_with_new_metric_store(mr.metric_store)
             end
           end
+        end
+
+        def set_exemplar_filter(exempler_filter)
+          @exempler_filter = exempler_filter
         end
 
         # The type of the Instrument(s) (optional).

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/meter_provider.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/meter_provider.rb
@@ -129,9 +129,15 @@ module OpenTelemetry
 
         # Adds a new ExemplarFilter to this {MeterProvider}. Existing exemplar_filter will be replaced
         # This is one way to turn on the exemplar
+        # Environment variable has higher precedence; if wants to use custom exemplar_filter, should unset OTEL_METRICS_EXEMPLAR_FILTER
+        # and then use meter_provider.exemplar_filter_on(exemplar_filter: custom_exemplar_filter)
         #
         # @param exemplar_filter the new ExemplarFilter to be added.
         def exemplar_filter_on(exemplar_filter: Exemplar::TraceBasedExemplarFilter)
+          if ENV.has_key?('OTEL_METRICS_EXEMPLAR_FILTER')
+            OpenTelemetry.logger.warn("Exemplar is on based on OTEL_METRICS_EXEMPLAR_FILTER #{ENV['OTEL_METRICS_EXEMPLAR_FILTER']}")
+            return
+          end
           @exemplar_filter = exemplar_filter
         end
 
@@ -152,10 +158,9 @@ module OpenTelemetry
             when 'always_off'
               @exemplar_filter = Exemplar::AlwaysOffExemplarFilter
             else
+              OpenTelemetry.logger.warn("OTEL_METRICS_EXEMPLAR_FILTER #{ENV['OTEL_METRICS_EXEMPLAR_FILTER']} is not part of provided exemplar filter; Exemplar is off.")
               @exemplar_filter = nil
             end
-            # @exemplar_on = true if @exemplar_filter
-
           end
         end
 

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/exemplar/exemplar_filter_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/exemplar/exemplar_filter_test.rb
@@ -7,16 +7,19 @@
 require 'test_helper'
 
 describe OpenTelemetry::SDK::Metrics::Exemplar::ExemplarFilter do
-
-  let(:context) { ::OpenTelemetry::Trace.context_with_span(
-                    ::OpenTelemetry::Trace.non_recording_span(
-                      ::OpenTelemetry::Trace::SpanContext.new(
-                        trace_id: Array("w\xCBl\xCCR-1\x06\x11M\xD6\xEC\xBBp\x03j").pack('H*'),
-                        span_id: Array("1\xE1u\x12\x8E\xFC@\x18").pack('H*'),
-                        trace_flags: ::OpenTelemetry::Trace::TraceFlags::DEFAULT)))
-                }
+  let(:context) do
+    ::OpenTelemetry::Trace.context_with_span(
+      ::OpenTelemetry::Trace.non_recording_span(
+        ::OpenTelemetry::Trace::SpanContext.new(
+          trace_id: Array("w\xCBl\xCCR-1\x06\x11M\xD6\xEC\xBBp\x03j").pack('H*'),
+          span_id: Array("1\xE1u\x12\x8E\xFC@\x18").pack('H*'),
+          trace_flags: ::OpenTelemetry::Trace::TraceFlags::DEFAULT
+        )
+      )
+    )
+  end
   let(:timestamp) { 123_456_789 }
-  let(:attributes) { {'test': 'test'} }
+  let(:attributes) { { 'test': 'test' } }
 
   it 'always true for always on exemplar filter' do
     result = OpenTelemetry::SDK::Metrics::Exemplar::AlwaysOnExemplarFilter.should_sample?(1, timestamp, attributes, context)

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/exemplar/exemplar_filter_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/exemplar/exemplar_filter_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+describe OpenTelemetry::SDK::Metrics::Exemplar::ExemplarFilter do
+
+  let(:context) { ::OpenTelemetry::Trace.context_with_span(
+                    ::OpenTelemetry::Trace.non_recording_span(
+                      ::OpenTelemetry::Trace::SpanContext.new(
+                        trace_id: Array("w\xCBl\xCCR-1\x06\x11M\xD6\xEC\xBBp\x03j").pack('H*'),
+                        span_id: Array("1\xE1u\x12\x8E\xFC@\x18").pack('H*'),
+                        trace_flags: ::OpenTelemetry::Trace::TraceFlags::DEFAULT)))
+                }
+  let(:timestamp) { 123_456_789 }
+  let(:attributes) { {'test': 'test'} }
+
+  it 'always true for always on exemplar filter' do
+    result = OpenTelemetry::SDK::Metrics::Exemplar::AlwaysOnExemplarFilter.should_sample?(1, timestamp, attributes, context)
+    _(result).must_equal true
+  end
+
+  it 'always false for always off exemplar filter' do
+    result = OpenTelemetry::SDK::Metrics::Exemplar::AlwaysOffExemplarFilter.should_sample?(1, timestamp, attributes, context)
+    _(result).must_equal false
+  end
+
+  it 'filter off when trace context flag is 0' do
+    result = OpenTelemetry::SDK::Metrics::Exemplar::TraceBasedExemplarFilter.should_sample?(1, timestamp, attributes, context)
+    _(result).must_equal false
+  end
+
+  it 'filter on when trace context flag is 1' do
+    context.instance_variable_get(:@entries).values[0].instance_variable_get(:@context).instance_variable_set(:@trace_flags, ::OpenTelemetry::Trace::TraceFlags::SAMPLED)
+    result = OpenTelemetry::SDK::Metrics::Exemplar::TraceBasedExemplarFilter.should_sample?(1, timestamp, attributes, context)
+    _(result).must_equal true
+  end
+end

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/exemplar/exemplar_integration_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/exemplar/exemplar_integration_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+describe OpenTelemetry::SDK do
+  describe '#exempler_integration_test' do
+    before { reset_metrics_sdk }
+
+    it 'emits metrics with list of exempler' do
+      OpenTelemetry::SDK.configure
+
+      metric_exporter = OpenTelemetry::SDK::Metrics::Export::InMemoryMetricPullExporter.new
+      OpenTelemetry.meter_provider.add_metric_reader(metric_exporter)
+
+      OpenTelemetry.meter_provider.exemplar_filter_on(exemplar_filter: OpenTelemetry::SDK::Metrics::Exemplar::AlwaysOnExemplarFilter)
+
+      exemplar_reservoir = OpenTelemetry::SDK::Metrics::Exemplar::ExemplarReservoir.new
+
+      meter = OpenTelemetry.meter_provider.meter('test')
+      counter = meter.create_counter('counter', unit: 'smidgen', description: 'a small amount of something', exemplar_reservoir: exemplar_reservoir)
+
+      counter.add(1)
+      counter.add(2, attributes: { 'a' => 'b' })
+      counter.add(2, attributes: { 'a' => 'b' })
+      counter.add(3, attributes: { 'b' => 'c' })
+      counter.add(4, attributes: { 'd' => 'e' })
+
+      metric_exporter.pull
+      last_snapshot = metric_exporter.metric_snapshots.last
+
+      _(last_snapshot).wont_be_empty
+      _(last_snapshot[0].name).must_equal('counter')
+      _(last_snapshot[0].unit).must_equal('smidgen')
+      _(last_snapshot[0].description).must_equal('a small amount of something')
+
+      _(last_snapshot[0].instrumentation_scope.name).must_equal('test')
+
+      _(last_snapshot[0].data_points[0].value).must_equal(1)
+      _(last_snapshot[0].data_points[0].attributes).must_equal({})
+
+      _(last_snapshot[0].data_points[1].value).must_equal(4)
+      _(last_snapshot[0].data_points[1].attributes).must_equal('a' => 'b')
+
+      _(last_snapshot[0].data_points[0].exemplars.size).must_equal 1
+      _(last_snapshot[0].data_points[0].exemplars[0].class).must_equal OpenTelemetry::SDK::Metrics::Exemplar::Exemplar
+      _(last_snapshot[0].data_points[0].exemplars[0].value).must_equal 1
+      _(last_snapshot[0].data_points[0].exemplars[0].span_id).must_equal '0000000000000000'
+      _(last_snapshot[0].data_points[0].exemplars[0].trace_id).must_equal '00000000000000000000000000000000'
+    end
+  end
+end

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/exemplar/exemplar_reservoir_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/exemplar/exemplar_reservoir_test.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+describe OpenTelemetry::SDK::Metrics::Exemplar::ExemplarReservoir do
+
+  describe 'basic exemplar reservoir operation test' do
+    let(:context) { ::OpenTelemetry::Trace.context_with_span(
+                    ::OpenTelemetry::Trace.non_recording_span(
+                      ::OpenTelemetry::Trace::SpanContext.new(
+                        trace_id: Array("w\xCBl\xCCR-1\x06\x11M\xD6\xEC\xBBp\x03j").pack('H*'),
+                        span_id: Array("1\xE1u\x12\x8E\xFC@\x18").pack('H*'),
+                        trace_flags: ::OpenTelemetry::Trace::TraceFlags::DEFAULT)))
+                  }
+    let(:timestamp) { 123_456_789 }
+    let(:attributes) { {'test': 'test'} }
+
+    it 'basic test for exemplar reservoir' do
+      exemplar = OpenTelemetry::SDK::Metrics::Exemplar::ExemplarReservoir.new
+      exemplar.offer(value: 1, timestamp: timestamp, attributes: attributes, context: context)
+      exemplars = exemplar.collect
+
+      _(exemplars.class).must_equal Array
+      _(exemplars[0].class).must_equal OpenTelemetry::SDK::Metrics::Exemplar::Exemplar
+      _(exemplars[0].value).must_equal 1
+      _(exemplars[0].time_unix_nano).must_equal 123_456_789
+      _(exemplars[0].attributes[:test]).must_equal 'test'
+      _(exemplars[0].span_id).must_equal '11e2ec08'
+      _(exemplars[0].trace_id).must_equal '0b5cbd16166cb933'
+    end
+
+    it 'basic test for fixed size exemplar reservoir' do
+      exemplar = OpenTelemetry::SDK::Metrics::Exemplar::FixedSizeExemplarReservoir.new(max_size: 2)
+      exemplar.offer(value: 1, timestamp: timestamp, attributes: attributes, context: context)
+      exemplars = exemplar.collect
+
+      _(exemplars.class).must_equal Array
+      _(exemplars[0].class).must_equal OpenTelemetry::SDK::Metrics::Exemplar::Exemplar
+      _(exemplars[0].value).must_equal 1
+      _(exemplars[0].time_unix_nano).must_equal 123_456_789
+      _(exemplars[0].attributes[:test]).must_equal 'test'
+      _(exemplars[0].span_id).must_equal '11e2ec08'
+      _(exemplars[0].trace_id).must_equal '0b5cbd16166cb933'
+    end
+
+    it 'basic test for fixed size exemplar reservoir when more offers' do
+      exemplar = OpenTelemetry::SDK::Metrics::Exemplar::FixedSizeExemplarReservoir.new(max_size: 2)
+      exemplar.offer(value: 1, timestamp: timestamp, attributes: attributes, context: context)
+      exemplar.offer(value: 2, timestamp: timestamp, attributes: attributes, context: context)
+      exemplar.offer(value: 3, timestamp: timestamp, attributes: attributes, context: context)
+
+      exemplars = exemplar.collect
+      _(exemplars.class).must_equal Array
+      _(exemplars[0].class).must_equal OpenTelemetry::SDK::Metrics::Exemplar::Exemplar
+      _(exemplars.size).must_equal 2
+    end
+
+    it 'basic test for histogram exemplar reservoir' do
+      exemplar = OpenTelemetry::SDK::Metrics::Exemplar::HistogramExemplarReservoir.new
+      exemplar.offer(value: 20, timestamp: timestamp, attributes: attributes, context: context)
+      exemplars = exemplar.collect
+
+      _(exemplars.class).must_equal Array
+      _(exemplars[0].class).must_equal OpenTelemetry::SDK::Metrics::Exemplar::Exemplar
+      _(exemplars[0].value).must_equal 20
+      _(exemplars[0].time_unix_nano).must_equal 123_456_789
+      _(exemplars[0].attributes[:test]).must_equal 'test'
+      _(exemplars[0].span_id).must_equal '11e2ec08'
+      _(exemplars[0].trace_id).must_equal '0b5cbd16166cb933'
+    end
+  end
+
+  describe 'complex exemplar reservoir integration test always on filter' do
+
+    let(:metric_exporter) { OpenTelemetry::SDK::Metrics::Export::InMemoryMetricPullExporter.new }
+    let(:exemplar_filter) { OpenTelemetry::SDK::Metrics::Exemplar::AlwaysOnExemplarFilter }
+    let(:exemplar_reservoir) { OpenTelemetry::SDK::Metrics::Exemplar::FixedSizeExemplarReservoir.new(max_size: 2) }
+
+    it 'integrate fixed size exemplar reservior with simple counter' do
+      meter = create_meter
+      histogram = meter.create_histogram('histogram', unit: 'smidgen', description: 'description', 
+                                              exemplar_filter: exemplar_filter, exemplar_reservoir: exemplar_reservoir)
+      histogram.record(1, attributes: {'foo' => 'bar'})
+
+      metric_exporter.pull
+      last_snapshot = metric_exporter.metric_snapshots.last
+      _(last_snapshot[0].description).must_equal 'description'
+      _(last_snapshot[0].data_points[0].exemplars[0].value).must_equal 1
+      _(last_snapshot[0].data_points[0].exemplars[0].attributes['foo']).must_equal 'bar'
+      _(last_snapshot[0].data_points[0].exemplars[0].span_id).must_equal '0000000000000000'
+      _(last_snapshot[0].data_points[0].exemplars[0].trace_id).must_equal '00000000000000000000000000000000'
+    end
+  end
+
+  describe 'complex exemplar reservoir integration test always off filter' do
+
+    let(:metric_exporter) { OpenTelemetry::SDK::Metrics::Export::InMemoryMetricPullExporter.new }
+    let(:exemplar_filter) { OpenTelemetry::SDK::Metrics::Exemplar::AlwaysOffExemplarFilter }
+    let(:exemplar_reservoir) { OpenTelemetry::SDK::Metrics::Exemplar::FixedSizeExemplarReservoir.new(max_size: 2) }
+
+    # def create_histogram(name, unit: nil, description: nil, exemplar_filter: nil, exemplar_reservoir: nil)
+    #   create_instrument(:histogram, name, unit, description, nil, exemplar_filter, exemplar_reservoir) { HISTOGRAM }
+    # end
+    # create_histogram -> create_instrument so if no exemplar_filter and exemplar_reservoir provided, these two will be nil
+    # create_instrument -> OpenTelemetry::SDK::Metrics::Instrument::Histogram.new(name, unit, description, @instrumentation_scope, @meter_provider, exemplar_filter, exemplar_reservoir)
+    it 'integrate fixed size exemplar reservior with simple counter' do
+      meter = create_meter
+      histogram = meter.create_histogram('histogram', unit: 'smidgen', description: 'description', 
+                                              exemplar_filter: exemplar_filter, exemplar_reservoir: exemplar_reservoir)
+      histogram.record(1, attributes: {'foo' => 'bar'})
+
+      metric_exporter.pull
+      last_snapshot = metric_exporter.metric_snapshots.last
+      _(last_snapshot[0].description).must_equal 'description'
+      _(last_snapshot[0].data_points[0].exemplars.size).must_equal 0
+    end
+  end
+end

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/exemplar/exemplar_reservoir_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/exemplar/exemplar_reservoir_test.rb
@@ -7,17 +7,20 @@
 require 'test_helper'
 
 describe OpenTelemetry::SDK::Metrics::Exemplar::ExemplarReservoir do
-
   describe 'basic exemplar reservoir operation test' do
-    let(:context) { ::OpenTelemetry::Trace.context_with_span(
-                    ::OpenTelemetry::Trace.non_recording_span(
-                      ::OpenTelemetry::Trace::SpanContext.new(
-                        trace_id: Array("w\xCBl\xCCR-1\x06\x11M\xD6\xEC\xBBp\x03j").pack('H*'),
-                        span_id: Array("1\xE1u\x12\x8E\xFC@\x18").pack('H*'),
-                        trace_flags: ::OpenTelemetry::Trace::TraceFlags::DEFAULT)))
-                  }
+    let(:context) do
+      ::OpenTelemetry::Trace.context_with_span(
+        ::OpenTelemetry::Trace.non_recording_span(
+          ::OpenTelemetry::Trace::SpanContext.new(
+            trace_id: Array("w\xCBl\xCCR-1\x06\x11M\xD6\xEC\xBBp\x03j").pack('H*'),
+            span_id: Array("1\xE1u\x12\x8E\xFC@\x18").pack('H*'),
+            trace_flags: ::OpenTelemetry::Trace::TraceFlags::DEFAULT
+          )
+        )
+      )
+    end
     let(:timestamp) { 123_456_789 }
-    let(:attributes) { {'test': 'test'} }
+    let(:attributes) { { 'test': 'test' } }
 
     it 'basic test for exemplar reservoir' do
       exemplar = OpenTelemetry::SDK::Metrics::Exemplar::ExemplarReservoir.new
@@ -75,16 +78,15 @@ describe OpenTelemetry::SDK::Metrics::Exemplar::ExemplarReservoir do
   end
 
   describe 'complex exemplar reservoir integration test always on filter' do
-
     let(:metric_exporter) { OpenTelemetry::SDK::Metrics::Export::InMemoryMetricPullExporter.new }
     let(:exemplar_filter) { OpenTelemetry::SDK::Metrics::Exemplar::AlwaysOnExemplarFilter }
     let(:exemplar_reservoir) { OpenTelemetry::SDK::Metrics::Exemplar::FixedSizeExemplarReservoir.new(max_size: 2) }
 
     it 'integrate fixed size exemplar reservior with simple counter' do
       meter = create_meter
-      histogram = meter.create_histogram('histogram', unit: 'smidgen', description: 'description', 
-                                              exemplar_filter: exemplar_filter, exemplar_reservoir: exemplar_reservoir)
-      histogram.record(1, attributes: {'foo' => 'bar'})
+      histogram = meter.create_histogram('histogram', unit: 'smidgen', description: 'description',
+                                                      exemplar_filter: exemplar_filter, exemplar_reservoir: exemplar_reservoir)
+      histogram.record(1, attributes: { 'foo' => 'bar' })
 
       metric_exporter.pull
       last_snapshot = metric_exporter.metric_snapshots.last
@@ -97,21 +99,15 @@ describe OpenTelemetry::SDK::Metrics::Exemplar::ExemplarReservoir do
   end
 
   describe 'complex exemplar reservoir integration test always off filter' do
-
     let(:metric_exporter) { OpenTelemetry::SDK::Metrics::Export::InMemoryMetricPullExporter.new }
     let(:exemplar_filter) { OpenTelemetry::SDK::Metrics::Exemplar::AlwaysOffExemplarFilter }
     let(:exemplar_reservoir) { OpenTelemetry::SDK::Metrics::Exemplar::FixedSizeExemplarReservoir.new(max_size: 2) }
 
-    # def create_histogram(name, unit: nil, description: nil, exemplar_filter: nil, exemplar_reservoir: nil)
-    #   create_instrument(:histogram, name, unit, description, nil, exemplar_filter, exemplar_reservoir) { HISTOGRAM }
-    # end
-    # create_histogram -> create_instrument so if no exemplar_filter and exemplar_reservoir provided, these two will be nil
-    # create_instrument -> OpenTelemetry::SDK::Metrics::Instrument::Histogram.new(name, unit, description, @instrumentation_scope, @meter_provider, exemplar_filter, exemplar_reservoir)
     it 'integrate fixed size exemplar reservior with simple counter' do
       meter = create_meter
-      histogram = meter.create_histogram('histogram', unit: 'smidgen', description: 'description', 
-                                              exemplar_filter: exemplar_filter, exemplar_reservoir: exemplar_reservoir)
-      histogram.record(1, attributes: {'foo' => 'bar'})
+      histogram = meter.create_histogram('histogram', unit: 'smidgen', description: 'description',
+                                                      exemplar_filter: exemplar_filter, exemplar_reservoir: exemplar_reservoir)
+      histogram.record(1, attributes: { 'foo' => 'bar' })
 
       metric_exporter.pull
       last_snapshot = metric_exporter.metric_snapshots.last

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/meter_provider_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/meter_provider_test.rb
@@ -134,6 +134,61 @@ describe OpenTelemetry::SDK::Metrics::MeterProvider do
     end
   end
 
+  describe 'exempler' do
+    describe '#exemplar_filter_setup' do
+      after do
+        ENV.delete('OTEL_METRICS_EXEMPLAR_FILTER')
+      end
+
+      it 'without OTEL_METRICS_EXEMPLAR_FILTER' do
+        OpenTelemetry.meter_provider.exemplar_filter_setup
+        _(OpenTelemetry.meter_provider.exemplar_filter).must_equal OpenTelemetry::SDK::Metrics::Exemplar::AlwaysOffExemplarFilter
+      end
+
+      it 'with OTEL_METRICS_EXEMPLAR_FILTER as always_on' do
+        ENV['OTEL_METRICS_EXEMPLAR_FILTER'] = 'always_on'
+        OpenTelemetry.meter_provider.exemplar_filter_setup
+        _(OpenTelemetry.meter_provider.exemplar_filter).must_equal OpenTelemetry::SDK::Metrics::Exemplar::AlwaysOnExemplarFilter
+      end
+
+      it 'with OTEL_METRICS_EXEMPLAR_FILTER as invalid option' do
+        ENV['OTEL_METRICS_EXEMPLAR_FILTER'] = 'better_on'
+        OpenTelemetry.meter_provider.exemplar_filter_setup
+        _(OpenTelemetry.meter_provider.exemplar_filter).must_equal OpenTelemetry::SDK::Metrics::Exemplar::AlwaysOffExemplarFilter
+      end
+    end
+
+    describe '#exemplar_filter_off' do
+      it 'will turn it off' do
+        ENV['OTEL_METRICS_EXEMPLAR_FILTER'] = 'always_on'
+        OpenTelemetry.meter_provider.exemplar_filter_setup
+        _(OpenTelemetry.meter_provider.exemplar_filter).must_equal OpenTelemetry::SDK::Metrics::Exemplar::AlwaysOnExemplarFilter
+
+        OpenTelemetry.meter_provider.exemplar_filter_off
+        _(OpenTelemetry.meter_provider.exemplar_filter).must_equal OpenTelemetry::SDK::Metrics::Exemplar::AlwaysOffExemplarFilter
+        ENV.delete('OTEL_METRICS_EXEMPLAR_FILTER')
+      end
+    end
+
+    describe '#exemplar_filter_on' do
+      it 'will turn it on with default exempler filter' do
+        OpenTelemetry.meter_provider.exemplar_filter_setup
+        _(OpenTelemetry.meter_provider.exemplar_filter).must_equal OpenTelemetry::SDK::Metrics::Exemplar::AlwaysOffExemplarFilter
+
+        OpenTelemetry.meter_provider.exemplar_filter_on
+        _(OpenTelemetry.meter_provider.exemplar_filter).must_equal OpenTelemetry::SDK::Metrics::Exemplar::TraceBasedExemplarFilter
+      end
+
+      it 'will turn it on with customized always on' do
+        OpenTelemetry.meter_provider.exemplar_filter_setup
+        _(OpenTelemetry.meter_provider.exemplar_filter).must_equal OpenTelemetry::SDK::Metrics::Exemplar::AlwaysOffExemplarFilter
+
+        OpenTelemetry.meter_provider.exemplar_filter_on(exemplar_filter: OpenTelemetry::SDK::Metrics::Exemplar::AlwaysOnExemplarFilter)
+        _(OpenTelemetry.meter_provider.exemplar_filter).must_equal OpenTelemetry::SDK::Metrics::Exemplar::AlwaysOnExemplarFilter
+      end
+    end
+  end
+
   # TODO: OpenTelemetry.meter_provider.add_view
   describe '#add_view' do
   end

--- a/metrics_sdk/test/test_helper.rb
+++ b/metrics_sdk/test/test_helper.rb
@@ -39,6 +39,5 @@ def create_meter
   OpenTelemetry::SDK.configure
   OpenTelemetry.meter_provider.add_metric_reader(metric_exporter)
   OpenTelemetry.meter_provider.exemplar_filter_on(exemplar_filter: exemplar_filter)
-  meter = OpenTelemetry.meter_provider.meter("SAMPLE_METER_NAME")
-  meter
+  OpenTelemetry.meter_provider.meter('SAMPLE_METER_NAME')
 end

--- a/metrics_sdk/test/test_helper.rb
+++ b/metrics_sdk/test/test_helper.rb
@@ -33,3 +33,12 @@ def with_test_logger
 ensure
   OpenTelemetry.logger = original_logger
 end
+
+def create_meter
+  ENV['OTEL_TRACES_EXPORTER'] = 'console'
+  OpenTelemetry::SDK.configure
+  OpenTelemetry.meter_provider.add_metric_reader(metric_exporter)
+  OpenTelemetry.meter_provider.exemplar_filter_on(exemplar_filter: exemplar_filter)
+  meter = OpenTelemetry.meter_provider.meter("SAMPLE_METER_NAME")
+  meter
+end


### PR DESCRIPTION
## Description

Exemplar is useful for trace-metric correlation and I'd like to make a contribute (based on [otel ticket](https://github.com/open-telemetry/opentelemetry-ruby/projects/2#card-84597496) and [otel spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#exemplar)).