### PR TITLE
Runs the processors before finishing the span

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/span.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span.rb
@@ -265,6 +265,7 @@ module OpenTelemetry
         #
         # @return [self] returns itself
         def finish(end_timestamp: nil)
+          @span_processors.each { |processor| processor.on_finish(self) }
           @mutex.synchronize do
             if @ended
               OpenTelemetry.logger.warn('Calling finish on an ended Span.')
@@ -276,7 +277,6 @@ module OpenTelemetry
             @links.freeze
             @ended = true
           end
-          @span_processors.each { |processor| processor.on_finish(self) }
           self
         end
 


### PR DESCRIPTION
Hi 👋🏼  

This Pull Request simply moves the processors call to the beginning of the `finish()` method. 

### Why?
Otherwise, you can't modify the span getting finished. Processors [are run AFTER](https://github.com/open-telemetry/opentelemetry-ruby/blob/21717b5d4d676a6ffd23a0f6c333d19f5dfd9656/sdk/lib/opentelemetry/sdk/trace/span.rb#L279) the span `@ended` variable 
gets [updated to](https://github.com/open-telemetry/opentelemetry-ruby/blob/21717b5d4d676a6ffd23a0f6c333d19f5dfd9656/sdk/lib/opentelemetry/sdk/trace/span.rb#L277) `true`. Thus, the span is locked for changes.

### Real use case
Suppose you want to add extra attributes to you spans on the way out the door. 

Therefore, you can create a custom processor by implementing a child class of 
`OpenTelemetry::SDK::Trace::SpanProcessor` and overriding the method `on_finish()`.  
This method receives the span getting finished and you can then add new attributes, right?

Not exactly, cause by calling `add_attributes` you receive an error: `Calling add_attributes on an ended Span`. 
Whit that, my personal assumption is that you can not do anything useful inside `on_finish()` method
of a custom Processor cause the span will always be `@ended` when this method is called. 

### The changes
This PR makes the span `finish()` method to iterate calling every Processor BEFORE actually ending 
the span. It will allow processors to modify spans before actually finishing it. 

### Other argument: on_start method
If you look at the way this Span class calls `on_start` method, you will see it being the [last thing](https://github.com/open-telemetry/opentelemetry-ruby/blob/21717b5d4d676a6ffd23a0f6c333d19f5dfd9656/sdk/lib/opentelemetry/sdk/trace/span.rb#L362) in the
`initialize()` method. That makes sense, we first create the span, then we call each processor for that particular span. 

The `on_finish()` method should do the opposite: run processors FIRST, then finish the span. Does it make sense?  

### Considerations
Please, let me know in case you folks think I should do something else for this PR. 
