### PR TITLE
test: Resolve Truffle ruby intermittent failures on exporters

### DIFF
--- a/exporter/otlp-common/test/opentelemetry/exporter/otlp/common/common_test.rb
+++ b/exporter/otlp-common/test/opentelemetry/exporter/otlp/common/common_test.rb
@@ -41,9 +41,6 @@ describe OpenTelemetry::Exporter::OTLP::Common do
     end
 
     it 'translates all the things' do
-      # TODO: See issue #1507 to fix
-      skip 'Intermittently fails' if RUBY_ENGINE == 'truffleruby'
-
       OpenTelemetry.tracer_provider = OpenTelemetry::SDK::Trace::TracerProvider.new(resource: OpenTelemetry::SDK::Resources::Resource.telemetry_sdk)
       tracer = OpenTelemetry.tracer_provider.tracer('tracer', 'v0.0.1')
       other_tracer = OpenTelemetry.tracer_provider.tracer('other_tracer')

--- a/exporter/otlp-http/test/opentelemetry/exporter/otlp/http/trace_exporter_test.rb
+++ b/exporter/otlp-http/test/opentelemetry/exporter/otlp/http/trace_exporter_test.rb
@@ -632,10 +632,6 @@ describe OpenTelemetry::Exporter::OTLP::HTTP::TraceExporter do
       )
 
       assert_requested(:post, 'http://localhost:4318/v1/traces') do |req|
-        # Zlib.gzip adds a timestamp, which may be different than the one in the
-        # encoded req.body due to the test timing, and may cause an intermittent
-        # failure. Compare the unzipped request with the encoded_estr to avoid
-        # the timestamp interfering with the equality check.
         Zlib.gunzip(req.body) == encoded_etsr
       end
     end

--- a/exporter/otlp-http/test/opentelemetry/exporter/otlp/http/trace_exporter_test.rb
+++ b/exporter/otlp-http/test/opentelemetry/exporter/otlp/http/trace_exporter_test.rb
@@ -468,9 +468,6 @@ describe OpenTelemetry::Exporter::OTLP::HTTP::TraceExporter do
     end
 
     it 'translates all the things' do
-      # TODO: See issue #1507 to fix
-      skip 'Intermittently fails' if RUBY_ENGINE == 'truffleruby'
-
       stub_request(:post, 'http://localhost:4318/v1/traces').to_return(status: 200)
       processor = OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(exporter)
       tracer = OpenTelemetry.tracer_provider.tracer('tracer', 'v0.0.1')
@@ -635,7 +632,11 @@ describe OpenTelemetry::Exporter::OTLP::HTTP::TraceExporter do
       )
 
       assert_requested(:post, 'http://localhost:4318/v1/traces') do |req|
-        req.body == Zlib.gzip(encoded_etsr)
+        # Zlib.gzip adds a timestamp, which may be different than the one in the
+        # encoded req.body due to the test timing, and may cause an intermittent
+        # failure. Compare the unzipped request with the encoded_estr to avoid
+        # the timestamp interfering with the equality check.
+        Zlib.gunzip(req.body) == encoded_etsr
       end
     end
   end

--- a/exporter/otlp-metrics/test/opentelemetry/exporter/otlp/metrics/metrics_exporter_test.rb
+++ b/exporter/otlp-metrics/test/opentelemetry/exporter/otlp/metrics/metrics_exporter_test.rb
@@ -637,10 +637,6 @@ describe OpenTelemetry::Exporter::OTLP::Metrics::MetricsExporter do
       )
 
       assert_requested(:post, 'http://localhost:4318/v1/metrics') do |req|
-        # Zlib.gzip adds a timestamp, which may be different than the one in the
-        # encoded req.body due to the test timing, and may cause an intermittent
-        # failure. Compare the unzipped request with the encoded_estr to avoid
-        # the timestamp interfering with the equality check.
         Zlib.gunzip(req.body) == encoded_etsr
       end
     end

--- a/exporter/otlp-metrics/test/opentelemetry/exporter/otlp/metrics/metrics_exporter_test.rb
+++ b/exporter/otlp-metrics/test/opentelemetry/exporter/otlp/metrics/metrics_exporter_test.rb
@@ -556,8 +556,6 @@ describe OpenTelemetry::Exporter::OTLP::Metrics::MetricsExporter do
     end
 
     it 'translates all the things' do
-      skip 'Intermittently fails' if RUBY_ENGINE == 'truffleruby'
-
       stub_request(:post, 'http://localhost:4318/v1/metrics').to_return(status: 200)
       meter_provider.add_metric_reader(exporter)
       meter   = meter_provider.meter('test')
@@ -639,7 +637,11 @@ describe OpenTelemetry::Exporter::OTLP::Metrics::MetricsExporter do
       )
 
       assert_requested(:post, 'http://localhost:4318/v1/metrics') do |req|
-        req.body == Zlib.gzip(encoded_etsr) # is asserting that the body of the HTTP request is equal to the result of gzipping the encoded_etsr.
+        # Zlib.gzip adds a timestamp, which may be different than the one in the
+        # encoded req.body due to the test timing, and may cause an intermittent
+        # failure. Compare the unzipped request with the encoded_estr to avoid
+        # the timestamp interfering with the equality check.
+        Zlib.gunzip(req.body) == encoded_etsr
       end
     end
   end

--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -611,9 +611,6 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
     end
 
     it 'translates all the things' do
-      # TODO: See issue #1507 to fix
-      skip 'Intermittently fails' if RUBY_ENGINE == 'truffleruby'
-
       stub_request(:post, 'http://localhost:4318/v1/traces').to_return(status: 200)
       processor = OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(exporter)
       tracer = OpenTelemetry.tracer_provider.tracer('tracer', 'v0.0.1')
@@ -778,7 +775,11 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       )
 
       assert_requested(:post, 'http://localhost:4318/v1/traces') do |req|
-        req.body == Zlib.gzip(encoded_etsr)
+        # Zlib.gzip adds a timestamp, which may be different than the one in the
+        # encoded req.body due to the test timing, and may cause an intermittent
+        # failure. Compare the unzipped request with the encoded_estr to avoid
+        # the timestamp interfering with the equality check.
+        Zlib.gunzip(req.body) == encoded_etsr
       end
     end
   end

--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -775,10 +775,6 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       )
 
       assert_requested(:post, 'http://localhost:4318/v1/traces') do |req|
-        # Zlib.gzip adds a timestamp, which may be different than the one in the
-        # encoded req.body due to the test timing, and may cause an intermittent
-        # failure. Compare the unzipped request with the encoded_estr to avoid
-        # the timestamp interfering with the equality check.
         Zlib.gunzip(req.body) == encoded_etsr
       end
     end


### PR DESCRIPTION
`Zlib.gzip` adds a timestamp, which may be different than the one in the encoded `req.body` due to the time difference between the request and the assertion. This caused intermittent an failure. 

To resolve the problem, compare the unzipped request body with the `encoded_estr` to avoid Zlib timestamp interference with the equality check.

Co-authored by @tannalynn 
Resolves #1507 