### PR TITLE
Prevent slow shutdown caused by waiting full metrics export interval

### DIFF
--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/export/periodic_metric_reader.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/export/periodic_metric_reader.rb
@@ -43,7 +43,11 @@ module OpenTelemetry
               @continue = false # force termination in next iteration
               @thread
             end
-            thread&.join(@export_interval)
+
+            # Trigger a final export before killing the writing thread
+            export(timeout: @export_timeout)
+            thread.kill
+
             @exporter.force_flush if @exporter.respond_to?(:force_flush)
             @exporter.shutdown
             Export::SUCCESS

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/export/periodic_metric_reader.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/export/periodic_metric_reader.rb
@@ -46,7 +46,7 @@ module OpenTelemetry
 
             # Trigger a final export before killing the writing thread
             export(timeout: @export_timeout)
-            thread.kill
+            lock { thread.kill }
 
             @exporter.force_flush if @exporter.respond_to?(:force_flush)
             @exporter.shutdown


### PR DESCRIPTION
We noticed that when using the new metrics functionality in the library that our Rails application now took longer to shut down. We want to export metrics every 60 seconds, but we don't want to wait an additional 60 seconds for the app to stop. This was caused by the shutdown logic in `PeriodicMetricReader` which worked by setting `@continue` to false, indicating to the loop in `start` to no longer continue sleeping and writing. However, this meant that on shutdown, it takes a full `@export_interval` in order to "notice" that `@continue` is false an the program should exit. 

With this change, upon `shutdown`, the program performs a final `export` and then kills the writer thread. This is an approach suggested by @xuan-cao-swi in https://github.com/open-telemetry/opentelemetry-ruby/issues/1662#issuecomment-2714994848. 

Some questions:

1. Does the `kill` need to acquire the lock first? 
3. Is it still necessary to set `@continue` to false, if `@continue` is no longer used to control shutdown behavior?
4. Is `@continue` even needed any more? 
5. Would it be preferable, rather than the thread-killing approach, to use a `ConditionVariable` with `wait(@export_mutex, @export_interval)` in the writing loop, and `signal()` in `shutdown`? This would allow the writing loop "wake up" responsively on shutdown, while ordinarily waiting `@export_interval` before looping and writing again. 