### PR TITLE
feat: add exponential histogram in otlp metrics exporter

### DIFF
--- a/exporter/otlp-metrics/lib/opentelemetry/exporter/otlp/metrics/metrics_exporter.rb
+++ b/exporter/otlp-metrics/lib/opentelemetry/exporter/otlp/metrics/metrics_exporter.rb
@@ -246,17 +246,8 @@ module OpenTelemetry
               )
 
             when :histogram
-              Opentelemetry::Proto::Metrics::V1::Metric.new(
-                name: metrics.name,
-                description: metrics.description,
-                unit: metrics.unit,
-                histogram: Opentelemetry::Proto::Metrics::V1::Histogram.new(
-                  aggregation_temporality: as_otlp_aggregation_temporality(metrics.aggregation_temporality),
-                  data_points: metrics.data_points.map do |hdp|
-                    histogram_data_point(hdp)
-                  end
-                )
-              )
+              histogram_data_point(metrics)
+
             end
           end
 
@@ -268,7 +259,37 @@ module OpenTelemetry
             end
           end
 
-          def histogram_data_point(hdp)
+          def histogram_data_point(metrics)
+            return if metrics.data_points.empty?
+
+            if metrics.data_points.first.instance_of?(OpenTelemetry::SDK::Metrics::Aggregation::ExponentialHistogramDataPoint)
+              Opentelemetry::Proto::Metrics::V1::Metric.new(
+                name: metrics.name,
+                description: metrics.description,
+                unit: metrics.unit,
+                exponential_histogram: Opentelemetry::Proto::Metrics::V1::ExponentialHistogram.new(
+                  aggregation_temporality: as_otlp_aggregation_temporality(metrics.aggregation_temporality),
+                  data_points: metrics.data_points.map do |ehdp|
+                    exponential_histogram_data_point(ehdp)
+                  end
+                )
+              )
+            elsif metrics.data_points.first.instance_of?(OpenTelemetry::SDK::Metrics::Aggregation::HistogramDataPoint)
+              Opentelemetry::Proto::Metrics::V1::Metric.new(
+                name: metrics.name,
+                description: metrics.description,
+                unit: metrics.unit,
+                histogram: Opentelemetry::Proto::Metrics::V1::Histogram.new(
+                  aggregation_temporality: as_otlp_aggregation_temporality(metrics.aggregation_temporality),
+                  data_points: metrics.data_points.map do |hdp|
+                    explicit_histogram_data_point(hdp)
+                  end
+                )
+              )
+            end
+          end
+
+          def explicit_histogram_data_point(hdp)
             Opentelemetry::Proto::Metrics::V1::HistogramDataPoint.new(
               attributes: hdp.attributes.map { |k, v| as_otlp_key_value(k, v) },
               start_time_unix_nano: hdp.start_time_unix_nano,
@@ -280,6 +301,31 @@ module OpenTelemetry
               exemplars: hdp.exemplars,
               min: hdp.min,
               max: hdp.max
+            )
+          end
+
+          def exponential_histogram_data_point(ehdp)
+            Opentelemetry::Proto::Metrics::V1::ExponentialHistogramDataPoint.new(
+              attributes: ehdp.attributes.map { |k, v| as_otlp_key_value(k, v) },
+              start_time_unix_nano: ehdp.start_time_unix_nano,
+              time_unix_nano: ehdp.time_unix_nano,
+              count: ehdp.count,
+              sum: ehdp.sum,
+              scale: ehdp.scale,
+              zero_count: ehdp.zero_count,
+              positive: Opentelemetry::Proto::Metrics::V1::ExponentialHistogramDataPoint::Buckets.new(
+                offset: ehdp.positive.offset,
+                bucket_counts: ehdp.positive.counts
+              ),
+              negative: Opentelemetry::Proto::Metrics::V1::ExponentialHistogramDataPoint::Buckets.new(
+                offset: ehdp.negative.offset,
+                bucket_counts: ehdp.negative.counts
+              ),
+              flags: ehdp.flags,
+              exemplars: ehdp.exemplars,
+              min: ehdp.min,
+              max: ehdp.max,
+              zero_threshold: ehdp.zero_threshold
             )
           end
 

--- a/exporter/otlp-metrics/test/opentelemetry/exporter/otlp/metrics/metrics_exporter_test.rb
+++ b/exporter/otlp-metrics/test/opentelemetry/exporter/otlp/metrics/metrics_exporter_test.rb
@@ -609,6 +609,11 @@ describe OpenTelemetry::Exporter::OTLP::Metrics::MetricsExporter do
       gauge = meter.create_gauge('test_gauge', unit: 'smidgen', description: 'a small amount of something')
       gauge.record(15, attributes: { 'baz' => 'qux' })
 
+      meter_provider.add_view('*exponential*', aggregation: OpenTelemetry::SDK::Metrics::Aggregation::ExponentialBucketHistogram.new(max_scale: 20), type: :histogram, unit: 'smidgen')
+
+      exponential_histogram = meter.create_histogram('test_exponential_histogram', unit: 'smidgen', description: 'a small amount of something')
+      exponential_histogram.record(20, attributes: { 'lox' => 'xol' })
+
       exporter.pull
       meter_provider.shutdown
 
@@ -710,6 +715,40 @@ describe OpenTelemetry::Exporter::OTLP::Metrics::MetricsExporter do
                             exemplars: nil
                           )
                         ]
+                      )
+                    ),
+                    Opentelemetry::Proto::Metrics::V1::Metric.new(
+                      name: 'test_exponential_histogram',
+                      description: 'a small amount of something',
+                      unit: 'smidgen',
+                      exponential_histogram: Opentelemetry::Proto::Metrics::V1::ExponentialHistogram.new(
+                        data_points: [
+                          Opentelemetry::Proto::Metrics::V1::ExponentialHistogramDataPoint.new(
+                            attributes: [
+                              Opentelemetry::Proto::Common::V1::KeyValue.new(key: 'lox', value: Opentelemetry::Proto::Common::V1::AnyValue.new(string_value: 'xol'))
+                            ],
+                            start_time_unix_nano: 1_699_593_427_329_946_585,
+                            time_unix_nano: 1_699_593_427_329_946_586,
+                            count: 1,
+                            sum: 20,
+                            scale: 20,
+                            zero_count: 0,
+                            positive: Opentelemetry::Proto::Metrics::V1::ExponentialHistogramDataPoint::Buckets.new(
+                              offset: 4_531_870,
+                              bucket_counts: [1]
+                            ),
+                            negative: Opentelemetry::Proto::Metrics::V1::ExponentialHistogramDataPoint::Buckets.new(
+                              offset: 0,
+                              bucket_counts: [0]
+                            ),
+                            flags: 0,
+                            exemplars: nil,
+                            min: 20,
+                            max: 20,
+                            zero_threshold: 0
+                          )
+                        ],
+                        aggregation_temporality: Opentelemetry::Proto::Metrics::V1::AggregationTemporality::AGGREGATION_TEMPORALITY_DELTA
                       )
                     )
                   ]

--- a/exporter/otlp-metrics/test/test_helper.rb
+++ b/exporter/otlp-metrics/test/test_helper.rb
@@ -27,6 +27,7 @@ end
 OpenTelemetry::SDK::Metrics::Aggregation::Sum.prepend(MockSum)
 OpenTelemetry::SDK::Metrics::Aggregation::ExplicitBucketHistogram.prepend(MockSum)
 OpenTelemetry::SDK::Metrics::Aggregation::LastValue.prepend(MockSum)
+OpenTelemetry::SDK::Metrics::Aggregation::ExponentialBucketHistogram.prepend(MockSum)
 
 def create_metrics_data(name: '', description: '', unit: '', instrument_kind: :counter, resource: nil,
                         instrumentation_scope: OpenTelemetry::SDK::InstrumentationScope.new('', 'v0.0.1'),


### PR DESCRIPTION
Adding support to otlp metrics exporter when recording histogram that use exponential histogram bucket.

When determining the instrument kind (e.g., via `as_otlp_metrics(metrics)`), OpenTelemetry Ruby typically uses `metrics.instrument_kind`. However, this approach doesn't work for exponential_histogram, so it needs to inspect the type of the data points instead. This is similar to how Python uses `isinstance(metric.data, ExponentialHistogramType)`. Refactoring the Ruby implementation to follow a similar pattern could be a potential improvement.
