### PR TITLE
chore: Loosen metrics gems versions on otlp exporter

### DIFF
--- a/exporter/otlp-metrics/opentelemetry-exporter-otlp-metrics.gemspec
+++ b/exporter/otlp-metrics/opentelemetry-exporter-otlp-metrics.gemspec
@@ -29,8 +29,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'google-protobuf', '>= 3.18', '< 5.0'
   spec.add_dependency 'opentelemetry-api', '~> 1.1'
   spec.add_dependency 'opentelemetry-common', '~> 0.20'
-  spec.add_dependency 'opentelemetry-metrics-api', '~> 0.1.0'
-  spec.add_dependency 'opentelemetry-metrics-sdk', '~> 0.1.0'
+  spec.add_dependency 'opentelemetry-metrics-api', '~> 0.1'
+  spec.add_dependency 'opentelemetry-metrics-sdk', '~> 0.2'
   spec.add_dependency 'opentelemetry-sdk', '~> 1.2'
   spec.add_dependency 'opentelemetry-semantic_conventions'
 


### PR DESCRIPTION
The OTLP metrics exporter fails to install for tests because the latest metrics SDK is newer than the previous version constraint. The rest of the gems are installed based on minor versions. Now metrics_sdk/metrics_api are in sync.