### PR TITLE
Fix/change some messaging attributes to match conventions

### DIFF
--- a/semantic_conventions/lib/opentelemetry/semantic_conventions/trace.rb
+++ b/semantic_conventions/lib/opentelemetry/semantic_conventions/trace.rb
@@ -421,6 +421,9 @@ module OpenTelemetry
       # @note If the key type is not string, it's string representation has to be supplied for the attribute. If the key has no unambiguous, canonical string form, don't include its value
       MESSAGING_KAFKA_MESSAGE_KEY = 'messaging.kafka.message.key'
 
+      # The offset of a record in the corresponding Kafka partition
+      MESSAGING_KAFKA_MESSAGE_OFFSET = 'messaging.kafka.message.offset'
+
       # Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers
       MESSAGING_KAFKA_CONSUMER_GROUP = 'messaging.kafka.consumer.group'
 

--- a/semantic_conventions/lib/opentelemetry/semantic_conventions/trace.rb
+++ b/semantic_conventions/lib/opentelemetry/semantic_conventions/trace.rb
@@ -419,7 +419,7 @@ module OpenTelemetry
 
       # Message keys in Kafka are used for grouping alike messages to ensure they're processed on the same partition. They differ from `messaging.message_id` in that they're not unique. If the key is `null`, the attribute MUST NOT be set
       # @note If the key type is not string, it's string representation has to be supplied for the attribute. If the key has no unambiguous, canonical string form, don't include its value
-      MESSAGING_KAFKA_MESSAGE_KEY = 'messaging.kafka.message_key'
+      MESSAGING_KAFKA_MESSAGE_KEY = 'messaging.kafka.message.key'
 
       # Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers
       MESSAGING_KAFKA_CONSUMER_GROUP = 'messaging.kafka.consumer.group'

--- a/semantic_conventions/lib/opentelemetry/semantic_conventions/trace.rb
+++ b/semantic_conventions/lib/opentelemetry/semantic_conventions/trace.rb
@@ -117,13 +117,13 @@ module OpenTelemetry
       #  This may be actually "in flight" in some languages (e.g. if the exception
       #  is passed to a Context manager's `__exit__` method in Python) but will
       #  usually be caught at the point of recording the exception in most languages.
-      #  
+      #
       #  It is usually not possible to determine at the point where an exception is thrown
       #  whether it will escape the scope of a span.
       #  However, it is trivial to know that an exception
       #  will escape, if one checks for an active exception just before ending the span,
       #  as done in the [example above](#recording-an-exception).
-      #  
+      #
       #  It follows that an exception may still escape the scope of the span
       #  even if the `exception.escaped` attribute was not set or set to false,
       #  since the event might have been recorded at a time where it was not
@@ -133,7 +133,7 @@ module OpenTelemetry
       # Type of the trigger which caused this function execution
       # @note For the server/consumer span on the incoming side,
       #  `faas.trigger` MUST be set.
-      #  
+      #
       #  Clients invoking FaaS instances usually cannot set `faas.trigger`,
       #  since they would typically need to look in the payload to determine
       #  the event type. If clients set it, it should be the same as the
@@ -209,7 +209,7 @@ module OpenTelemetry
       # The IP address of the original client behind all proxies, if known (e.g. from [X-Forwarded-For](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For))
       # @note This is not necessarily the same as `net.peer.ip`, which would
       #  identify the network-level peer, which may be a proxy.
-      #  
+      #
       #  This attribute should be set when a source of information different
       #  from the one used for `net.peer.ip`, is available even if that other
       #  source just confirms the same value as `net.peer.ip`.

--- a/semantic_conventions/lib/opentelemetry/semantic_conventions/trace.rb
+++ b/semantic_conventions/lib/opentelemetry/semantic_conventions/trace.rb
@@ -427,8 +427,11 @@ module OpenTelemetry
       # Client Id for the Consumer or Producer that is handling the message
       MESSAGING_KAFKA_CLIENT_ID = 'messaging.kafka.client_id'
 
-      # Partition the message is sent to
+      # Deprecated, use `MESSAGING_KAFKA_DESTINATION_PARTITION` instead
       MESSAGING_KAFKA_PARTITION = 'messaging.kafka.partition'
+
+      # Partition the message is sent to
+      MESSAGING_KAFKA_DESTINATION_PARTITION = 'messaging.kafka.destination.partition'
 
       # A boolean that is true if the message is a tombstone
       MESSAGING_KAFKA_TOMBSTONE = 'messaging.kafka.tombstone'

--- a/semantic_conventions/lib/opentelemetry/semantic_conventions/trace.rb
+++ b/semantic_conventions/lib/opentelemetry/semantic_conventions/trace.rb
@@ -422,7 +422,7 @@ module OpenTelemetry
       MESSAGING_KAFKA_MESSAGE_KEY = 'messaging.kafka.message_key'
 
       # Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers
-      MESSAGING_KAFKA_CONSUMER_GROUP = 'messaging.kafka.consumer_group'
+      MESSAGING_KAFKA_CONSUMER_GROUP = 'messaging.kafka.consumer.group'
 
       # Client Id for the Consumer or Producer that is handling the message
       MESSAGING_KAFKA_CLIENT_ID = 'messaging.kafka.client_id'

--- a/semantic_conventions/lib/opentelemetry/semantic_conventions/trace.rb
+++ b/semantic_conventions/lib/opentelemetry/semantic_conventions/trace.rb
@@ -411,6 +411,9 @@ module OpenTelemetry
       # A string identifying the kind of message consumption as defined in the [Operation names](#operation-names) section above. If the operation is "send", this attribute MUST NOT be set, since the operation can be inferred from the span kind in that case
       MESSAGING_OPERATION = 'messaging.operation'
 
+      # The number of messages sent, received, or processed in the scope of the batching operation
+      MESSAGING_BATCH_MESSAGE_COUNT = 'messaging.batch.message_count'
+
       # The identifier for the consumer receiving a message. For Kafka, set it to `{messaging.kafka.consumer_group} - {messaging.kafka.client_id}`, if both are present, or only `messaging.kafka.consumer_group`. For brokers, such as RabbitMQ and Artemis, set it to the `client_id` of the client consuming the message
       MESSAGING_CONSUMER_ID = 'messaging.consumer_id'
 


### PR DESCRIPTION
I used `opentelemetry-semantic_conventions` in one of my projects and noticed that some attributes are different from the docs on following pages:
- https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/#messaging-attributes
- https://opentelemetry.io/docs/specs/semconv/messaging/kafka/

All kafka attributes described in docs are present in `opentelemetry-semantic_conventions` gem now.
Messaging batch count is added because I wat to use it in my code and it was missing before.