### PR TITLE
feat: Allow specifying aggregation for SynchronousInstruments

### DIFF
--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/synchronous_instrument.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/synchronous_instrument.rb
@@ -24,7 +24,7 @@ module OpenTelemetry
           end
 
           # @api private
-          def register_with_new_metric_store(metric_store, aggregation: nil)
+          def register_with_new_metric_store(metric_store, aggregation: @aggregation)
             ms = OpenTelemetry::SDK::Metrics::State::MetricStream.new(
               @name,
               @description,
@@ -32,7 +32,7 @@ module OpenTelemetry
               instrument_kind,
               @meter_provider,
               @instrumentation_scope,
-              aggregation || @aggregation
+              aggregation
             )
             @metric_streams << ms
             metric_store.add_metric_stream(ms)

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/synchronous_instrument.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/synchronous_instrument.rb
@@ -11,19 +11,20 @@ module OpenTelemetry
         # {SynchronousInstrument} contains the common functionality shared across
         # the synchronous instruments SDK instruments.
         class SynchronousInstrument
-          def initialize(name, unit, description, instrumentation_scope, meter_provider)
+          def initialize(name, unit, description, instrumentation_scope, meter_provider, aggregation: default_aggregation)
             @name = name
             @unit = unit
             @description = description
             @instrumentation_scope = instrumentation_scope
             @meter_provider = meter_provider
+            @aggregation = aggregation
             @metric_streams = []
 
             meter_provider.register_synchronous_instrument(self)
           end
 
           # @api private
-          def register_with_new_metric_store(metric_store, aggregation: default_aggregation)
+          def register_with_new_metric_store(metric_store, aggregation: nil)
             ms = OpenTelemetry::SDK::Metrics::State::MetricStream.new(
               @name,
               @description,
@@ -31,7 +32,7 @@ module OpenTelemetry
               instrument_kind,
               @meter_provider,
               @instrumentation_scope,
-              aggregation
+              aggregation || @aggregation
             )
             @metric_streams << ms
             metric_store.add_metric_stream(ms)

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/meter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/meter.rb
@@ -35,7 +35,7 @@ module OpenTelemetry
           end
         end
 
-        def create_instrument(kind, name, unit, description, callback)
+        def create_instrument(kind, name, unit, description, callback, **options)
           raise InstrumentNameError if name.nil?
           raise InstrumentNameError if name.empty?
           raise InstrumentNameError unless NAME_REGEX.match?(name)
@@ -44,12 +44,12 @@ module OpenTelemetry
 
           super do
             case kind
-            when :counter then OpenTelemetry::SDK::Metrics::Instrument::Counter.new(name, unit, description, @instrumentation_scope, @meter_provider)
+            when :counter then OpenTelemetry::SDK::Metrics::Instrument::Counter.new(name, unit, description, @instrumentation_scope, @meter_provider, **options)
             when :observable_counter then OpenTelemetry::SDK::Metrics::Instrument::ObservableCounter.new(name, unit, description, callback, @instrumentation_scope, @meter_provider)
-            when :gauge then OpenTelemetry::SDK::Metrics::Instrument::Gauge.new(name, unit, description, @instrumentation_scope, @meter_provider)
-            when :histogram then OpenTelemetry::SDK::Metrics::Instrument::Histogram.new(name, unit, description, @instrumentation_scope, @meter_provider)
+            when :gauge then OpenTelemetry::SDK::Metrics::Instrument::Gauge.new(name, unit, description, @instrumentation_scope, @meter_provider, **options)
+            when :histogram then OpenTelemetry::SDK::Metrics::Instrument::Histogram.new(name, unit, description, @instrumentation_scope, @meter_provider, **options)
             when :observable_gauge then OpenTelemetry::SDK::Metrics::Instrument::ObservableGauge.new(name, unit, description, callback, @instrumentation_scope, @meter_provider)
-            when :up_down_counter then OpenTelemetry::SDK::Metrics::Instrument::UpDownCounter.new(name, unit, description, @instrumentation_scope, @meter_provider)
+            when :up_down_counter then OpenTelemetry::SDK::Metrics::Instrument::UpDownCounter.new(name, unit, description, @instrumentation_scope, @meter_provider, **options)
             when :observable_up_down_counter then OpenTelemetry::SDK::Metrics::Instrument::ObservableUpDownCounter.new(name, unit, description, callback, @instrumentation_scope, @meter_provider)
             end
           end


### PR DESCRIPTION
Our application has a handful of legacy API endpoints that far exceed the default explicit histogram buckets, and currently there is no way to override the default buckets for histograms. Allowing the aggregation to be explicitly provided for `SyncrhonousInstrument`s means we will be able to get data that is actually representative of our API response times.