### PR TITLE
chore: bump ruby/setup-ruby from 1.165.1 to 1.176.0

### DIFF
--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -58,7 +58,7 @@ runs:
     # ...but not for appraisals, sadly.
     - name: Install Ruby ${{ inputs.ruby }} with dependencies
       if: "${{ steps.setup.outputs.appraisals == 'false' }}"
-      uses: ruby/setup-ruby@v1.165.1
+      uses: ruby/setup-ruby@v1.176.0
       with:
         ruby-version: "${{ inputs.ruby }}"
         working-directory: "${{ steps.setup.outputs.gem_dir }}"
@@ -69,7 +69,7 @@ runs:
     # If we're using appraisals, do it all manually.
     - name: Install Ruby ${{ inputs.ruby }} without dependencies
       if: "${{ steps.setup.outputs.appraisals == 'true' }}"
-      uses: ruby/setup-ruby@v1.165.1
+      uses: ruby/setup-ruby@v1.176.0
       with:
         ruby-version: "${{ inputs.ruby }}"
         bundler:  "latest"

--- a/.github/workflows/release-hook-on-closed.yml
+++ b/.github/workflows/release-hook-on-closed.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}
-        uses: ruby/setup-ruby@v1.165.1
+        uses: ruby/setup-ruby@v1.176.0
         with:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo

--- a/.github/workflows/release-hook-on-push.yml
+++ b/.github/workflows/release-hook-on-push.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}
-        uses: ruby/setup-ruby@v1.165.1
+        uses: ruby/setup-ruby@v1.176.0
         with:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo

--- a/.github/workflows/release-perform.yml
+++ b/.github/workflows/release-perform.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}
-        uses: ruby/setup-ruby@v1.165.1
+        uses: ruby/setup-ruby@v1.176.0
         with:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo

--- a/.github/workflows/release-request.yml
+++ b/.github/workflows/release-request.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}
-        uses: ruby/setup-ruby@v1.165.1
+        uses: ruby/setup-ruby@v1.176.0
         with:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo

--- a/.github/workflows/release-retry.yml
+++ b/.github/workflows/release-retry.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Ruby ${{ env.ruby_version }}
-        uses: ruby/setup-ruby@v1.165.1
+        uses: ruby/setup-ruby@v1.176.0
         with:
           ruby-version: ${{ env.ruby_version }}
       - name: Checkout repo


### PR DESCRIPTION
To fix an error[1] on macos runners resolved in v1.171.0[2]:

    The current runner (macos-14-arm64) was detected as self-hosted
    because the platform does not match a GitHub-hosted runner image
    (or that imageis deprecated and no longer supported).

[1] https://github.com/ruby/setup-ruby/issues/568
[2] https://github.com/ruby/setup-ruby/pull/567