### PR TITLE
test: Fix intermittent logs test failures

### DIFF
--- a/logs_sdk/test/opentelemetry/sdk/logs/export/batch_log_record_processor_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/export/batch_log_record_processor_test.rb
@@ -188,19 +188,19 @@ describe OpenTelemetry::SDK::Logs::Export::BatchLogRecordProcessor do
     it 'removes the older log records from the batch if full' do
       processor = BatchLogRecordProcessor.new(TestExporter.new, max_queue_size: 1, max_export_batch_size: 1)
 
-      older_log_record = TestLogRecord.new
-      newer_log_record = TestLogRecord.new
-      newest_log_record = TestLogRecord.new
+      # Don't actually try to export, we're looking at the log records array
+      processor.stub(:work, nil) do
+        older_log_record = TestLogRecord.new
+        newest_log_record = TestLogRecord.new
 
-      processor.on_emit(older_log_record, mock_context)
-      processor.on_emit(newer_log_record, mock_context)
-      processor.on_emit(newest_log_record, mock_context)
+        processor.on_emit(older_log_record, mock_context)
+        processor.on_emit(newest_log_record, mock_context)
 
-      records = processor.instance_variable_get(:@log_records)
+        records = processor.instance_variable_get(:@log_records)
 
-      assert_includes(records, newest_log_record)
-      refute_includes(records, newer_log_record)
-      refute_includes(records, older_log_record)
+        assert_includes(records, newest_log_record)
+        refute_includes(records, older_log_record)
+      end
     end
 
     it 'logs a warning if a log record was emitted after the buffer is full' do
@@ -469,18 +469,21 @@ describe OpenTelemetry::SDK::Logs::Export::BatchLogRecordProcessor do
     let(:processor) { BatchLogRecordProcessor.new(exporter) }
 
     it 'reports export failures' do
-      mock_logger = Minitest::Mock.new
-      mock_logger.expect(:error, nil, [/Unable to export/])
-      mock_logger.expect(:error, nil, [/Result code: 1/])
-      mock_logger.expect(:error, nil, [/unexpected error in .*\#export_batch/])
+      # skip the work method's behavior, we rely on shutdown to get us to the failures
+      processor.stub(:work, nil) do
+        mock_logger = Minitest::Mock.new
+        mock_logger.expect(:error, nil, [/Unable to export/])
+        mock_logger.expect(:error, nil, [/Result code: 1/])
+        mock_logger.expect(:error, nil, [/unexpected error in .*\#export_batch/])
 
-      OpenTelemetry.stub(:logger, mock_logger) do
-        log_records = [TestLogRecord.new, TestLogRecord.new, TestLogRecord.new, TestLogRecord.new]
-        log_records.each { |log_record| processor.on_emit(log_record, mock_context) }
-        processor.shutdown
+        OpenTelemetry.stub(:logger, mock_logger) do
+          log_records = [TestLogRecord.new, TestLogRecord.new, TestLogRecord.new, TestLogRecord.new]
+          log_records.each { |log_record| processor.on_emit(log_record, mock_context) }
+          processor.shutdown
+        end
+
+        mock_logger.verify
       end
-
-      mock_logger.verify
     end
   end
 


### PR DESCRIPTION
Some tests in BatchLogRecordProcessor had timing issues due to the work method. Since we don't rely on that method for these tests, stub the work method to do nothing.

Co-authored-by: @tannalynn 

Closes #1701

**Note:** A few open PRs contain skips for these tests. The skips should be removed once this PR is merged.