### PR TITLE
feat!: Set logs exporter default to OTLP

### DIFF
--- a/logs_sdk/lib/opentelemetry/sdk/logs/configurator_patch.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/configurator_patch.rb
@@ -36,8 +36,7 @@ module OpenTelemetry
         end
 
         def wrapped_log_exporters_from_env
-          # TODO: set default to OTLP to match traces, default is console until other exporters merged
-          exporters = ENV.fetch('OTEL_LOGS_EXPORTER', 'console')
+          exporters = ENV.fetch('OTEL_LOGS_EXPORTER', 'otlp')
 
           exporters.split(',').map do |exporter|
             case exporter.strip


### PR DESCRIPTION
The OTLP logs exporter is available on RubyGems. This changes the default to match the other signals.