### PR TITLE
docs: Add ruby compatibility documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ The [opentelemetry-ruby-contrib repository][contrib-repo] contains instrumentati
 
 OpenTelemetry Ruby follows the [versioning and stability document][otel-versioning] in the OpenTelemetry specification. Notably, we adhere to the outlined version numbering exception, which states that experimental signals may have a `0.x` version number.
 
+## Compatibility
+
+OpenTelemetry Ruby ensures compatibility with the current supported versions of
+the [Ruby language](https://www.ruby-lang.org/en/downloads/branches/).
+
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>


### PR DESCRIPTION
This is a proposal to document the supported ruby versions in the README, so folks know what to expect.