### PR TITLE
fix: update references to logging exporter

### DIFF
--- a/examples/metrics_sdk/README.md
+++ b/examples/metrics_sdk/README.md
@@ -36,8 +36,8 @@ receivers:
       # Default endpoints: 0.0.0.0:4317 for gRPC and 0.0.0.0:4318 for HTTP
 
 exporters:
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
 
 processors:
   batch:
@@ -47,11 +47,11 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]
 ```
 
 More information on how to setup the OTel collector can be found in the in [quick start docs](https://opentelemetry.io/docs/collector/quick-start/).

--- a/examples/otel-collector/.env
+++ b/examples/otel-collector/.env
@@ -1,2 +1,2 @@
-OTELCOL_IMG=otel/opentelemetry-collector-contrib:0.35.0
+OTELCOL_IMG=otel/opentelemetry-collector-contrib:0.109.0
 OTELCOL_ARGS=

--- a/examples/otel-collector/otel-collector-config.yaml
+++ b/examples/otel-collector/otel-collector-config.yaml
@@ -3,6 +3,7 @@ receivers:
   otlp:
     protocols:
       http:
+        endpoint: 0.0.0.0:4318
 
 exporters:
   debug:
@@ -11,9 +12,10 @@ exporters:
     endpoint: "http://zipkin-all-in-one:9411/api/v2/spans"
     format: proto
 
-  jaeger:
-    endpoint: jaeger-all-in-one:14250
-    insecure: true
+  otlp:
+    endpoint: jaeger-all-in-one:4317
+    tls:
+      insecure: true
 
 processors:
   batch:
@@ -23,7 +25,7 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [debug, zipkin, jaeger]
+      exporters: [debug, zipkin, otlp]
     metrics:
       receivers: [otlp]
       processors: [batch]

--- a/examples/otel-collector/otel-collector-config.yaml
+++ b/examples/otel-collector/otel-collector-config.yaml
@@ -5,7 +5,7 @@ receivers:
       http:
 
 exporters:
-  logging:
+  debug:
 
   zipkin:
     endpoint: "http://zipkin-all-in-one:9411/api/v2/spans"
@@ -23,8 +23,8 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, zipkin, jaeger]
+      exporters: [debug, zipkin, jaeger]
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]


### PR DESCRIPTION
This exporter has been replaced by the debug exporter and will be removed soon

Related to https://github.com/open-telemetry/opentelemetry-collector/pull/11037