### PR TITLE
chore: Add CI for Logs SDK, Rubocop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           - opentelemetry-api
           - opentelemetry-common
           - opentelemetry-logs-api
+          - opentelemetry-logs-sdk
           - opentelemetry-metrics-api
           - opentelemetry-metrics-sdk
           - opentelemetry-registry

--- a/logs_sdk/lib/opentelemetry/sdk/logs/log_record.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/log_record.rb
@@ -101,7 +101,7 @@ module OpenTelemetry
         def to_integer_nanoseconds(timestamp)
           return unless timestamp.is_a?(Time)
 
-          t = (timestamp.to_r * 10**9).to_i
+          (timestamp.to_r * 10**9).to_i
         end
       end
     end

--- a/logs_sdk/lib/opentelemetry/sdk/logs/log_record_data.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/log_record_data.rb
@@ -12,11 +12,8 @@ module OpenTelemetry
                                  :observed_timestamp,        # Integer nanoseconds since Epoch
                                  :severity_text,             # optional String
                                  :severity_number,           # optional Integer
-                                 :body,                      # optional String, Numeric, Boolean, Array<String, Numeric,
-                                                             #   Boolean>, Hash{String => String, Numeric, Boolean,
-                                                             #   Array<String, Numeric, Boolean>}
-                                 :attributes,                # optional Hash{String => String, Numeric, Boolean,
-                                                             #   Array<String, Numeric, Boolean>}
+                                 :body,                      # optional String, Numeric, Boolean, Array<String, Numeric, Boolean>, Hash{String => String, Numeric, Boolean, Array<String, Numeric, Boolean>}
+                                 :attributes, # optional Hash{String => String, Numeric, Boolean, Array<String, Numeric, Boolean>}
                                  :trace_id,                  # optional String (16-byte binary)
                                  :span_id,                   # optional String (8-byte binary)
                                  :trace_flags,               # optional Integer (8-bit byte of bit flags)

--- a/logs_sdk/lib/opentelemetry/sdk/logs/logger.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/logger.rb
@@ -74,16 +74,16 @@ module OpenTelemetry
           span_context = current_span.context unless current_span == OpenTelemetry::Trace::Span::INVALID
 
           @logger_provider.on_emit(timestamp: timestamp,
-                                  observed_timestamp: observed_timestamp,
-                                  severity_text: severity_text,
-                                  severity_number: severity_number,
-                                  body: body,
-                                  attributes: attributes,
-                                  trace_id: trace_id || span_context&.trace_id,
-                                  span_id: span_id || span_context&.span_id,
-                                  trace_flags: trace_flags || span_context&.trace_flags,
-                                  instrumentation_scope: @instrumentation_scope,
-                                  context: context)
+                                   observed_timestamp: observed_timestamp,
+                                   severity_text: severity_text,
+                                   severity_number: severity_number,
+                                   body: body,
+                                   attributes: attributes,
+                                   trace_id: trace_id || span_context&.trace_id,
+                                   span_id: span_id || span_context&.span_id,
+                                   trace_flags: trace_flags || span_context&.trace_flags,
+                                   instrumentation_scope: @instrumentation_scope,
+                                   context: context)
         end
       end
     end

--- a/logs_sdk/test/opentelemetry/sdk/logs/log_record_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/log_record_test.rb
@@ -83,8 +83,8 @@ describe OpenTelemetry::SDK::Logs::LogRecord do
       it 'transforms the LogRecord into a LogRecordData' do
         log_record_data = log_record.to_log_record_data
 
-        assert_equal(args[:timestamp].strftime("%s%N").to_i, log_record_data.timestamp)
-        assert_equal(args[:observed_timestamp].strftime("%s%N").to_i, log_record_data.observed_timestamp)
+        assert_equal(args[:timestamp].strftime('%s%N').to_i, log_record_data.timestamp)
+        assert_equal(args[:observed_timestamp].strftime('%s%N').to_i, log_record_data.observed_timestamp)
         assert_equal(args[:severity_text], log_record_data.severity_text)
         assert_equal(args[:severity_number], log_record_data.severity_number)
         assert_equal(args[:body], log_record_data.body)

--- a/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/logger_provider_test.rb
@@ -192,7 +192,7 @@ describe OpenTelemetry::SDK::Logs::LoggerProvider do
         span_id: span_context.span_id,
         trace_flags: span_context.trace_flags,
         instrumentation_scope: OpenTelemetry::SDK::InstrumentationScope,
-        context: mock_context,
+        context: mock_context
       }
     end
 


### PR DESCRIPTION
The CI was missing the `opentelemetry-logs-sdk` from the gem matrix. 

Now that it's present, Rubocop will run, so this PR fixes those errors too.