### PR TITLE
fix: validate scale range and raise exception if out of bounds

### DIFF
--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/aggregation/exponential_bucket_histogram.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/aggregation/exponential_bucket_histogram.rb
@@ -207,15 +207,15 @@ module OpenTelemetry
           end
 
           def validate_scale(scale)
-            raise ArgumentError, "Scale #{scale} is larger than maximal scale #{MAX_SCALE}" if scale > MAX_SCALE
-            raise ArgumentError, "Scale #{scale} is smaller than minimal scale #{MIN_SCALE}" if scale < MIN_SCALE
+            raise ArgumentError, "Scale #{scale} is larger than maximum scale #{MAX_SCALE}" if scale > MAX_SCALE
+            raise ArgumentError, "Scale #{scale} is smaller than minimum scale #{MIN_SCALE}" if scale < MIN_SCALE
 
             scale
           end
 
           def validate_size(size)
-            raise ArgumentError, "Max size #{size} is smaller than minimal size #{MIN_MAX_SIZE}" if size < MIN_MAX_SIZE
-            raise ArgumentError, "Max size #{size} is larger than maximal size #{MAX_MAX_SIZE}" if size > MAX_MAX_SIZE
+            raise ArgumentError, "Max size #{size} is smaller than minimum size #{MIN_MAX_SIZE}" if size < MIN_MAX_SIZE
+            raise ArgumentError, "Max size #{size} is larger than maximum size #{MAX_MAX_SIZE}" if size > MAX_MAX_SIZE
 
             size
           end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/aggregation/exponential_bucket_histogram.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/aggregation/exponential_bucket_histogram.rb
@@ -19,15 +19,18 @@ module OpenTelemetry
           attr_reader :aggregation_temporality
 
           # relate to min max scale: https://opentelemetry.io/docs/specs/otel/metrics/sdk/#support-a-minimum-and-maximum-scale
+          DEFAULT_SIZE  = 160
+          DEFAULT_SCALE = 20
           MAX_SCALE = 20
           MIN_SCALE = -10
-          MAX_SIZE  = 160
+          MIN_MAX_SIZE = 2
+          MAX_MAX_SIZE = 16_384
 
           # The default boundaries are calculated based on default max_size and max_scale values
           def initialize(
             aggregation_temporality: ENV.fetch('OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE', :delta),
-            max_size: MAX_SIZE,
-            max_scale: MAX_SCALE,
+            max_size: DEFAULT_SIZE,
+            max_scale: DEFAULT_SCALE,
             record_min_max: true,
             zero_threshold: 0
           )
@@ -175,6 +178,7 @@ module OpenTelemetry
           end
 
           def new_mapping(scale)
+            scale = validate_scale(scale)
             scale <= 0 ? ExponentialHistogram::ExponentMapping.new(scale) : ExponentialHistogram::LogarithmMapping.new(scale)
           end
 
@@ -203,17 +207,17 @@ module OpenTelemetry
           end
 
           def validate_scale(scale)
-            return scale unless scale > MAX_SCALE || scale < MIN_SCALE
+            raise ArgumentError, "Scale #{scale} is larger than maximal scale #{MAX_SCALE}" if scale > MAX_SCALE
+            raise ArgumentError, "Scale #{scale} is smaller than minimal scale #{MIN_SCALE}" if scale < MIN_SCALE
 
-            OpenTelemetry.logger.warn "Scale #{scale} is invalid, using default max scale #{MAX_SCALE}"
-            MAX_SCALE
+            scale
           end
 
           def validate_size(size)
-            return size unless size > MAX_SIZE || size < 0
+            raise ArgumentError, "Max size #{size} is smaller than minimal size #{MIN_MAX_SIZE}" if size < MIN_MAX_SIZE
+            raise ArgumentError, "Max size #{size} is larger than maximal size #{MAX_MAX_SIZE}" if size > MAX_MAX_SIZE
 
-            OpenTelemetry.logger.warn "Size #{size} is invalid, using default max size #{MAX_SIZE}"
-            MAX_SIZE
+            size
           end
         end
       end

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/aggregation/exponential_bucket_histogram_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/aggregation/exponential_bucket_histogram_test.rb
@@ -260,24 +260,24 @@ describe OpenTelemetry::SDK::Metrics::Aggregation::ExponentialBucketHistogram do
       error = assert_raises(ArgumentError) do
         OpenTelemetry::SDK::Metrics::Aggregation::ExponentialBucketHistogram.new(max_scale: 100)
       end
-      assert_equal('Scale 100 is larger than maximal scale 20', error.message)
+      assert_equal('Scale 100 is larger than maximum scale 20', error.message)
 
       error = assert_raises(ArgumentError) do
         OpenTelemetry::SDK::Metrics::Aggregation::ExponentialBucketHistogram.new(max_scale: -20)
       end
-      assert_equal('Scale -20 is smaller than minimal scale -10', error.message)
+      assert_equal('Scale -20 is smaller than minimum scale -10', error.message)
     end
 
     it 'test_invalid_size_validation' do
       error = assert_raises(ArgumentError) do
         OpenTelemetry::SDK::Metrics::Aggregation::ExponentialBucketHistogram.new(max_size: 10_000_000)
       end
-      assert_equal('Max size 10000000 is larger than maximal size 16384', error.message)
+      assert_equal('Max size 10000000 is larger than maximum size 16384', error.message)
 
       error = assert_raises(ArgumentError) do
         OpenTelemetry::SDK::Metrics::Aggregation::ExponentialBucketHistogram.new(max_size: 0)
       end
-      assert_equal('Max size 0 is smaller than minimal size 2', error.message)
+      assert_equal('Max size 0 is smaller than minimum size 2', error.message)
     end
   end
 end

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/aggregation/exponential_bucket_histogram_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/aggregation/exponential_bucket_histogram_test.rb
@@ -255,5 +255,29 @@ describe OpenTelemetry::SDK::Metrics::Aggregation::ExponentialBucketHistogram do
     it 'test_merge' do
       # TODO
     end
+
+    it 'test_invalid_scale_validation' do
+      error = assert_raises(ArgumentError) do
+        OpenTelemetry::SDK::Metrics::Aggregation::ExponentialBucketHistogram.new(max_scale: 100)
+      end
+      assert_equal('Scale 100 is larger than maximal scale 20', error.message)
+
+      error = assert_raises(ArgumentError) do
+        OpenTelemetry::SDK::Metrics::Aggregation::ExponentialBucketHistogram.new(max_scale: -20)
+      end
+      assert_equal('Scale -20 is smaller than minimal scale -10', error.message)
+    end
+
+    it 'test_invalid_size_validation' do
+      error = assert_raises(ArgumentError) do
+        OpenTelemetry::SDK::Metrics::Aggregation::ExponentialBucketHistogram.new(max_size: 10_000_000)
+      end
+      assert_equal('Max size 10000000 is larger than maximal size 16384', error.message)
+
+      error = assert_raises(ArgumentError) do
+        OpenTelemetry::SDK::Metrics::Aggregation::ExponentialBucketHistogram.new(max_size: 0)
+      end
+      assert_equal('Max size 0 is smaller than minimal size 2', error.message)
+    end
   end
 end


### PR DESCRIPTION
## Description

During testing, we encountered scale values that exceeded the valid range (from 20 to -10), which led to huge bucket size when rescaling occurred during aggregation. To address this, we added explicit validation to ensure the scale remains within the allowed range. If the scale is out of bounds, an exception is raised, but it will not interrupt the application or metrics collection process.

**Sample error output:**

```
E, [2025-07-09T17:27:13.800435 #50669] ERROR -- : OpenTelemetry error: Scale 30 is larger than maximal scale 20 - /usr/local/bundle/gems/opentelemetry-metrics-sdk-0.7.3/lib/opentelemetry/sdk/metrics/aggregation/exponential_bucket_histogram.rb:217:in `validate_scale'
```

### Additional Changes
Updated the default parameter to a new constant named `DEFAULT_*` to avoid confusion that the default is the maximum allowed value. Also added `MIN_MAX_SIZE` and `MAX_MAX_SIZE` to define the valid value range for max_size in the bucket.