### PR TITLE
chore: Update http example gems

### DIFF
--- a/examples/http/Gemfile
+++ b/examples/http/Gemfile
@@ -2,9 +2,10 @@
 
 source "https://rubygems.org"
 
-gem "faraday", "~> 0.16.1"
+gem "faraday", "~> 2.0"
 gem "opentelemetry-api"
 gem "opentelemetry-common"
 gem "opentelemetry-sdk"
-gem "sinatra", "~> 2.0"
+gem "sinatra", "~> 4.1"
 gem "puma"
+gem "rackup"


### PR DESCRIPTION
The Faraday and Sinatra versions were very out of date. Dependabot noticed the Sinatra version had known vulnerabilities. This updates the Gemfile. The example has the same output.