### PR TITLE
feat: add untraced ctx method

### DIFF
--- a/common/.rubocop.yml
+++ b/common/.rubocop.yml
@@ -6,6 +6,8 @@ Bundler/OrderedGems:
 Style/FrozenStringLiteralComment:
   Exclude:
     - gemfiles/**/*
+Style/ExplicitBlockArgument:
+  Enabled: false
 Style/StringLiterals:
   Exclude:
     - gemfiles/**/*

--- a/common/lib/opentelemetry/common/utilities.rb
+++ b/common/lib/opentelemetry/common/utilities.rb
@@ -89,9 +89,12 @@ module OpenTelemetry
       end
 
       # Disables tracing within the provided block.
-      def untraced
-        Context.with_value(UNTRACED_KEY, true) do |ctx, _|
-          yield ctx
+      def untraced(context = Context.current)
+        context = context.set_value(UNTRACED_KEY, true)
+        if block_given?
+          Context.with_current(context) { |ctx| yield ctx }
+        else
+          context
         end
       end
 

--- a/common/lib/opentelemetry/common/utilities.rb
+++ b/common/lib/opentelemetry/common/utilities.rb
@@ -88,7 +88,11 @@ module OpenTelemetry
         end
       end
 
-      # Disables tracing within the provided block.
+      # Disables tracing within the provided block
+      # If no block is provided instead returns an
+      # untraced ctx.
+      #
+      # @param [optional Context] context Accepts an explicit context, defaults to current
       def untraced(context = Context.current)
         context = context.set_value(UNTRACED_KEY, true)
         if block_given?

--- a/common/test/opentelemetry/common/utilities_test.rb
+++ b/common/test/opentelemetry/common/utilities_test.rb
@@ -26,6 +26,13 @@ describe OpenTelemetry::Common::Utilities do
       common_utils.untraced {}
       assert_equal(false, common_utils.untraced?)
     end
+
+    it 'supports non block format' do
+      token = OpenTelemetry::Context.attach(common_utils.untraced)
+      assert_equal(true, common_utils.untraced?)
+      OpenTelemetry::Context.detach(token)
+      assert_equal(false, common_utils.untraced?)
+    end
   end
 
   describe '#utf8_encode' do


### PR DESCRIPTION
Support untraced usage in a non block structure https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/965#issuecomment-2099275533