### PR TITLE
chore: promote kaylareopelle to maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Approvers ([@open-telemetry/ruby-approvers](https://github.com/orgs/open-telemet
 - [Andrew Hayworth](https://github.com/ahayworth), Shopify
 - [Sam Handler](https://github.com/plantfansam), Shopify
 - [Robb Kidd](https://github.com/robbkidd), Honeycomb
-- [Kayla Reopelle](https://github.com/kaylareopelle), New Relic
 
 *Find more about the approver role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver).*
 
@@ -43,6 +42,7 @@ Maintainers ([@open-telemetry/ruby-maintainers](https://github.com/orgs/open-tel
 - [Francis Bogsanyi](https://github.com/fbogsany), Shopify
 - [Matthew Wear](https://github.com/mwear), Lightstep
 - [Daniel Azuma](https://github.com/dazuma), Google
+- [Kayla Reopelle](https://github.com/kaylareopelle), New Relic
 
 *Find more about the maintainer role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#maintainer).*
 


### PR DESCRIPTION
@kaylareopelle has made a number of contributions to OpenTelemetry Ruby in the form of PRs, PR reviews, issues, and backlog management. She has been doing the work of a maintainer for some time, and we'd like to make it official by promoting her to this role. Here is a summary of her work:

- [PRs authored](https://github.com/open-telemetry/opentelemetry-ruby/pulls?q=author%3Akaylareopelle+is%3Apr)
- [PRs commented upon](https://github.com/open-telemetry/opentelemetry-ruby/issues?q=commenter%3Akaylareopelle++)
- [Issues opened](https://github.com/open-telemetry/opentelemetry-ruby/issues?q=is%3Aissue+author%3Akaylareopelle+)
- [Issues commented upon](https://github.com/open-telemetry/opentelemetry-ruby/issues?q=is%3Aissue+commenter%3Akaylareopelle+)