### PR TITLE
feat: add basic implementation of asynchronous metrics

### DIFF
--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument.rb
@@ -14,6 +14,7 @@ module OpenTelemetry
 end
 
 require 'opentelemetry/sdk/metrics/instrument/synchronous_instrument'
+require 'opentelemetry/sdk/metrics/instrument/asynchronous_instrument'
 require 'opentelemetry/sdk/metrics/instrument/counter'
 require 'opentelemetry/sdk/metrics/instrument/histogram'
 require 'opentelemetry/sdk/metrics/instrument/observable_counter'

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/asynchronous_instrument.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/asynchronous_instrument.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Metrics
+      module Instrument
+        # {AsynchronousInstrument} contains the common functionality shared across
+        # the asynchronous instruments SDK instruments.
+        class AsynchronousInstrument
+          def initialize(name, unit, description, callback, instrumentation_scope, meter_provider)
+            @name = name
+            @unit = unit
+            @description = description
+            @instrumentation_scope = instrumentation_scope
+            @meter_provider = meter_provider
+            @metric_streams = []
+            @callbacks = []
+
+            register_callback(callback)
+            meter_provider.register_asynchronous_instrument(self)
+          end
+
+          # @api private
+          def register_with_new_metric_store(metric_store, aggregation: default_aggregation)
+            ms = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
+              @name,
+              @description,
+              @unit,
+              instrument_kind,
+              @meter_provider,
+              @instrumentation_scope,
+              aggregation,
+              @callbacks
+            )
+            @metric_streams << ms
+            metric_store.add_metric_stream(ms)
+          end
+
+          def register_callback(callback)
+            callbacks = [callback] unless callback.instance_of? Array
+
+            callbacks.each do |cb|
+              if cb.instance_of? Proc
+                @callbacks << cb
+              else
+                OpenTelemetry.logger.warn "The callback registeration failed for instrument #{@name}"
+              end
+            end
+            @meter_provider.register_callback(self, @callbacks) # meter_provider should register list of callback
+          end
+
+          def remove_callback(callback)
+            orig_callback_size = @callbacks.size
+            callbacks = [callback] unless callback.instance_of? Array
+
+            callbacks.each { |cb| @callback.delete(cb) }
+            @meter_provider.register_callback(self, @callbacks) if @callback.size != orig_callback_size
+          end
+
+          private
+
+          def update(timeout, attributes)
+            @metric_streams.each { |ms| ms.invoke_callback(timeout, attributes) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/asynchronous_instrument.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/asynchronous_instrument.rb
@@ -19,6 +19,8 @@ module OpenTelemetry
             @meter_provider = meter_provider
             @metric_streams = []
             @callbacks = []
+            @timeout   = nil
+            @attributes = {}
 
             register_callback(callback)
             meter_provider.register_asynchronous_instrument(self)
@@ -34,7 +36,9 @@ module OpenTelemetry
               @meter_provider,
               @instrumentation_scope,
               aggregation,
-              @callbacks
+              @callbacks,
+              @timeout,
+              @attributes
             )
             @metric_streams << ms
             metric_store.add_metric_stream(ms)
@@ -43,7 +47,7 @@ module OpenTelemetry
           # For multiple callbacks in single instrument
           def register_callback(callback)
             if callback.instance_of?(Proc)
-              @callbacks << callback  # since @callbacks pass to ms, so no need to add it again
+              @callbacks << callback
             else
               OpenTelemetry.logger.warn "Only accept single Proc for registering callback (given callback #{callback.class}"
             end
@@ -52,6 +56,14 @@ module OpenTelemetry
           # For callback functions registered after an asynchronous instrument is created,
           def unregister(callback)
             @callbacks.delete(callback)
+          end
+
+          def timeout(timeout)
+            @timeout = timeout
+          end
+
+          def add_attributes(attributes)
+            @attributes.merge!(attributes) if attributes.instance_of?(Hash)
           end
 
           private

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/observable_counter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/observable_counter.rb
@@ -8,16 +8,30 @@ module OpenTelemetry
   module SDK
     module Metrics
       module Instrument
-        # {ObservableCounter} is the SDK implementation of {OpenTelemetry::Metrics::ObservableCounter}.
-        class ObservableCounter < OpenTelemetry::Metrics::Instrument::ObservableCounter
-          attr_reader :name, :unit, :description
+        # {ObservableCounter} is the SDK implementation of {OpenTelemetry::SDK::Metrics::Instrument::AsynchronousInstrument}.
+        class ObservableCounter < OpenTelemetry::SDK::Metrics::Instrument::AsynchronousInstrument
+          # Returns the instrument kind as a Symbol
+          #
+          # @return [Symbol]
+          def instrument_kind
+            :observable_counter
+          end
 
-          def initialize(name, unit, description, callback, meter)
-            @name = name
-            @unit = unit
-            @description = description
-            @callback = callback
-            @meter = meter
+          # Observe the ObservableCounter with fixed timeout duartion.
+          #
+          # @param [int] timeout The timeout duration for callback to run, which MUST be a non-negative numeric value.
+          # @param [Hash{String => String, Numeric, Boolean, Array<String, Numeric, Boolean>}] attributes
+          #   Values must be non-nil and (array of) string, boolean or numeric type.
+          #   Array values must not contain nil elements and all elements must be of
+          #   the same basic type (string, numeric, boolean).
+          def observe(timeout: nil, attributes: {})
+            update(timeout, attributes)
+          end
+
+          private
+
+          def default_aggregation
+            OpenTelemetry::SDK::Metrics::Aggregation::Sum.new
           end
         end
       end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/observable_counter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/observable_counter.rb
@@ -9,6 +9,7 @@ module OpenTelemetry
     module Metrics
       module Instrument
         # {ObservableCounter} is the SDK implementation of {OpenTelemetry::SDK::Metrics::Instrument::AsynchronousInstrument}.
+        # Asynchronous Counter is an asynchronous Instrument which reports non-additive, monotonically increasing value(s) when the instrument is being observed.
         class ObservableCounter < OpenTelemetry::SDK::Metrics::Instrument::AsynchronousInstrument
           # Returns the instrument kind as a Symbol
           #

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/observable_gauge.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/observable_gauge.rb
@@ -9,6 +9,7 @@ module OpenTelemetry
     module Metrics
       module Instrument
         # {ObservableGauge} is the SDK implementation of {OpenTelemetry::SDK::Metrics::Instrument::AsynchronousInstrument}.
+        # Asynchronous Gauge is an asynchronous Instrument which reports non-additive value(s) (e.g. the room temperature)
         class ObservableGauge < OpenTelemetry::SDK::Metrics::Instrument::AsynchronousInstrument
           # Returns the instrument kind as a Symbol
           #

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/observable_gauge.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/observable_gauge.rb
@@ -8,16 +8,30 @@ module OpenTelemetry
   module SDK
     module Metrics
       module Instrument
-        # {ObservableGauge} is the SDK implementation of {OpenTelemetry::Metrics::ObservableGauge}.
-        class ObservableGauge < OpenTelemetry::Metrics::Instrument::ObservableGauge
-          attr_reader :name, :unit, :description
+        # {ObservableGauge} is the SDK implementation of {OpenTelemetry::SDK::Metrics::Instrument::AsynchronousInstrument}.
+        class ObservableGauge < OpenTelemetry::SDK::Metrics::Instrument::AsynchronousInstrument
+          # Returns the instrument kind as a Symbol
+          #
+          # @return [Symbol]
+          def instrument_kind
+            :observable_gauge
+          end
 
-          def initialize(name, unit, description, callback, meter)
-            @name = name
-            @unit = unit
-            @description = description
-            @callback = callback
-            @meter = meter
+          # Observe the ObservableCounter with fixed timeout duartion.
+          #
+          # @param [int] timeout The timeout duration for callback to run, which MUST be a non-negative numeric value.
+          # @param [Hash{String => String, Numeric, Boolean, Array<String, Numeric, Boolean>}] attributes
+          #   Values must be non-nil and (array of) string, boolean or numeric type.
+          #   Array values must not contain nil elements and all elements must be of
+          #   the same basic type (string, numeric, boolean).
+          def observe(timeout: nil, attributes: {})
+            update(timeout, attributes)
+          end
+
+          private
+
+          def default_aggregation
+            OpenTelemetry::SDK::Metrics::Aggregation::Sum.new
           end
         end
       end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/observable_up_down_counter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/observable_up_down_counter.rb
@@ -8,16 +8,30 @@ module OpenTelemetry
   module SDK
     module Metrics
       module Instrument
-        # {ObservableUpDownCounter} is the SDK implementation of {OpenTelemetry::Metrics::ObservableUpDownCounter}.
-        class ObservableUpDownCounter < OpenTelemetry::Metrics::Instrument::ObservableUpDownCounter
-          attr_reader :name, :unit, :description
+        # {ObservableUpDownCounter} is the SDK implementation of {OpenTelemetry::SDK::Metrics::Instrument::AsynchronousInstrument}.
+        class ObservableUpDownCounter < OpenTelemetry::SDK::Metrics::Instrument::AsynchronousInstrument
+          # Returns the instrument kind as a Symbol
+          #
+          # @return [Symbol]
+          def instrument_kind
+            :observable_up_down_counter
+          end
 
-          def initialize(name, unit, description, callback, meter)
-            @name = name
-            @unit = unit
-            @description = description
-            @callback = callback
-            @meter = meter
+          # Observe the ObservableCounter with fixed timeout duartion.
+          #
+          # @param [int] timeout The timeout duration for callback to run, which MUST be a non-negative numeric value.
+          # @param [Hash{String => String, Numeric, Boolean, Array<String, Numeric, Boolean>}] attributes
+          #   Values must be non-nil and (array of) string, boolean or numeric type.
+          #   Array values must not contain nil elements and all elements must be of
+          #   the same basic type (string, numeric, boolean).
+          def observe(timeout: nil, attributes: {})
+            update(timeout, attributes)
+          end
+
+          private
+
+          def default_aggregation
+            OpenTelemetry::SDK::Metrics::Aggregation::Sum.new
           end
         end
       end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/observable_up_down_counter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/observable_up_down_counter.rb
@@ -9,6 +9,7 @@ module OpenTelemetry
     module Metrics
       module Instrument
         # {ObservableUpDownCounter} is the SDK implementation of {OpenTelemetry::SDK::Metrics::Instrument::AsynchronousInstrument}.
+        # Asynchronous UpDownCounter is an asynchronous Instrument which reports additive value(s) (e.g. the process heap size)
         class ObservableUpDownCounter < OpenTelemetry::SDK::Metrics::Instrument::AsynchronousInstrument
           # Returns the instrument kind as a Symbol
           #
@@ -18,6 +19,7 @@ module OpenTelemetry
           end
 
           # Observe the ObservableCounter with fixed timeout duartion.
+          # Everytime observe, the value should be sent to backend through exporter
           #
           # @param [int] timeout The timeout duration for callback to run, which MUST be a non-negative numeric value.
           # @param [Hash{String => String, Numeric, Boolean, Array<String, Numeric, Boolean>}] attributes
@@ -31,7 +33,7 @@ module OpenTelemetry
           private
 
           def default_aggregation
-            OpenTelemetry::SDK::Metrics::Aggregation::Sum.new
+            OpenTelemetry::SDK::Metrics::Aggregation::Sum.new(aggregation_temporality: :cumulative)
           end
         end
       end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/meter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/meter.rb
@@ -26,6 +26,30 @@ module OpenTelemetry
           @meter_provider = meter_provider
         end
 
+
+        # Multiple-instrument callbacks
+        # Callbacks registered after the time of instrument creation MAY be associated with multiple instruments.
+        # Related spec: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#multiple-instrument-callbacks
+        # Related spec: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#synchronous-instrument-api
+        #
+        # @param [Array] instruments A list (or tuple, etc.) of Instruments used in the callback function.
+        # @param [Proc] callback A callback function
+        #
+        # It is RECOMMENDED that the API authors use one of the following forms for the callback function:
+        # The list (or tuple, etc.) returned by the callback function contains (Instrument, Measurement) pairs.
+        # the Observable Result parameter receives an additional (Instrument, Measurement) pairs
+        def register_callback(instruments, callback)
+          instruments.each do |instrument|
+            instrument.register_callback(callback)
+          end
+        end
+
+        def unregister(instruments, callback)
+          instruments.each do |instrument|
+            instrument.unregister(callback)
+          end
+        end
+
         # @api private
         def add_metric_reader(metric_reader)
           @instrument_registry.each do |_n, instrument|

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/meter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/meter.rb
@@ -37,6 +37,7 @@ module OpenTelemetry
         # It is RECOMMENDED that the API authors use one of the following forms for the callback function:
         # The list (or tuple, etc.) returned by the callback function contains (Instrument, Measurement) pairs.
         # the Observable Result parameter receives an additional (Instrument, Measurement) pairs
+        # Here it chose the second form
         def register_callback(instruments, callback)
           instruments.each do |instrument|
             instrument.register_callback(callback)

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/meter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/meter.rb
@@ -26,7 +26,6 @@ module OpenTelemetry
           @meter_provider = meter_provider
         end
 
-
         # Multiple-instrument callbacks
         # Callbacks registered after the time of instrument creation MAY be associated with multiple instruments.
         # Related spec: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#multiple-instrument-callbacks

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/meter_provider.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/meter_provider.rb
@@ -22,7 +22,6 @@ module OpenTelemetry
           @stopped = false
           @metric_readers = []
           @resource = resource
-          @registered_callback = {}
         end
 
         # Returns a {Meter} instance.
@@ -128,16 +127,6 @@ module OpenTelemetry
 
         def register_asynchronous_instrument(instrument)
           register_synchronous_instrument(instrument)
-        end
-
-        def register_callback(instrument, callback)
-          instruments = [instrument] unless instrument.instance_of? Array
-          instruments.each { |inst| inst.register_callback(callback) }
-        end
-
-        def remove_callback(instrument, callback)
-          instruments = [instrument] unless instrument.instance_of? Array
-          instruments.each { |inst| inst.remove_callback(callback) }
         end
 
         # The type of the Instrument(s) (optional).

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/meter_provider.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/meter_provider.rb
@@ -22,6 +22,7 @@ module OpenTelemetry
           @stopped = false
           @metric_readers = []
           @resource = resource
+          @registered_callback = {}
         end
 
         # Returns a {Meter} instance.
@@ -123,6 +124,20 @@ module OpenTelemetry
               instrument.register_with_new_metric_store(mr.metric_store)
             end
           end
+        end
+
+        def register_asynchronous_instrument(instrument)
+          register_synchronous_instrument(instrument)
+        end
+
+        def register_callback(instrument, callback)
+          instruments = [instrument] unless instrument.instance_of? Array
+          instruments.each { |inst| inst.register_callback(callback) }
+        end
+
+        def remove_callback(instrument, callback)
+          instruments = [instrument] unless instrument.instance_of? Array
+          instruments.each { |inst| inst.remove_callback(callback) }
         end
 
         # The type of the Instrument(s) (optional).

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/state.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/state.rb
@@ -20,3 +20,4 @@ end
 require 'opentelemetry/sdk/metrics/state/metric_data'
 require 'opentelemetry/sdk/metrics/state/metric_store'
 require 'opentelemetry/sdk/metrics/state/metric_stream'
+require 'opentelemetry/sdk/metrics/state/asynchronous_metric_stream'

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/state/asynchronous_metric_stream.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/state/asynchronous_metric_stream.rb
@@ -23,7 +23,9 @@ module OpenTelemetry
             meter_provider,
             instrumentation_scope,
             aggregation,
-            callback
+            callback,
+            timeout,
+            attributes
           )
             @name = name
             @description = description
@@ -34,6 +36,8 @@ module OpenTelemetry
             @aggregation = aggregation
             @callback = callback
             @start_time = now_in_nano
+            @timeout = timeout
+            @attributes = attributes
 
             @mutex = Mutex.new
           end
@@ -42,7 +46,7 @@ module OpenTelemetry
           # Related spec: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#collect
           # invoke_callback will update the data_points in aggregation
           def collect(start_time, end_time)
-            invoke_callback(nil, {})
+            invoke_callback(@timeout, @attributes)
 
             @mutex.synchronize do
               MetricData.new(

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/state/asynchronous_metric_stream.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/state/asynchronous_metric_stream.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Metrics
+      module State
+        # @api private
+        #
+        # The MetricStream class provides SDK internal functionality that is not a part of the
+        # public API.
+        class AsynchronousMetricStream
+          attr_reader :name, :description, :unit, :instrument_kind, :instrumentation_scope, :data_points
+
+          def initialize(
+            name,
+            description,
+            unit,
+            instrument_kind,
+            meter_provider,
+            instrumentation_scope,
+            aggregation,
+            callback
+          )
+            @name = name
+            @description = description
+            @unit = unit
+            @instrument_kind = instrument_kind
+            @meter_provider = meter_provider
+            @instrumentation_scope = instrumentation_scope
+            @aggregation = aggregation
+            @callback = callback
+
+            @mutex = Mutex.new
+          end
+
+          def collect(start_time, end_time)
+            invoke_callback(nil, {})  # number of callbacks are finalized, collect the metric data in aggregation
+
+            @mutex.synchronize do
+              MetricData.new(
+                @name,
+                @description,
+                @unit,
+                @instrument_kind,
+                @meter_provider.resource,
+                @instrumentation_scope,
+                @aggregation.collect(start_time, end_time),
+                start_time,
+                end_time
+              )
+            end
+          end
+
+          def invoke_callback(timeout, attributes)
+            timeout_ = timeout || 30
+            Timeout.timeout(timeout) do
+              @callback.each do |cb|
+                value = cb.call
+                @mutex.synchronize { 
+                  @aggregation.update(value, attributes) 
+                }
+              end
+              
+            end
+          end
+
+          def to_s
+            instrument_info = String.new
+            instrument_info << "name=#{@name}"
+            instrument_info << " description=#{@description}" if @description
+            instrument_info << " unit=#{@unit}" if @unit
+            @data_points.map do |attributes, value|
+              metric_stream_string = String.new
+              metric_stream_string << instrument_info
+              metric_stream_string << " attributes=#{attributes}" if attributes
+              metric_stream_string << " #{value}"
+              metric_stream_string
+            end.join("\n")
+          end
+        end
+      end
+    end
+  end
+end

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/instrument/observable_counter_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/instrument/observable_counter_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+describe OpenTelemetry::SDK::Metrics::Instrument::ObservableCounter do
+  let(:metric_exporter) { OpenTelemetry::SDK::Metrics::Export::InMemoryMetricPullExporter.new }
+  let(:meter) { OpenTelemetry.meter_provider.meter('test') }
+
+  before do
+    reset_metrics_sdk
+    OpenTelemetry::SDK.configure
+    OpenTelemetry.meter_provider.add_metric_reader(metric_exporter)
+  end
+
+  it 'counts without observe' do
+    callback = Proc.new { 10 }
+    meter.create_observable_counter('counter', unit: 'smidgen', description: 'a small amount of something', callback: callback)
+
+    metric_exporter.pull
+    last_snapshot = metric_exporter.metric_snapshots.last
+
+    # puts "last_snapshot.inspect: #{last_snapshot.inspect}"
+    _(last_snapshot[0].name).must_equal('counter')
+    _(last_snapshot[0].unit).must_equal('smidgen')
+    _(last_snapshot[0].description).must_equal('a small amount of something')
+    _(last_snapshot[0].instrumentation_scope.name).must_equal('test')
+    _(last_snapshot[0].data_points[0].value).must_equal(10)
+    _(last_snapshot[0].data_points[0].attributes).must_equal({})
+    _(last_snapshot[0].aggregation_temporality).must_equal(:delta)
+  end
+
+  it 'counts with observe' do
+    callback = Proc.new { 10 }
+    observable_counter = meter.create_observable_counter('counter', unit: 'smidgen', description: 'a small amount of something', callback: callback)
+    observable_counter.observe(timeout: 10, attributes: {'foo' => 'bar'})
+
+    metric_exporter.pull
+    last_snapshot = metric_exporter.metric_snapshots.last
+
+    _(last_snapshot[0].name).must_equal('counter')
+    _(last_snapshot[0].unit).must_equal('smidgen')
+    _(last_snapshot[0].description).must_equal('a small amount of something')
+    _(last_snapshot[0].instrumentation_scope.name).must_equal('test')
+    _(last_snapshot[0].data_points[0].value).must_equal(10)
+    _(last_snapshot[0].data_points[0].attributes).must_equal('foo' => 'bar')
+
+    _(last_snapshot[0].data_points[1].value).must_equal(10)
+    _(last_snapshot[0].data_points[1].attributes).must_equal({})
+    _(last_snapshot[0].aggregation_temporality).must_equal(:delta)
+  end
+
+  it 'counts with observe after initialization' do
+    callback_1 = Proc.new { 10 }
+    observable_counter = meter.create_observable_counter('counter', unit: 'smidgen', description: 'a small amount of something', callback: callback_1)
+    _(observable_counter.instance_variable_get(:@callbacks).size).must_equal 1
+
+    callback_2 = Proc.new { 20 }
+    observable_counter.register_callback(callback_2)
+    _(observable_counter.instance_variable_get(:@callbacks).size).must_equal 2
+
+    metric_exporter.pull
+    last_snapshot = metric_exporter.metric_snapshots.last
+
+    _(last_snapshot[0].name).must_equal('counter')
+    _(last_snapshot[0].unit).must_equal('smidgen')
+    _(last_snapshot[0].description).must_equal('a small amount of something')
+    _(last_snapshot[0].instrumentation_scope.name).must_equal('test')
+    _(last_snapshot[0].data_points[0].value).must_equal(30)   # two callback aggregate value to 30
+    _(last_snapshot[0].data_points[0].attributes).must_equal({})
+  end
+
+  it 'remove the callback after initialization result no metrics data' do
+    callback_1 = Proc.new { 10 }
+    observable_counter = meter.create_observable_counter('counter', unit: 'smidgen', description: 'a small amount of something', callback: callback_1)
+    _(observable_counter.instance_variable_get(:@callbacks).size).must_equal 1
+
+    observable_counter.unregister(callback_1)
+    _(observable_counter.instance_variable_get(:@callbacks).size).must_equal 0
+
+    metric_exporter.pull
+    last_snapshot = metric_exporter.metric_snapshots.last
+
+    _(last_snapshot[0].name).must_equal('counter')
+    _(last_snapshot[0].unit).must_equal('smidgen')
+    _(last_snapshot[0].description).must_equal('a small amount of something')
+    _(last_snapshot[0].instrumentation_scope.name).must_equal('test')
+    _(last_snapshot[0].data_points.size).must_equal 0
+  end
+
+end

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/instrument/observable_gauge_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/instrument/observable_gauge_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+describe OpenTelemetry::SDK::Metrics::Instrument::ObservableGauge do
+  let(:metric_exporter) { OpenTelemetry::SDK::Metrics::Export::InMemoryMetricPullExporter.new }
+  let(:meter) { OpenTelemetry.meter_provider.meter('test') }
+
+  before do
+    reset_metrics_sdk
+    OpenTelemetry::SDK.configure
+    OpenTelemetry.meter_provider.add_metric_reader(metric_exporter)
+  end
+
+  it 'counts without observe' do
+    callback = Proc.new { 10 }
+    meter.create_observable_gauge('gauge', unit: 'smidgen', description: 'a small amount of something', callback: callback)
+
+    metric_exporter.pull
+    last_snapshot = metric_exporter.metric_snapshots.last
+
+    _(last_snapshot[0].name).must_equal('gauge')
+    _(last_snapshot[0].unit).must_equal('smidgen')
+    _(last_snapshot[0].description).must_equal('a small amount of something')
+    _(last_snapshot[0].instrumentation_scope.name).must_equal('test')
+    _(last_snapshot[0].data_points[0].value).must_equal(10)
+    _(last_snapshot[0].data_points[0].attributes).must_equal({})
+    _(last_snapshot[0].aggregation_temporality).must_equal(:delta)
+  end
+
+  it 'counts with observe' do
+    callback = Proc.new { 10 }
+    observable_gauge = meter.create_observable_gauge('gauge', unit: 'smidgen', description: 'a small amount of something', callback: callback)
+    observable_gauge.observe(timeout: 10, attributes: {'foo' => 'bar'})
+
+    metric_exporter.pull
+    last_snapshot = metric_exporter.metric_snapshots.last
+
+    _(last_snapshot[0].name).must_equal('gauge')
+    _(last_snapshot[0].unit).must_equal('smidgen')
+    _(last_snapshot[0].description).must_equal('a small amount of something')
+    _(last_snapshot[0].instrumentation_scope.name).must_equal('test')
+    _(last_snapshot[0].data_points[0].value).must_equal(10)
+    _(last_snapshot[0].data_points[0].attributes).must_equal('foo' => 'bar')
+
+    _(last_snapshot[0].data_points[1].value).must_equal(10)
+    _(last_snapshot[0].data_points[1].attributes).must_equal({})
+    _(last_snapshot[0].aggregation_temporality).must_equal(:delta)
+  end
+end

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/instrument/observable_gauge_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/instrument/observable_gauge_test.rb
@@ -17,7 +17,7 @@ describe OpenTelemetry::SDK::Metrics::Instrument::ObservableGauge do
   end
 
   it 'counts without observe' do
-    callback = Proc.new { 10 }
+    callback = proc { 10 }
     meter.create_observable_gauge('gauge', unit: 'smidgen', description: 'a small amount of something', callback: callback)
 
     metric_exporter.pull
@@ -33,9 +33,9 @@ describe OpenTelemetry::SDK::Metrics::Instrument::ObservableGauge do
   end
 
   it 'counts with observe' do
-    callback = Proc.new { 10 }
+    callback = proc { 10 }
     observable_gauge = meter.create_observable_gauge('gauge', unit: 'smidgen', description: 'a small amount of something', callback: callback)
-    observable_gauge.observe(timeout: 10, attributes: {'foo' => 'bar'})
+    observable_gauge.observe(timeout: 10, attributes: { 'foo' => 'bar' })
 
     metric_exporter.pull
     last_snapshot = metric_exporter.metric_snapshots.last

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/instrument/observable_up_down_counter_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/instrument/observable_up_down_counter_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+describe OpenTelemetry::SDK::Metrics::Instrument::ObservableUpDownCounter do
+  let(:metric_exporter) { OpenTelemetry::SDK::Metrics::Export::InMemoryMetricPullExporter.new }
+  let(:meter) { OpenTelemetry.meter_provider.meter('test') }
+
+  before do
+    reset_metrics_sdk
+    OpenTelemetry::SDK.configure
+    OpenTelemetry.meter_provider.add_metric_reader(metric_exporter)
+  end
+
+  it 'counts without observe' do
+    callback = Proc.new { 10 }
+    meter.create_observable_up_down_counter('updown_counter', unit: 'smidgen', description: 'a small amount of something', callback: callback)
+
+    metric_exporter.pull
+    last_snapshot = metric_exporter.metric_snapshots.last
+
+    _(last_snapshot[0].name).must_equal('updown_counter')
+    _(last_snapshot[0].unit).must_equal('smidgen')
+    _(last_snapshot[0].description).must_equal('a small amount of something')
+    _(last_snapshot[0].instrumentation_scope.name).must_equal('test')
+    _(last_snapshot[0].data_points[0].value).must_equal(10)
+    _(last_snapshot[0].data_points[0].attributes).must_equal({})
+    _(last_snapshot[0].aggregation_temporality).must_equal(:cumulative)
+  end
+
+  it 'counts with observe' do
+    callback = Proc.new { 10 }
+    up_down_counter = meter.create_observable_up_down_counter('updown_counter', unit: 'smidgen', description: 'a small amount of something', callback: callback)
+    up_down_counter.observe(timeout: 10, attributes: {'foo' => 'bar'})
+
+    metric_exporter.pull
+    last_snapshot = metric_exporter.metric_snapshots.last
+
+    _(last_snapshot[0].name).must_equal('updown_counter')
+    _(last_snapshot[0].unit).must_equal('smidgen')
+    _(last_snapshot[0].description).must_equal('a small amount of something')
+    _(last_snapshot[0].instrumentation_scope.name).must_equal('test')
+    _(last_snapshot[0].data_points[0].value).must_equal(10)
+    _(last_snapshot[0].data_points[0].attributes).must_equal('foo' => 'bar')
+
+    _(last_snapshot[0].data_points[1].value).must_equal(10)
+    _(last_snapshot[0].data_points[1].attributes).must_equal({})
+    _(last_snapshot[0].aggregation_temporality).must_equal(:cumulative)
+  end
+end

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/instrument/observable_up_down_counter_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/instrument/observable_up_down_counter_test.rb
@@ -17,7 +17,7 @@ describe OpenTelemetry::SDK::Metrics::Instrument::ObservableUpDownCounter do
   end
 
   it 'counts without observe' do
-    callback = Proc.new { 10 }
+    callback = proc { 10 }
     meter.create_observable_up_down_counter('updown_counter', unit: 'smidgen', description: 'a small amount of something', callback: callback)
 
     metric_exporter.pull
@@ -33,9 +33,9 @@ describe OpenTelemetry::SDK::Metrics::Instrument::ObservableUpDownCounter do
   end
 
   it 'counts with observe' do
-    callback = Proc.new { 10 }
+    callback = proc { 10 }
     up_down_counter = meter.create_observable_up_down_counter('updown_counter', unit: 'smidgen', description: 'a small amount of something', callback: callback)
-    up_down_counter.observe(timeout: 10, attributes: {'foo' => 'bar'})
+    up_down_counter.observe(timeout: 10, attributes: { 'foo' => 'bar' })
 
     metric_exporter.pull
     last_snapshot = metric_exporter.metric_snapshots.last

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/meter_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/meter_test.rb
@@ -34,21 +34,21 @@ describe OpenTelemetry::SDK::Metrics::Meter do
 
   describe '#create_observable_counter' do
     it 'creates a observable_counter instrument' do
-      instrument = meter.create_observable_counter('a_observable_counter', unit: 'minutes', description: 'useful description', callback: proc {10})
+      instrument = meter.create_observable_counter('a_observable_counter', unit: 'minutes', description: 'useful description', callback: proc { 10 })
       _(instrument).must_be_instance_of OpenTelemetry::SDK::Metrics::Instrument::ObservableCounter
     end
   end
 
   describe '#create_observable_gauge' do
     it 'creates a observable_gauge instrument' do
-      instrument = meter.create_observable_gauge('a_observable_gauge', unit: 'minutes', description: 'useful description', callback: proc {10})
+      instrument = meter.create_observable_gauge('a_observable_gauge', unit: 'minutes', description: 'useful description', callback: proc { 10 })
       _(instrument).must_be_instance_of OpenTelemetry::SDK::Metrics::Instrument::ObservableGauge
     end
   end
 
   describe '#create_observable_up_down_counter' do
     it 'creates a observable_up_down_counter instrument' do
-      instrument = meter.create_observable_up_down_counter('a_observable_up_down_counter', unit: 'minutes', description: 'useful description', callback: proc {10})
+      instrument = meter.create_observable_up_down_counter('a_observable_up_down_counter', unit: 'minutes', description: 'useful description', callback: proc { 10 })
       _(instrument).must_be_instance_of OpenTelemetry::SDK::Metrics::Instrument::ObservableUpDownCounter
     end
   end
@@ -65,20 +65,20 @@ describe OpenTelemetry::SDK::Metrics::Meter do
       end
 
       it 'create callback with multi asychronous instrument' do
-        callback_1 = Proc.new { 10 }
-        counter_1 = meter.create_observable_counter('counter_1', unit: 'smidgen', description: '', callback: callback_1)
-        counter_2 = meter.create_observable_counter('counter_2', unit: 'smidgen', description: '', callback: callback_1)
+        callback_first = proc { 10 }
+        counter_first  = meter.create_observable_counter('counter_first', unit: 'smidgen', description: '', callback: callback_first)
+        counter_second = meter.create_observable_counter('counter_second', unit: 'smidgen', description: '', callback: callback_first)
 
-        callback_2 = Proc.new { 20 }
-        meter.register_callback([counter_1, counter_2], callback_2)
+        callback_second = proc { 20 }
+        meter.register_callback([counter_first, counter_second], callback_second)
 
-        _(counter_1.instance_variable_get(:@callbacks).size).must_equal 2
-        _(counter_2.instance_variable_get(:@callbacks).size).must_equal 2
+        _(counter_first.instance_variable_get(:@callbacks).size).must_equal 2
+        _(counter_second.instance_variable_get(:@callbacks).size).must_equal 2
 
         metric_exporter.pull
         last_snapshot = metric_exporter.metric_snapshots.last
 
-        _(last_snapshot[0].name).must_equal('counter_1')
+        _(last_snapshot[0].name).must_equal('counter_first')
         _(last_snapshot[0].unit).must_equal('smidgen')
         _(last_snapshot[0].description).must_equal('')
         _(last_snapshot[0].instrumentation_scope.name).must_equal('test')
@@ -86,7 +86,7 @@ describe OpenTelemetry::SDK::Metrics::Meter do
         _(last_snapshot[0].data_points[0].attributes).must_equal({})
         _(last_snapshot[0].aggregation_temporality).must_equal(:delta)
 
-        _(last_snapshot[1].name).must_equal('counter_2')
+        _(last_snapshot[1].name).must_equal('counter_second')
         _(last_snapshot[1].unit).must_equal('smidgen')
         _(last_snapshot[1].description).must_equal('')
         _(last_snapshot[1].instrumentation_scope.name).must_equal('test')
@@ -96,20 +96,20 @@ describe OpenTelemetry::SDK::Metrics::Meter do
       end
 
       it 'remove callback with multi asychronous instrument' do
-        callback_1 = Proc.new { 10 }
-        counter_1 = meter.create_observable_counter('counter_1', unit: 'smidgen', description: '', callback: callback_1)
-        counter_2 = meter.create_observable_counter('counter_2', unit: 'smidgen', description: '', callback: callback_1)
+        callback_first = proc { 10 }
+        counter_first  = meter.create_observable_counter('counter_first', unit: 'smidgen', description: '', callback: callback_first)
+        counter_second = meter.create_observable_counter('counter_second', unit: 'smidgen', description: '', callback: callback_first)
 
-        callback_2 = Proc.new { 20 }
-        meter.register_callback([counter_1, counter_2], callback_2)
+        callback_second = proc { 20 }
+        meter.register_callback([counter_first, counter_second], callback_second)
 
-        _(counter_1.instance_variable_get(:@callbacks).size).must_equal 2
-        _(counter_2.instance_variable_get(:@callbacks).size).must_equal 2
+        _(counter_first.instance_variable_get(:@callbacks).size).must_equal 2
+        _(counter_second.instance_variable_get(:@callbacks).size).must_equal 2
 
         metric_exporter.pull
         last_snapshot = metric_exporter.metric_snapshots.last
 
-        _(last_snapshot[0].name).must_equal('counter_1')
+        _(last_snapshot[0].name).must_equal('counter_first')
         _(last_snapshot[0].unit).must_equal('smidgen')
         _(last_snapshot[0].description).must_equal('')
         _(last_snapshot[0].instrumentation_scope.name).must_equal('test')
@@ -117,7 +117,7 @@ describe OpenTelemetry::SDK::Metrics::Meter do
         _(last_snapshot[0].data_points[0].attributes).must_equal({})
         _(last_snapshot[0].aggregation_temporality).must_equal(:delta)
 
-        _(last_snapshot[1].name).must_equal('counter_2')
+        _(last_snapshot[1].name).must_equal('counter_second')
         _(last_snapshot[1].unit).must_equal('smidgen')
         _(last_snapshot[1].description).must_equal('')
         _(last_snapshot[1].instrumentation_scope.name).must_equal('test')
@@ -125,13 +125,13 @@ describe OpenTelemetry::SDK::Metrics::Meter do
         _(last_snapshot[1].data_points[0].attributes).must_equal({})
         _(last_snapshot[1].aggregation_temporality).must_equal(:delta)
 
-        # unregister the callback_2 from instruments counter_1 and counter_2
-        meter.unregister([counter_1, counter_2], callback_2)
+        # unregister the callback_second from instruments counter_first and counter_second
+        meter.unregister([counter_first, counter_second], callback_second)
 
         metric_exporter.pull
         last_snapshot = metric_exporter.metric_snapshots.last
 
-        _(last_snapshot[0].name).must_equal('counter_1')
+        _(last_snapshot[0].name).must_equal('counter_first')
         _(last_snapshot[0].unit).must_equal('smidgen')
         _(last_snapshot[0].description).must_equal('')
         _(last_snapshot[0].instrumentation_scope.name).must_equal('test')
@@ -139,7 +139,7 @@ describe OpenTelemetry::SDK::Metrics::Meter do
         _(last_snapshot[0].data_points[0].attributes).must_equal({})
         _(last_snapshot[0].aggregation_temporality).must_equal(:delta)
 
-        _(last_snapshot[1].name).must_equal('counter_2')
+        _(last_snapshot[1].name).must_equal('counter_second')
         _(last_snapshot[1].unit).must_equal('smidgen')
         _(last_snapshot[1].description).must_equal('')
         _(last_snapshot[1].instrumentation_scope.name).must_equal('test')

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/meter_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/meter_test.rb
@@ -34,28 +34,119 @@ describe OpenTelemetry::SDK::Metrics::Meter do
 
   describe '#create_observable_counter' do
     it 'creates a observable_counter instrument' do
-      # TODO: Implement observable instruments
-      skip
-      instrument = meter.create_observable_counter('a_observable_counter', unit: 'minutes', description: 'useful description', callback: nil)
+      instrument = meter.create_observable_counter('a_observable_counter', unit: 'minutes', description: 'useful description', callback: proc {10})
       _(instrument).must_be_instance_of OpenTelemetry::SDK::Metrics::Instrument::ObservableCounter
     end
   end
 
   describe '#create_observable_gauge' do
     it 'creates a observable_gauge instrument' do
-      # TODO: Implement observable instruments
-      skip
-      instrument = meter.create_observable_gauge('a_observable_gauge', unit: 'minutes', description: 'useful description', callback: nil)
+      instrument = meter.create_observable_gauge('a_observable_gauge', unit: 'minutes', description: 'useful description', callback: proc {10})
       _(instrument).must_be_instance_of OpenTelemetry::SDK::Metrics::Instrument::ObservableGauge
     end
   end
 
   describe '#create_observable_up_down_counter' do
     it 'creates a observable_up_down_counter instrument' do
-      # TODO: Implement observable instruments
-      skip
-      instrument = meter.create_observable_up_down_counter('a_observable_up_down_counter', unit: 'minutes', description: 'useful description', callback: nil)
+      instrument = meter.create_observable_up_down_counter('a_observable_up_down_counter', unit: 'minutes', description: 'useful description', callback: proc {10})
       _(instrument).must_be_instance_of OpenTelemetry::SDK::Metrics::Instrument::ObservableUpDownCounter
+    end
+  end
+
+  describe 'callback' do
+    describe '#register_callback' do
+      let(:metric_exporter) { OpenTelemetry::SDK::Metrics::Export::InMemoryMetricPullExporter.new }
+      let(:meter) { OpenTelemetry.meter_provider.meter('test') }
+
+      before do
+        reset_metrics_sdk
+        OpenTelemetry::SDK.configure
+        OpenTelemetry.meter_provider.add_metric_reader(metric_exporter)
+      end
+
+      it 'create callback with multi asychronous instrument' do
+        callback_1 = Proc.new { 10 }
+        counter_1 = meter.create_observable_counter('counter_1', unit: 'smidgen', description: '', callback: callback_1)
+        counter_2 = meter.create_observable_counter('counter_2', unit: 'smidgen', description: '', callback: callback_1)
+
+        callback_2 = Proc.new { 20 }
+        meter.register_callback([counter_1, counter_2], callback_2)
+
+        _(counter_1.instance_variable_get(:@callbacks).size).must_equal 2
+        _(counter_2.instance_variable_get(:@callbacks).size).must_equal 2
+
+        metric_exporter.pull
+        last_snapshot = metric_exporter.metric_snapshots.last
+
+        _(last_snapshot[0].name).must_equal('counter_1')
+        _(last_snapshot[0].unit).must_equal('smidgen')
+        _(last_snapshot[0].description).must_equal('')
+        _(last_snapshot[0].instrumentation_scope.name).must_equal('test')
+        _(last_snapshot[0].data_points[0].value).must_equal(30)
+        _(last_snapshot[0].data_points[0].attributes).must_equal({})
+        _(last_snapshot[0].aggregation_temporality).must_equal(:delta)
+
+        _(last_snapshot[1].name).must_equal('counter_2')
+        _(last_snapshot[1].unit).must_equal('smidgen')
+        _(last_snapshot[1].description).must_equal('')
+        _(last_snapshot[1].instrumentation_scope.name).must_equal('test')
+        _(last_snapshot[1].data_points[0].value).must_equal(30)
+        _(last_snapshot[1].data_points[0].attributes).must_equal({})
+        _(last_snapshot[1].aggregation_temporality).must_equal(:delta)
+      end
+
+      it 'remove callback with multi asychronous instrument' do
+        callback_1 = Proc.new { 10 }
+        counter_1 = meter.create_observable_counter('counter_1', unit: 'smidgen', description: '', callback: callback_1)
+        counter_2 = meter.create_observable_counter('counter_2', unit: 'smidgen', description: '', callback: callback_1)
+
+        callback_2 = Proc.new { 20 }
+        meter.register_callback([counter_1, counter_2], callback_2)
+
+        _(counter_1.instance_variable_get(:@callbacks).size).must_equal 2
+        _(counter_2.instance_variable_get(:@callbacks).size).must_equal 2
+
+        metric_exporter.pull
+        last_snapshot = metric_exporter.metric_snapshots.last
+
+        _(last_snapshot[0].name).must_equal('counter_1')
+        _(last_snapshot[0].unit).must_equal('smidgen')
+        _(last_snapshot[0].description).must_equal('')
+        _(last_snapshot[0].instrumentation_scope.name).must_equal('test')
+        _(last_snapshot[0].data_points[0].value).must_equal(30)
+        _(last_snapshot[0].data_points[0].attributes).must_equal({})
+        _(last_snapshot[0].aggregation_temporality).must_equal(:delta)
+
+        _(last_snapshot[1].name).must_equal('counter_2')
+        _(last_snapshot[1].unit).must_equal('smidgen')
+        _(last_snapshot[1].description).must_equal('')
+        _(last_snapshot[1].instrumentation_scope.name).must_equal('test')
+        _(last_snapshot[1].data_points[0].value).must_equal(30)
+        _(last_snapshot[1].data_points[0].attributes).must_equal({})
+        _(last_snapshot[1].aggregation_temporality).must_equal(:delta)
+
+        # unregister the callback_2 from instruments counter_1 and counter_2
+        meter.unregister([counter_1, counter_2], callback_2)
+
+        metric_exporter.pull
+        last_snapshot = metric_exporter.metric_snapshots.last
+
+        _(last_snapshot[0].name).must_equal('counter_1')
+        _(last_snapshot[0].unit).must_equal('smidgen')
+        _(last_snapshot[0].description).must_equal('')
+        _(last_snapshot[0].instrumentation_scope.name).must_equal('test')
+        _(last_snapshot[0].data_points[0].value).must_equal(10)
+        _(last_snapshot[0].data_points[0].attributes).must_equal({})
+        _(last_snapshot[0].aggregation_temporality).must_equal(:delta)
+
+        _(last_snapshot[1].name).must_equal('counter_2')
+        _(last_snapshot[1].unit).must_equal('smidgen')
+        _(last_snapshot[1].description).must_equal('')
+        _(last_snapshot[1].instrumentation_scope.name).must_equal('test')
+        _(last_snapshot[1].data_points[0].value).must_equal(10)
+        _(last_snapshot[1].data_points[0].attributes).must_equal({})
+        _(last_snapshot[1].aggregation_temporality).must_equal(:delta)
+      end
     end
   end
 end


### PR DESCRIPTION
## Description

I'd like to make contribution on basic implementation on asynchronous metrics.

Related: https://github.com/open-telemetry/opentelemetry-ruby/issues/1386, [Asynchronous Up Down Counter card](https://github.com/open-telemetry/opentelemetry-ruby/projects/2#card-84597629), [Asynchronous Gauge](https://github.com/open-telemetry/opentelemetry-ruby/projects/2#card-84597614).
Spec: [asynchronous-instrument-api](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#asynchronous-instrument-api)

WIP:
1. when multiple callbacks exist in single instrument, they may all impose (accumulative) modification on data points, which need further consideration of use case.