### PR TITLE
feat!: add noop for Trace::Span attributes and events

### DIFF
--- a/api/lib/opentelemetry/trace/span.rb
+++ b/api/lib/opentelemetry/trace/span.rb
@@ -78,6 +78,18 @@ module OpenTelemetry
         self
       end
 
+      # Retrieve attributes
+      #
+      # Note that the OpenTelemetry project
+      # {https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md
+      # documents} certain "standard attributes" that have prescribed semantic
+      # meanings.
+      #
+      # @return [hash] returns empty hash
+      def attributes
+        {}
+      end
+
       # Add a link to a {Span}.
       #
       # Adding links at span creation using the `links` option is preferred
@@ -121,6 +133,18 @@ module OpenTelemetry
       # @return [self] returns itself
       def add_event(name, attributes: nil, timestamp: nil)
         self
+      end
+
+      # Retrieve events
+      #
+      # Note that the OpenTelemetry project
+      # {https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md
+      # documents} certain "standard event names and keys" which have
+      # prescribed semantic meanings.
+      #
+      # @return [array] returns empty array
+      def events
+        []
       end
 
       # Record an exception during the execution of this span. Multiple exceptions


### PR DESCRIPTION
### Description

Adds no-op `attributes` and `events` methods to `OpenTelemetry::Trace::Span`.

This change ensures that when `in_span` returns a non-recording or invalid span (i.e., a no-op span), calls like `span.attributes` or `span.events` won't raise method errors. This prevents crashes in cases like [AWS Lambda instrumentation](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/opentelemetry-instrumentation-aws_lambda/v0.3.0/instrumentation/aws_lambda/lib/opentelemetry/instrumentation/aws_lambda/wrap.rb#L46), where such calls may occur on no-op spans.

Operational function from sdk: [attributes](https://github.com/open-telemetry/opentelemetry-ruby/blob/main/sdk/lib/opentelemetry/sdk/trace/span.rb#L39), [events](https://github.com/open-telemetry/opentelemetry-ruby/blob/main/sdk/lib/opentelemetry/sdk/trace/span.rb#L50)