### PR TITLE
fix: Handle exporting nil otlp metric

### DIFF
--- a/exporter/otlp-metrics/lib/opentelemetry/exporter/otlp/metrics/metrics_exporter.rb
+++ b/exporter/otlp-metrics/lib/opentelemetry/exporter/otlp/metrics/metrics_exporter.rb
@@ -201,7 +201,7 @@ module OpenTelemetry
                               name: instrumentation_scope.name,
                               version: instrumentation_scope.version
                             ),
-                            metrics: metrics.map { |sd| as_otlp_metrics(sd) }
+                            metrics: metrics.filter_map { |sd| as_otlp_metrics(sd) }
                           )
                         end
                     )


### PR DESCRIPTION
### Type of change

Bug fix

### Linked issue

https://github.com/open-telemetry/opentelemetry-ruby/issues/1864

### Why

The `metrics` field in `Opentelemetry::Proto::Metrics::V1::ScopeMetrics` cannot contain a `nil` value.

### How

Use the `filter_map`, instead of `map`, function to remove values that are not truthy (i.e. nil).