### PR TITLE
fix: update out-of-date google-protobuf-any

### DIFF
--- a/exporter/otlp-metrics/README.md
+++ b/exporter/otlp-metrics/README.md
@@ -70,6 +70,8 @@ Or, if you use [bundler][bundler-home], include `opentelemetry-sdk`, `openteleme
 Then, configure the SDK to use the OTLP metrics exporter
 
 ```ruby
+ENV['OTEL_METRICS_EXPORTER'] = 'none'
+
 require 'opentelemetry/sdk'
 require 'opentelemetry-metrics-sdk'
 require 'opentelemetry/exporter/otlp_metrics'

--- a/exporter/otlp-metrics/lib/opentelemetry/exporter/otlp/metrics/util.rb
+++ b/exporter/otlp-metrics/lib/opentelemetry/exporter/otlp/metrics/util.rb
@@ -118,7 +118,7 @@ module OpenTelemetry
             status = Google::Rpc::Status.decode(body)
             details = status.details.map do |detail|
               type_name = detail.type_url.to_s.split('/').last.to_s
-              klass_or_nil = ::Google::Protobuf::DescriptorPool.generated_pool.lookup(detail.type_name)&.msgclass
+              klass_or_nil = ::Google::Protobuf::DescriptorPool.generated_pool.lookup(type_name)&.msgclass
               detail.unpack(klass_or_nil) if klass_or_nil
             end.compact
             OpenTelemetry.handle_error(message: "OTLP metrics_exporter received rpc.Status{message=#{status.message}, details=#{details}}")

--- a/exporter/otlp-metrics/lib/opentelemetry/exporter/otlp/metrics/util.rb
+++ b/exporter/otlp-metrics/lib/opentelemetry/exporter/otlp/metrics/util.rb
@@ -117,7 +117,8 @@ module OpenTelemetry
           def log_status(body)
             status = Google::Rpc::Status.decode(body)
             details = status.details.map do |detail|
-              klass_or_nil = ::Google::Protobuf::DescriptorPool.generated_pool.lookup(detail.type_name).msgclass
+              type_name = detail.type_url.to_s.split('/').last.to_s
+              klass_or_nil = ::Google::Protobuf::DescriptorPool.generated_pool.lookup(detail.type_name)&.msgclass
               detail.unpack(klass_or_nil) if klass_or_nil
             end.compact
             OpenTelemetry.handle_error(message: "OTLP metrics_exporter received rpc.Status{message=#{status.message}, details=#{details}}")


### PR DESCRIPTION
Closes: https://github.com/open-telemetry/opentelemetry-ruby/issues/1814

This issue won't cause any major breakdown since it's only for logging the error message.

If the change is valid, then it needs to be updated for all exporters.