### PR TITLE
fix: ForwardingLogger should foward block param

### DIFF
--- a/sdk/lib/opentelemetry/sdk/forwarding_logger.rb
+++ b/sdk/lib/opentelemetry/sdk/forwarding_logger.rb
@@ -35,10 +35,10 @@ module OpenTelemetry
         end
       end
 
-      def add(severity, message = nil, progname = nil)
+      def add(severity, message = nil, progname = nil, &block)
         return true if severity < @level
 
-        @logger.add(severity, message, progname)
+        @logger.add(severity, message, progname, &block)
       end
 
       def debug(progname = nil, &block)


### PR DESCRIPTION
Also added tests to verify the default forwarding logger level, and to make sure it actually forwards logs.

Fixes #1599