### PR TITLE
test: Add workaround for Windows logs SDK test failure

### DIFF
--- a/logs_sdk/test/opentelemetry/sdk/logs/export/batch_log_record_processor_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/export/batch_log_record_processor_test.rb
@@ -186,20 +186,23 @@ describe OpenTelemetry::SDK::Logs::Export::BatchLogRecordProcessor do
     end
 
     it 'removes the older log records from the batch if full' do
-      processor = BatchLogRecordProcessor.new(TestExporter.new, max_queue_size: 1, max_export_batch_size: 1)
+      # Windows intermittently fails if we don't set this
+      OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_BLRP_START_THREAD_ON_BOOT' => 'false') do
+        processor = BatchLogRecordProcessor.new(TestExporter.new, max_queue_size: 1, max_export_batch_size: 1)
 
-      # Don't actually try to export, we're looking at the log records array
-      processor.stub(:work, nil) do
-        older_log_record = TestLogRecord.new
-        newest_log_record = TestLogRecord.new
+        # Don't actually try to export, we're looking at the log records array
+        processor.stub(:work, nil) do
+          older_log_record = TestLogRecord.new
+          newest_log_record = TestLogRecord.new
 
-        processor.on_emit(older_log_record, mock_context)
-        processor.on_emit(newest_log_record, mock_context)
+          processor.on_emit(older_log_record, mock_context)
+          processor.on_emit(newest_log_record, mock_context)
 
-        records = processor.instance_variable_get(:@log_records)
+          records = processor.instance_variable_get(:@log_records)
 
-        assert_includes(records, newest_log_record)
-        refute_includes(records, older_log_record)
+          assert_includes(records, newest_log_record)
+          refute_includes(records, older_log_record)
+        end
       end
     end
 


### PR DESCRIPTION
The Logs SDK has an intermittent failure in the Windows OS for Ruby 3.2 related to the `work` method being run outside of its stub.

We have to instantiate the processor outside of the stub so that the stub can be applied to the processor, but the method we're stubbing runs on initialization, so we sometimes run out of expectations due to timing with thread generation.

If we explicitly set `OTEL_RUBY_BLRP_START_THREAD_ON_BOOT` to `false` for the `removes the older log records from the batch if full` test, the stubbed `work` method will not run outside of the stub block.

Co-authored by @tannalynn 