### PR TITLE
chore: Use PAT for release actions

### DIFF
--- a/.github/workflows/release-request-weekly.yml
+++ b/.github/workflows/release-request-weekly.yml
@@ -21,7 +21,7 @@ jobs:
         run: "gem install --no-document toys -v 0.15.5"
       - name: Open release pull request
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
         run: |
           toys release request --yes --verbose \
             "--release-ref=${{ github.ref }}" \

--- a/.github/workflows/release-request.yml
+++ b/.github/workflows/release-request.yml
@@ -25,7 +25,7 @@ jobs:
         run: "gem install --no-document toys -v 0.15.5"
       - name: Open release pull request
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
         run: |
           toys release request --yes --verbose \
             "--gems=${{ github.event.inputs.gems }}" \


### PR DESCRIPTION
A GitHub token will not trigger workflows associated with PRs. A PAT, however, should trigger those workflows automatically. This should stop us from needing to push empty commits when a release PR is opened.