### PR TITLE
chore: Prepare logs gems for release

### DIFF
--- a/.toys/.data/releases.yml
+++ b/.toys/.data/releases.yml
@@ -63,6 +63,10 @@ gems:
     directory: exporter/otlp
     version_constant: [OpenTelemetry, Exporter, OTLP, VERSION]
 
+  - name: opentelemetry-exporter-otlp-logs
+    directory: exporter/otlp-logs
+    version_constant: [OpenTelemetry, Exporter, OTLP, Logs, VERSION]
+
   - name: opentelemetry-exporter-otlp-metrics
     directory: exporter/otlp-metrics
     version_constant: [OpenTelemetry, Exporter, OTLP, Metrics, VERSION]
@@ -98,3 +102,13 @@ gems:
     directory: metrics_sdk
     version_rb_path: lib/opentelemetry/sdk/metrics/version.rb
     version_constant: [OpenTelemetry, SDK, Metrics, VERSION]
+
+  - name: opentelemetry-logs-api
+    directory: logs_api
+    version_rb_path: lib/opentelemetry/logs/version.rb
+    version_constant: [OpenTelemetry, Logs, VERSION]
+
+  - name: opentelemetry-logs-sdk
+    directory: logs_sdk
+    version_rb_path: lib/opentelemetry/sdk/logs/version.rb
+    version_constant: [OpenTelemetry, SDK, Logs, VERSION]

--- a/exporter/otlp-logs/README.md
+++ b/exporter/otlp-logs/README.md
@@ -25,7 +25,7 @@ Install the gem using:
 ```console
 
 gem install opentelemetry-logs-sdk
-gem install opentelemetry-exporter-otlp
+gem install opentelemetry-exporter-otlp-logs
 
 ```
 


### PR DESCRIPTION
This PR adds the following gems to the release.yml file:
* `opentelemetry-exporter-otlp-logs`
* `opentelemetry-logs-sdk`
* `opentelemetry-logs-api`

It also fixes a typo in the OTLP logs exporter README