### PR TITLE
feat: integrate exponential histogram to sdk and exporter

### DIFF
--- a/exporter/otlp-metrics/lib/opentelemetry/exporter/otlp/metrics/metrics_exporter.rb
+++ b/exporter/otlp-metrics/lib/opentelemetry/exporter/otlp/metrics/metrics_exporter.rb
@@ -257,6 +257,20 @@ module OpenTelemetry
                   end
                 )
               )
+
+            when :exponential_histogram
+              Opentelemetry::Proto::Metrics::V1::Metric.new(
+                name: metrics.name,
+                description: metrics.description,
+                unit: metrics.unit,
+                exponential_histogram: Opentelemetry::Proto::Metrics::V1::ExponentialHistogram.new(
+                  aggregation_temporality: as_otlp_aggregation_temporality(metrics.aggregation_temporality),
+                  data_points: metrics.data_points.map do |ehdp|
+                    exponential_histogram_data_point(ehdp)
+                  end
+                )
+              )
+
             end
           end
 
@@ -280,6 +294,31 @@ module OpenTelemetry
               exemplars: hdp.exemplars,
               min: hdp.min,
               max: hdp.max
+            )
+          end
+
+          def exponential_histogram_data_point(ehdp)
+            Opentelemetry::Proto::Metrics::V1::ExponentialHistogramDataPoint.new(
+              attributes: ehdp.attributes.map { |k, v| as_otlp_key_value(k, v) },
+              start_time_unix_nano: ehdp.start_time_unix_nano,
+              time_unix_nano: ehdp.time_unix_nano,
+              count: ehdp.count,
+              sum: ehdp.sum,
+              scale: ehdp.scale,
+              zero_count: ehdp.zero_count,
+              positive: Opentelemetry::Proto::Metrics::V1::ExponentialHistogramDataPoint::Buckets.new(
+                offset: ehdp.positive.offset,
+                bucket_counts: ehdp.positive.counts
+              ),
+              negative: Opentelemetry::Proto::Metrics::V1::ExponentialHistogramDataPoint::Buckets.new(
+                offset: ehdp.negative.offset,
+                bucket_counts: ehdp.negative.counts
+              ),
+              flags: ehdp.flags,
+              exemplars: ehdp.exemplars,
+              min: ehdp.min,
+              max: ehdp.max,
+              zero_threshold: ehdp.zero_threshold
             )
           end
 

--- a/exporter/otlp-metrics/test/opentelemetry/exporter/otlp/metrics/metrics_exporter_test.rb
+++ b/exporter/otlp-metrics/test/opentelemetry/exporter/otlp/metrics/metrics_exporter_test.rb
@@ -609,6 +609,9 @@ describe OpenTelemetry::Exporter::OTLP::Metrics::MetricsExporter do
       gauge = meter.create_gauge('test_gauge', unit: 'smidgen', description: 'a small amount of something')
       gauge.record(15, attributes: { 'baz' => 'qux' })
 
+      exponential_histogram = meter.create_exponential_histogram('test_exponential_histogram', unit: 'smidgen', description: 'a small amount of something')
+      exponential_histogram.record(20, attributes: { 'lox' => 'xol' })
+
       exporter.pull
       meter_provider.shutdown
 
@@ -710,6 +713,40 @@ describe OpenTelemetry::Exporter::OTLP::Metrics::MetricsExporter do
                             exemplars: nil
                           )
                         ]
+                      )
+                    ),
+                    Opentelemetry::Proto::Metrics::V1::Metric.new(
+                      name: 'test_exponential_histogram',
+                      description: 'a small amount of something',
+                      unit: 'smidgen',
+                      exponential_histogram: Opentelemetry::Proto::Metrics::V1::ExponentialHistogram.new(
+                        data_points: [
+                          Opentelemetry::Proto::Metrics::V1::ExponentialHistogramDataPoint.new(
+                            attributes: [
+                              Opentelemetry::Proto::Common::V1::KeyValue.new(key: 'lox', value: Opentelemetry::Proto::Common::V1::AnyValue.new(string_value: 'xol'))
+                            ],
+                            start_time_unix_nano: 1_699_593_427_329_946_585,
+                            time_unix_nano: 1_699_593_427_329_946_586,
+                            count: 1,
+                            sum: 20,
+                            scale: 20,
+                            zero_count: 0,
+                            positive: Opentelemetry::Proto::Metrics::V1::ExponentialHistogramDataPoint::Buckets.new(
+                              offset: 4_531_870,
+                              bucket_counts: [1]
+                            ),
+                            negative: Opentelemetry::Proto::Metrics::V1::ExponentialHistogramDataPoint::Buckets.new(
+                              offset: 0,
+                              bucket_counts: [0]
+                            ),
+                            flags: 0,
+                            exemplars: nil,
+                            min: 20,
+                            max: 20,
+                            zero_threshold: 0
+                          )
+                        ],
+                        aggregation_temporality: Opentelemetry::Proto::Metrics::V1::AggregationTemporality::AGGREGATION_TEMPORALITY_DELTA
                       )
                     )
                   ]

--- a/exporter/otlp-metrics/test/test_helper.rb
+++ b/exporter/otlp-metrics/test/test_helper.rb
@@ -26,6 +26,7 @@ end
 
 OpenTelemetry::SDK::Metrics::Aggregation::Sum.prepend(MockSum)
 OpenTelemetry::SDK::Metrics::Aggregation::ExplicitBucketHistogram.prepend(MockSum)
+OpenTelemetry::SDK::Metrics::Aggregation::ExponentialBucketHistogram.prepend(MockSum)
 OpenTelemetry::SDK::Metrics::Aggregation::LastValue.prepend(MockSum)
 
 def create_metrics_data(name: '', description: '', unit: '', instrument_kind: :counter, resource: nil,

--- a/metrics_api/lib/opentelemetry/internal/proxy_meter.rb
+++ b/metrics_api/lib/opentelemetry/internal/proxy_meter.rb
@@ -45,6 +45,7 @@ module OpenTelemetry
           case kind
           when :counter then @delegate.create_counter(name, unit: unit, description: description)
           when :histogram then @delegate.create_histogram(name, unit: unit, description: description)
+          when :exponential_histogram then @delegate.create_exponential_histogram(name, unit: unit, description: description)
           when :gauge then @delegate.create_gauge(name, unit: unit, description: description)
           when :up_down_counter then @delegate.create_up_down_counter(name, unit: unit, description: description)
           when :observable_counter then @delegate.create_observable_counter(name, unit: unit, description: description, callback: callback)

--- a/metrics_api/lib/opentelemetry/metrics/instrument.rb
+++ b/metrics_api/lib/opentelemetry/metrics/instrument.rb
@@ -11,6 +11,7 @@ require 'opentelemetry/metrics/instrument/observable_counter'
 require 'opentelemetry/metrics/instrument/observable_gauge'
 require 'opentelemetry/metrics/instrument/observable_up_down_counter'
 require 'opentelemetry/metrics/instrument/up_down_counter'
+require 'opentelemetry/metrics/instrument/exponential_histogram'
 
 module OpenTelemetry
   module Metrics

--- a/metrics_api/lib/opentelemetry/metrics/instrument/exponential_histogram.rb
+++ b/metrics_api/lib/opentelemetry/metrics/instrument/exponential_histogram.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module Metrics
+    module Instrument
+      # No-op implementation of ExponentialHistogram.
+      class ExponentialHistogram
+        # Updates the statistics with the specified amount.
+        #
+        # @param [numeric] amount The amount of the Measurement, which MUST be a non-negative numeric value.
+        # @param [Hash{String => String, Numeric, Boolean, Array<String, Numeric, Boolean>}] attributes
+        #   Values must be non-nil and (array of) string, boolean or numeric type.
+        #   Array values must not contain nil elements and all elements must be of
+        #   the same basic type (string, numeric, boolean).
+        def record(amount, attributes: {}); end
+      end
+    end
+  end
+end

--- a/metrics_api/lib/opentelemetry/metrics/meter.rb
+++ b/metrics_api/lib/opentelemetry/metrics/meter.rb
@@ -11,6 +11,7 @@ module OpenTelemetry
       COUNTER = Instrument::Counter.new
       OBSERVABLE_COUNTER = Instrument::ObservableCounter.new
       HISTOGRAM = Instrument::Histogram.new
+      EXPONENTIAL_HISTOGRAM = Instrument::ExponentialHistogram.new
       GAUGE = Instrument::Gauge.new
       OBSERVABLE_GAUGE = Instrument::ObservableGauge.new
       UP_DOWN_COUNTER = Instrument::UpDownCounter.new
@@ -64,6 +65,25 @@ module OpenTelemetry
       # @return [nil] after creation of histogram, it will be stored in instrument_registry
       def create_histogram(name, unit: nil, description: nil)
         create_instrument(:histogram, name, unit, description, nil) { HISTOGRAM }
+      end
+
+      # Expotential Histogram is a synchronous Instrument which can be used to report arbitrary values that are likely
+      # to be statistically meaningful. It is intended for statistics such as histograms,
+      # summaries, and percentiles with defined scale.
+      #
+      # With this api call:
+      #
+      #   http_server_duration = meter.create_exponential_histogram("http.server.duration",
+      #                                                 description: "measures the duration of the inbound HTTP request",
+      #                                                 unit: "s")
+      #
+      # @param name [String] the name of the expotential histogram
+      # @param unit [optional String] an optional string provided by user.
+      # @param description [optional String] an optional free-form text provided by user.
+      #
+      # @return [nil] after creation of expotential histogram, it will be stored in instrument_registry
+      def create_exponential_histogram(name, unit: nil, description: nil)
+        create_instrument(:exponential_histogram, name, unit, description, nil) { EXPONENTIAL_HISTOGRAM }
       end
 
       # Gauge is an synchronous Instrument which reports non-additive value(s)

--- a/metrics_api/test/opentelemetry/metrics/meter_test.rb
+++ b/metrics_api/test/opentelemetry/metrics/meter_test.rb
@@ -29,6 +29,11 @@ describe OpenTelemetry::Metrics::Meter do
       _(counter.class).must_equal(OpenTelemetry::Metrics::Instrument::Histogram)
     end
 
+    it 'test create_exponential_histogram' do
+      counter = meter.create_exponential_histogram('test')
+      _(counter.class).must_equal(OpenTelemetry::Metrics::Instrument::ExponentialHistogram)
+    end
+
     it 'test create_up_down_counter' do
       counter = meter.create_up_down_counter('test')
       _(counter.class).must_equal(OpenTelemetry::Metrics::Instrument::UpDownCounter)

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument.rb
@@ -16,6 +16,7 @@ end
 require 'opentelemetry/sdk/metrics/instrument/synchronous_instrument'
 require 'opentelemetry/sdk/metrics/instrument/counter'
 require 'opentelemetry/sdk/metrics/instrument/histogram'
+require 'opentelemetry/sdk/metrics/instrument/exponential_histogram'
 require 'opentelemetry/sdk/metrics/instrument/observable_counter'
 require 'opentelemetry/sdk/metrics/instrument/observable_gauge'
 require 'opentelemetry/sdk/metrics/instrument/observable_up_down_counter'

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/exponential_histogram.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/exponential_histogram.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  module SDK
+    module Metrics
+      module Instrument
+        # {Histogram} is the SDK implementation of {OpenTelemetry::Metrics::Histogram}.
+        class ExponentialHistogram < OpenTelemetry::SDK::Metrics::Instrument::SynchronousInstrument
+          # Returns the instrument kind as a Symbol
+          #
+          # @return [Symbol]
+          def instrument_kind
+            :exponential_histogram
+          end
+
+          # Updates the statistics with the specified amount.
+          #
+          # @param [numeric] amount The amount of the Measurement, which MUST be a non-negative numeric value.
+          # @param [Hash{String => String, Numeric, Boolean, Array<String, Numeric, Boolean>}] attributes
+          #   Values must be non-nil and (array of) string, boolean or numeric type.
+          #   Array values must not contain nil elements and all elements must be of
+          #   the same basic type (string, numeric, boolean).
+          def record(amount, attributes: {})
+            update(amount, attributes)
+            nil
+          rescue StandardError => e
+            OpenTelemetry.handle_error(exception: e)
+            nil
+          end
+
+          private
+
+          def default_aggregation
+            OpenTelemetry::SDK::Metrics::Aggregation::ExponentialBucketHistogram.new
+          end
+        end
+      end
+    end
+  end
+end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/meter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/meter.rb
@@ -48,6 +48,7 @@ module OpenTelemetry
             when :observable_counter then OpenTelemetry::SDK::Metrics::Instrument::ObservableCounter.new(name, unit, description, callback, @instrumentation_scope, @meter_provider)
             when :gauge then OpenTelemetry::SDK::Metrics::Instrument::Gauge.new(name, unit, description, @instrumentation_scope, @meter_provider)
             when :histogram then OpenTelemetry::SDK::Metrics::Instrument::Histogram.new(name, unit, description, @instrumentation_scope, @meter_provider)
+            when :exponential_histogram then OpenTelemetry::SDK::Metrics::Instrument::ExponentialHistogram.new(name, unit, description, @instrumentation_scope, @meter_provider)
             when :observable_gauge then OpenTelemetry::SDK::Metrics::Instrument::ObservableGauge.new(name, unit, description, callback, @instrumentation_scope, @meter_provider)
             when :up_down_counter then OpenTelemetry::SDK::Metrics::Instrument::UpDownCounter.new(name, unit, description, @instrumentation_scope, @meter_provider)
             when :observable_up_down_counter then OpenTelemetry::SDK::Metrics::Instrument::ObservableUpDownCounter.new(name, unit, description, callback, @instrumentation_scope, @meter_provider)

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/instrument/exponential_histogram_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/instrument/exponential_histogram_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+describe OpenTelemetry::SDK::Metrics::Instrument::ExponentialHistogram do
+  let(:metric_exporter) { OpenTelemetry::SDK::Metrics::Export::InMemoryMetricPullExporter.new }
+  let(:meter) { OpenTelemetry.meter_provider.meter('test') }
+  let(:exponential_histogram) { meter.create_exponential_histogram('exponential_histogram', unit: 'smidgen', description: 'a small amount of something') }
+
+  before do
+    reset_metrics_sdk
+    OpenTelemetry::SDK.configure
+    OpenTelemetry.meter_provider.add_metric_reader(metric_exporter)
+  end
+
+  it 'expotential histograms' do
+    exponential_histogram.record(5, attributes: { 'foo' => 'bar' })
+    exponential_histogram.record(6, attributes: { 'foo' => 'bar' })
+    metric_exporter.pull
+    last_snapshot = metric_exporter.metric_snapshots
+
+    _(last_snapshot[0].name).must_equal('exponential_histogram')
+    _(last_snapshot[0].unit).must_equal('smidgen')
+    _(last_snapshot[0].description).must_equal('a small amount of something')
+    _(last_snapshot[0].instrumentation_scope.name).must_equal('test')
+    _(last_snapshot[0].data_points[0].count).must_equal(2)
+    _(last_snapshot[0].data_points[0].sum).must_equal(11)
+    _(last_snapshot[0].data_points[0].min).must_equal(5)
+    _(last_snapshot[0].data_points[0].max).must_equal(6)
+    _(last_snapshot[0].data_points[0].scale).must_equal(9)
+    _(last_snapshot[0].data_points[0].zero_count).must_equal(0)
+    _(last_snapshot[0].data_points[0].positive.offset).must_equal(1188)
+    _(last_snapshot[0].data_points[0].positive.counts).must_equal([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+    _(last_snapshot[0].data_points[0].negative.offset).must_equal(0)
+    _(last_snapshot[0].data_points[0].negative.counts).must_equal([0])
+    _(last_snapshot[0].data_points[0].flags).must_equal(0)
+    _(last_snapshot[0].data_points[0].zero_threshold).must_equal(0)
+    _(last_snapshot[0].aggregation_temporality).must_equal(:delta)
+  end
+end


### PR DESCRIPTION
User can create exponential_histogram through `meter.create_exponential_histogram('exponential_histogram', ...)`.