### PR TITLE
feat: coerce OpenTelemetry::Trace::Status.description to String

### DIFF
--- a/api/lib/opentelemetry/trace/status.rb
+++ b/api/lib/opentelemetry/trace/status.rb
@@ -59,7 +59,7 @@ module OpenTelemetry
       # @param [String] description
       def initialize(code, description: '')
         @code = code
-        @description = description
+        @description = description.to_s
       end
 
       # Returns false if this {Status} represents an error, else returns true.

--- a/api/test/opentelemetry/trace/status_test.rb
+++ b/api/test/opentelemetry/trace/status_test.rb
@@ -26,6 +26,11 @@ describe OpenTelemetry::Trace::Status do
       status = OpenTelemetry::Trace::Status.ok('ok')
       _(status.description).must_equal('ok')
     end
+
+    it 'coerces the value passed in' do
+      status = OpenTelemetry::Trace::Status.ok(true)
+      _(status.description).must_equal('true')
+    end
   end
 
   describe '.ok?' do


### PR DESCRIPTION
Accepting non string values results in obscure errors when exporting traces.

----

The motivation for this PR is due to me spending a chunk of hours trying to track down an error I was seeing in our logs.

The error was: `OpenTelemetry error: unexpected error in OTLP::Exporter#encode - Invalid argument for string field 'message' (given Class).`

This was pretty obscure to me it took a while to get to the bottom of it. As it turned out it was because I was passing a class to Status like so `OpenTelemetry::Trace::Status.error(e.class)`. I dunno how I didn't see this issue before in testing or if behaviour has changes in recent versions, but in any case it was painful to debug especially as someone not familiar with the OTEL API/SDK.

Unsure what the maintainers will think of this but I feel the DX could be improved with more leniency in what is accepted or improved logging.