### PR TITLE
feat: Gauge metrics exporter encoding

### DIFF
--- a/exporter/otlp-metrics/lib/opentelemetry/exporter/otlp/metrics/metrics_exporter.rb
+++ b/exporter/otlp-metrics/lib/opentelemetry/exporter/otlp/metrics/metrics_exporter.rb
@@ -219,25 +219,12 @@ module OpenTelemetry
           # metrics [MetricData]
           def as_otlp_metrics(metrics)
             case metrics.instrument_kind
-            when :gauge
+            when :observable_gauge, :gauge
               Opentelemetry::Proto::Metrics::V1::Metric.new(
                 name: metrics.name,
                 description: metrics.description,
                 unit: metrics.unit,
                 gauge: Opentelemetry::Proto::Metrics::V1::Gauge.new(
-                  data_points: metrics.data_points.map do |ndp|
-                    number_data_point(ndp)
-                  end
-                )
-              )
-
-            when :observable_gauge
-              Opentelemetry::Proto::Metrics::V1::Metric.new(
-                name: metrics.name,
-                description: metrics.description,
-                unit: metrics.unit,
-                gauge: Opentelemetry::Proto::Metrics::V1::Gauge.new(
-                  aggregation_temporality: as_otlp_aggregation_temporality(metrics.aggregation_temporality),
                   data_points: metrics.data_points.map do |ndp|
                     number_data_point(ndp)
                   end

--- a/exporter/otlp-metrics/lib/opentelemetry/exporter/otlp/metrics/metrics_exporter.rb
+++ b/exporter/otlp-metrics/lib/opentelemetry/exporter/otlp/metrics/metrics_exporter.rb
@@ -214,11 +214,23 @@ module OpenTelemetry
           end
 
           # metrics_pb has following type of data: :gauge, :sum, :histogram, :exponential_histogram, :summary
-          # current metric sdk only implements instrument: :counter -> :sum, :histogram -> :histogram
+          # current metric sdk only implements instrument: :counter -> :sum, :histogram -> :histogram, :gauge -> :gauge
           #
           # metrics [MetricData]
           def as_otlp_metrics(metrics)
             case metrics.instrument_kind
+            when :gauge
+              Opentelemetry::Proto::Metrics::V1::Metric.new(
+                name: metrics.name,
+                description: metrics.description,
+                unit: metrics.unit,
+                gauge: Opentelemetry::Proto::Metrics::V1::Gauge.new(
+                  data_points: metrics.data_points.map do |ndp|
+                    number_data_point(ndp)
+                  end
+                )
+              )
+
             when :observable_gauge
               Opentelemetry::Proto::Metrics::V1::Metric.new(
                 name: metrics.name,

--- a/exporter/otlp-metrics/test/opentelemetry/exporter/otlp/metrics/metrics_exporter_test.rb
+++ b/exporter/otlp-metrics/test/opentelemetry/exporter/otlp/metrics/metrics_exporter_test.rb
@@ -665,9 +665,9 @@ describe OpenTelemetry::Exporter::OTLP::Metrics::MetricsExporter do
                             time_unix_nano: 1_699_593_427_329_946_586,
                             exemplars: nil
                           )
-                        ],
+                        ]
                       )
-                    ),
+                    )
                   ]
                 )
               ]

--- a/exporter/otlp-metrics/test/opentelemetry/exporter/otlp/metrics/metrics_exporter_test.rb
+++ b/exporter/otlp-metrics/test/opentelemetry/exporter/otlp/metrics/metrics_exporter_test.rb
@@ -576,11 +576,16 @@ describe OpenTelemetry::Exporter::OTLP::Metrics::MetricsExporter do
       stub_request(:post, 'http://localhost:4318/v1/metrics').to_return(status: 200)
       meter_provider.add_metric_reader(exporter)
       meter   = meter_provider.meter('test')
+
       counter = meter.create_counter('test_counter', unit: 'smidgen', description: 'a small amount of something')
       counter.add(5, attributes: { 'foo' => 'bar' })
 
       histogram = meter.create_histogram('test_histogram', unit: 'smidgen', description: 'a small amount of something')
       histogram.record(10, attributes: { 'oof' => 'rab' })
+
+      gauge = meter.create_gauge('test_gauge', unit: 'smidgen', description: 'a small amount of something')
+      gauge.record(15, attributes: { 'baz' => 'qux' })
+
       exporter.pull
       meter_provider.shutdown
 
@@ -644,7 +649,25 @@ describe OpenTelemetry::Exporter::OTLP::Metrics::MetricsExporter do
                         ],
                         aggregation_temporality: Opentelemetry::Proto::Metrics::V1::AggregationTemporality::AGGREGATION_TEMPORALITY_DELTA
                       )
-                    )
+                    ),
+                    Opentelemetry::Proto::Metrics::V1::Metric.new(
+                      name: 'test_gauge',
+                      description: 'a small amount of something',
+                      unit: 'smidgen',
+                      gauge: Opentelemetry::Proto::Metrics::V1::Gauge.new(
+                        data_points: [
+                          Opentelemetry::Proto::Metrics::V1::NumberDataPoint.new(
+                            attributes: [
+                              Opentelemetry::Proto::Common::V1::KeyValue.new(key: 'baz', value: Opentelemetry::Proto::Common::V1::AnyValue.new(string_value: 'qux'))
+                            ],
+                            as_int: 15,
+                            start_time_unix_nano: 1_699_593_427_329_946_585,
+                            time_unix_nano: 1_699_593_427_329_946_586,
+                            exemplars: nil
+                          )
+                        ],
+                      )
+                    ),
                   ]
                 )
               ]

--- a/exporter/otlp-metrics/test/test_helper.rb
+++ b/exporter/otlp-metrics/test/test_helper.rb
@@ -26,6 +26,7 @@ end
 
 OpenTelemetry::SDK::Metrics::Aggregation::Sum.prepend(MockSum)
 OpenTelemetry::SDK::Metrics::Aggregation::ExplicitBucketHistogram.prepend(MockSum)
+OpenTelemetry::SDK::Metrics::Aggregation::LastValue.prepend(MockSum)
 
 def create_metrics_data(name: '', description: '', unit: '', instrument_kind: :counter, resource: nil,
                         instrumentation_scope: OpenTelemetry::SDK::InstrumentationScope.new('', 'v0.0.1'),


### PR DESCRIPTION
Support exporting gauge metrics from `OTLP::Metrics::MetricsExporter` now that support for `Gauge` instruments in `metrics_sdk` has been added (https://github.com/open-telemetry/opentelemetry-ruby/pull/1718)