### PR TITLE
Record stats for serialization time

### DIFF
--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -271,6 +271,7 @@ module OpenTelemetry
         end
 
         def encode(span_data) # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
+          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           Opentelemetry::Proto::Collector::Trace::V1::ExportTraceServiceRequest.encode(
             Opentelemetry::Proto::Collector::Trace::V1::ExportTraceServiceRequest.new(
               resource_spans: span_data
@@ -298,6 +299,11 @@ module OpenTelemetry
         rescue StandardError => e
           OpenTelemetry.handle_error(exception: e, message: 'unexpected error in OTLP::Exporter#encode')
           nil
+        ensure
+          stop = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          duration_ms = 1000.0 * (stop - start)
+          @metrics_reporter.record_value('otel.otlp_exporter.encode_duration',
+                                         value: duration_ms)
         end
 
         def as_otlp_span(span_data) # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity


### PR DESCRIPTION
Serialization takes place during export and is a resource-intensive process; users may want to see how long it takes.

#### Remnants of earlier approach 

~~I had to prove to myself that the value returned from a block passed to a block-handling function will be returned from the block-handling function even when there's an `ensure` in that function (I was worried that something from the `ensure` block would be returned). For documentation, I'll reproduce that experiment here:~~

~~Given the Ruby~~
```ruby
def mymethod
  "return from mymethod"
end

def wrap_mymethod
  begin
    yield
  ensure
    puts "Ensure ran within wrap_mymethod"
  end
end


ret = wrap_mymethod { mymethod }

puts "Return value from `wrap_mymethod`: #{ret}"
```

~~Yields output:~~ 
```
ruby yield.rb
Ensure ran within wrap_mymethod
Return value from `wrap_mymethod`: return from mymethod
```
