### PR TITLE
ci: Prevent stale action runs on forks

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   stale:
-
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby' }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Today, I noticed the stalebot is running regularly on my fork. I'm not sure if this is the best choice. 

Limiting it to the main repo will allow users to keep PRs they've prepped on their forks, but aren't ready to open on the main repo, free from interference. Plus, we might save some unnecessary GHA runs 🌲 🌎 