### PR TITLE
fix: update docs for in_span method to list start_timestamp as a Time object

### DIFF
--- a/api/lib/opentelemetry/trace/tracer.rb
+++ b/api/lib/opentelemetry/trace/tracer.rb
@@ -26,7 +26,7 @@ module OpenTelemetry
       # @param attributes [optional Hash] attributes to attach to the span {String => String,
       # Numeric, Boolean, Array<String, Numeric, Boolean>}
       # @param links [optional Array] an array of OpenTelemetry::Trace::Link instances
-      # @param start_timestamp [optional Integer] nanoseconds since Epoch
+      # @param start_timestamp [optional Time] timestamp to use as the start time of the span
       # @param kind [optional Symbol] One of :internal, :server, :client, :producer, :consumer
       #
       # @yield [span, context] yields the newly created span and a context containing the


### PR DESCRIPTION
Updates the docs line for start_timestamp so that it is listed as a Time object now, instead of an integer. 

resolves https://github.com/open-telemetry/opentelemetry-ruby/issues/1841