### PR TITLE
fix: Update max instrument length from 63 to 255

### DIFF
--- a/metrics_api/lib/opentelemetry/metrics/meter.rb
+++ b/metrics_api/lib/opentelemetry/metrics/meter.rb
@@ -16,7 +16,7 @@ module OpenTelemetry
       UP_DOWN_COUNTER = Instrument::UpDownCounter.new
       OBSERVABLE_UP_DOWN_COUNTER = Instrument::ObservableUpDownCounter.new
 
-      NAME_REGEX = /\A[a-zA-Z][-.\/\w]{0,254}\z/
+      NAME_REGEX = %r{\A[a-zA-Z][-.\/\w]{0,254}\z}
 
       private_constant(:COUNTER, :OBSERVABLE_COUNTER, :HISTOGRAM, :GAUGE, :OBSERVABLE_GAUGE, :UP_DOWN_COUNTER, :OBSERVABLE_UP_DOWN_COUNTER)
 

--- a/metrics_api/lib/opentelemetry/metrics/meter.rb
+++ b/metrics_api/lib/opentelemetry/metrics/meter.rb
@@ -16,7 +16,7 @@ module OpenTelemetry
       UP_DOWN_COUNTER = Instrument::UpDownCounter.new
       OBSERVABLE_UP_DOWN_COUNTER = Instrument::ObservableUpDownCounter.new
 
-      NAME_REGEX = /\A[a-zA-Z][-.\w]{0,62}\z/
+      NAME_REGEX = /\A[a-zA-Z][-.\w]{0,255}\z/
 
       private_constant(:COUNTER, :OBSERVABLE_COUNTER, :HISTOGRAM, :GAUGE, :OBSERVABLE_GAUGE, :UP_DOWN_COUNTER, :OBSERVABLE_UP_DOWN_COUNTER)
 

--- a/metrics_api/lib/opentelemetry/metrics/meter.rb
+++ b/metrics_api/lib/opentelemetry/metrics/meter.rb
@@ -16,7 +16,7 @@ module OpenTelemetry
       UP_DOWN_COUNTER = Instrument::UpDownCounter.new
       OBSERVABLE_UP_DOWN_COUNTER = Instrument::ObservableUpDownCounter.new
 
-      NAME_REGEX = %r{\A[a-zA-Z][-.\/\w]{0,254}\z}
+      NAME_REGEX = %r{\A[a-zA-Z][-./\w]{0,254}\z}
 
       private_constant(:COUNTER, :OBSERVABLE_COUNTER, :HISTOGRAM, :GAUGE, :OBSERVABLE_GAUGE, :UP_DOWN_COUNTER, :OBSERVABLE_UP_DOWN_COUNTER)
 

--- a/metrics_api/lib/opentelemetry/metrics/meter.rb
+++ b/metrics_api/lib/opentelemetry/metrics/meter.rb
@@ -16,7 +16,7 @@ module OpenTelemetry
       UP_DOWN_COUNTER = Instrument::UpDownCounter.new
       OBSERVABLE_UP_DOWN_COUNTER = Instrument::ObservableUpDownCounter.new
 
-      NAME_REGEX = /\A[a-zA-Z][-.\w]{0,255}\z/
+      NAME_REGEX = /\A[a-zA-Z][-.\/\w]{0,254}\z/
 
       private_constant(:COUNTER, :OBSERVABLE_COUNTER, :HISTOGRAM, :GAUGE, :OBSERVABLE_GAUGE, :UP_DOWN_COUNTER, :OBSERVABLE_UP_DOWN_COUNTER)
 

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/meter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/meter.rb
@@ -11,7 +11,7 @@ module OpenTelemetry
     module Metrics
       # {Meter} is the SDK implementation of {OpenTelemetry::Metrics::Meter}.
       class Meter < OpenTelemetry::Metrics::Meter
-        NAME_REGEX = /\A[a-zA-Z][-.\w]{0,62}\z/
+        NAME_REGEX = /\A[a-zA-Z][-.\w]{0,255}\z/
 
         # @api private
         #

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/meter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/meter.rb
@@ -11,7 +11,7 @@ module OpenTelemetry
     module Metrics
       # {Meter} is the SDK implementation of {OpenTelemetry::Metrics::Meter}.
       class Meter < OpenTelemetry::Metrics::Meter
-        NAME_REGEX = /\A[a-zA-Z][-.\/\w]{0,254}\z/
+        NAME_REGEX = %r{\A[a-zA-Z][-./\w]{0,254}\z}
 
         # @api private
         #

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/meter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/meter.rb
@@ -11,7 +11,7 @@ module OpenTelemetry
     module Metrics
       # {Meter} is the SDK implementation of {OpenTelemetry::Metrics::Meter}.
       class Meter < OpenTelemetry::Metrics::Meter
-        NAME_REGEX = /\A[a-zA-Z][-.\w]{0,255}\z/
+        NAME_REGEX = /\A[a-zA-Z][-.\/\w]{0,254}\z/
 
         # @api private
         #

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/meter_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/meter_test.rb
@@ -185,8 +185,8 @@ describe OpenTelemetry::SDK::Metrics::Meter do
       _(-> { meter.create_counter('1_counter') }).must_raise(INSTRUMENT_NAME_ERROR)
     end
 
-    it 'instrument name must not exceed 63 character limit' do
-      long_name = 'a' * 63
+    it 'instrument name must not exceed 256 character limit' do
+      long_name = 'a' * 256
       meter.create_counter(long_name)
       _(-> { meter.create_counter(long_name + 'a') }).must_raise(INSTRUMENT_NAME_ERROR)
     end

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/meter_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/meter_test.rb
@@ -191,8 +191,8 @@ describe OpenTelemetry::SDK::Metrics::Meter do
       _(-> { meter.create_counter(long_name + 'a') }).must_raise(INSTRUMENT_NAME_ERROR)
     end
 
-    it 'instrument name must belong to alphanumeric characters, _, ., and -' do
-      meter.create_counter('a_-..-_a')
+    it 'instrument name must belong to alphanumeric characters, _, ., -, and /' do
+      meter.create_counter('a_/-..-/_a')
       _(-> { meter.create_counter('a@') }).must_raise(INSTRUMENT_NAME_ERROR)
       _(-> { meter.create_counter('a!') }).must_raise(INSTRUMENT_NAME_ERROR)
     end

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/meter_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/meter_test.rb
@@ -185,8 +185,8 @@ describe OpenTelemetry::SDK::Metrics::Meter do
       _(-> { meter.create_counter('1_counter') }).must_raise(INSTRUMENT_NAME_ERROR)
     end
 
-    it 'instrument name must not exceed 256 character limit' do
-      long_name = 'a' * 256
+    it 'instrument name must not exceed 255 character limit' do
+      long_name = 'a' * 255
       meter.create_counter(long_name)
       _(-> { meter.create_counter(long_name + 'a') }).must_raise(INSTRUMENT_NAME_ERROR)
     end


### PR DESCRIPTION
The current specification states that the max instrument length is 255 chars:
https://opentelemetry.io/docs/specs/otel/metrics/api/#instrument-name-syntax

This commit updates the Ruby sdk to reflect this!