### PR TITLE
chore: Update appraisals of google-protobuf

### DIFF
--- a/exporter/otlp-metrics/Appraisals
+++ b/exporter/otlp-metrics/Appraisals
@@ -4,9 +4,21 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-(14..25).each do |i|
-  version = "3.#{i}"
-  appraise "google-protobuf-#{version}" do
-    gem 'google-protobuf', "~> #{version}"
-  end
+# Oldest compatible version
+appraise 'google-protobuf-3.18.0' do
+  gem 'google-protobuf', '~> 3.18.0'
+end
+
+# Last 3.x version
+appraise 'google-protobuf-3.25.0' do
+  gem 'google-protobuf', '~> 3.25.0'
+end
+
+# Latest version on 2024-10-22
+appraise 'google-protobuf-4.29.0' do
+  gem 'google-protobuf', '~> 4.29.0'
+end
+
+appraise 'google-protobuf-latest' do
+  gem 'google-protobuf'
 end

--- a/exporter/otlp/Appraisals
+++ b/exporter/otlp/Appraisals
@@ -4,9 +4,21 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-(14..23).each do |i|
-  version = "3.#{i}"
-  appraise "google-protobuf-#{version}" do
-    gem 'google-protobuf', "~> #{version}"
-  end
+# Oldest compatible version
+appraise 'google-protobuf-3.18.0' do
+  gem 'google-protobuf', '~> 3.18.0'
+end
+
+# Last 3.x version
+appraise 'google-protobuf-3.25.0' do
+  gem 'google-protobuf', '~> 3.25.0'
+end
+
+# Latest version on 2024-10-22
+appraise 'google-protobuf-4.29.0' do
+  gem 'google-protobuf', '~> 4.29.0'
+end
+
+appraise 'google-protobuf-latest' do
+  gem 'google-protobuf'
 end


### PR DESCRIPTION
The `google-protobuf` gem has a 4.x release. Also, our minimum supported version is now 3.18.0.

This PR updates the Appraisals file for the OTLP exporter and the OTLP metrics exporter to test different versions.