### PR TITLE
fix: Add csv as a dependency for Ruby 3.4

### DIFF
--- a/exporter/otlp/opentelemetry-exporter-otlp.gemspec
+++ b/exporter/otlp/opentelemetry-exporter-otlp.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 3.0'
 
+  spec.add_dependency 'csv', '~> 3.1'
   spec.add_dependency 'googleapis-common-protos-types', '~> 1.3'
   spec.add_dependency 'google-protobuf', '>= 3.18'
   spec.add_dependency 'opentelemetry-api', '~> 1.1'


### PR DESCRIPTION
csv has been a default gem for a long while. In Ruby 3.4, it will stop being a default gem and will need to be explicitly required as a dependency.

> warning: /opt/rubies/3.3.1/lib/ruby/3.3.0/csv.rb was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec. Also contact author of opentelemetry-exporter-otlp-0.26.1 to add csv into its gemspec.

This change adds it as a dependency for the OTLP exporter since it makes use of the library. It uses the same version constraint as the Zipkin exporter for consistency.

See eb89cd62f5df71886651f87f38824cbcb6e47251 for a similar change.