### PR TITLE
chore: Skip flaky logs test on Windows

### DIFF
--- a/logs_sdk/test/opentelemetry/sdk/logs/export/batch_log_record_processor_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/export/batch_log_record_processor_test.rb
@@ -472,6 +472,9 @@ describe OpenTelemetry::SDK::Logs::Export::BatchLogRecordProcessor do
     let(:processor) { BatchLogRecordProcessor.new(exporter) }
 
     it 'reports export failures' do
+      # This test is unreliable on Windows platforms, but works just fine on others
+      skip if Gem.win_platform?
+
       # skip the work method's behavior, we rely on shutdown to get us to the failures
       processor.stub(:work, nil) do
         mock_logger = Minitest::Mock.new


### PR DESCRIPTION
We keep running out of expectations on the Windows platform. This is intermittent, but happens frequently enough that it's blocking releases.