### PR TITLE
feat: add low memory to TEMPORALITY_PREFERENCE

### DIFF
--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/aggregation/explicit_bucket_histogram.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/aggregation/explicit_bucket_histogram.rb
@@ -23,7 +23,7 @@ module OpenTelemetry
             boundaries: DEFAULT_BOUNDARIES,
             record_min_max: true
           )
-            @aggregation_temporality = aggregation_temporality.to_sym == :delta ? AggregationTemporality.delta : AggregationTemporality.cumulative
+            @aggregation_temporality = AggregationTemporality.determine_temporality(aggregation_temporality: aggregation_temporality, default: :cumulative)
             @boundaries = boundaries && !boundaries.empty? ? boundaries.sort : nil
             @record_min_max = record_min_max
           end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/aggregation/exponential_bucket_histogram.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/aggregation/exponential_bucket_histogram.rb
@@ -16,8 +16,6 @@ module OpenTelemetry
       module Aggregation
         # Contains the implementation of the {https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponentialhistogram ExponentialBucketHistogram} aggregation
         class ExponentialBucketHistogram # rubocop:disable Metrics/ClassLength
-          attr_reader :aggregation_temporality
-
           # relate to min max scale: https://opentelemetry.io/docs/specs/otel/metrics/sdk/#support-a-minimum-and-maximum-scale
           DEFAULT_SIZE  = 160
           DEFAULT_SCALE = 20
@@ -34,7 +32,7 @@ module OpenTelemetry
             record_min_max: true,
             zero_threshold: 0
           )
-            @aggregation_temporality = aggregation_temporality.to_sym
+            @aggregation_temporality = AggregationTemporality.determine_temporality(aggregation_temporality: aggregation_temporality, default: :delta)
             @record_min_max = record_min_max
             @min            = Float::INFINITY
             @max            = -Float::INFINITY
@@ -49,7 +47,7 @@ module OpenTelemetry
           end
 
           def collect(start_time, end_time, data_points)
-            if @aggregation_temporality == :delta
+            if @aggregation_temporality.delta?
               # Set timestamps and 'move' data point values to result.
               hdps = data_points.values.map! do |hdp|
                 hdp.start_time_unix_nano = start_time
@@ -167,6 +165,10 @@ module OpenTelemetry
             nil
           end
           # rubocop:enable Metrics/MethodLength
+
+          def aggregation_temporality
+            @aggregation_temporality.temporality
+          end
 
           private
 

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/aggregation/sum.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/aggregation/sum.rb
@@ -11,8 +11,8 @@ module OpenTelemetry
         # Contains the implementation of the Sum aggregation
         # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#sum-aggregation
         class Sum
-          def initialize(aggregation_temporality: ENV.fetch('OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE', :cumulative), monotonic: false)
-            @aggregation_temporality = aggregation_temporality.to_sym == :delta ? AggregationTemporality.delta : AggregationTemporality.cumulative
+          def initialize(aggregation_temporality: ENV.fetch('OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE', :cumulative), monotonic: false, instrument_kind: nil)
+            @aggregation_temporality = AggregationTemporality.determine_temporality(aggregation_temporality: aggregation_temporality, instrument_kind: instrument_kind, default: :cumulative)
             @monotonic = monotonic
           end
 

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/observable_counter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/observable_counter.rb
@@ -32,7 +32,7 @@ module OpenTelemetry
           private
 
           def default_aggregation
-            OpenTelemetry::SDK::Metrics::Aggregation::Sum.new(monotonic: true)
+            OpenTelemetry::SDK::Metrics::Aggregation::Sum.new(monotonic: true, instrument_kind: instrument_kind)
           end
         end
       end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/observable_up_down_counter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/observable_up_down_counter.rb
@@ -32,7 +32,7 @@ module OpenTelemetry
           private
 
           def default_aggregation
-            OpenTelemetry::SDK::Metrics::Aggregation::Sum.new(aggregation_temporality: :delta, monotonic: false)
+            OpenTelemetry::SDK::Metrics::Aggregation::Sum.new(aggregation_temporality: :cumulative, monotonic: false)
           end
         end
       end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/up_down_counter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/instrument/up_down_counter.rb
@@ -35,7 +35,7 @@ module OpenTelemetry
           private
 
           def default_aggregation
-            OpenTelemetry::SDK::Metrics::Aggregation::Sum.new(monotonic: false)
+            OpenTelemetry::SDK::Metrics::Aggregation::Sum.new(aggregation_temporality: :cumulative, monotonic: false)
           end
         end
       end

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/aggregation/aggregation_temporality_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/aggregation/aggregation_temporality_test.rb
@@ -1,0 +1,295 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+describe OpenTelemetry::SDK::Metrics::Aggregation::AggregationTemporality do
+  describe '.determine_temporality' do
+    describe 'with CUMULATIVE preference' do
+      it 'returns cumulative for counter instrument' do
+        result = OpenTelemetry::TestHelpers.with_env('OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE' => 'cumulative') do
+          OpenTelemetry::SDK::Metrics::Aggregation::AggregationTemporality.determine_temporality(
+            aggregation_temporality: ENV['OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE'],
+            instrument_kind: :counter,
+            default: :cumulative
+          )
+        end
+        _(result.temporality).must_equal :cumulative
+        _(result.cumulative?).must_equal true
+        _(result.delta?).must_equal false
+      end
+
+      it 'returns cumulative for observable_counter instrument' do
+        result = OpenTelemetry::TestHelpers.with_env('OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE' => 'cumulative') do
+          OpenTelemetry::SDK::Metrics::Aggregation::AggregationTemporality.determine_temporality(
+            aggregation_temporality: ENV['OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE'],
+            instrument_kind: :observable_counter,
+            default: :cumulative
+          )
+        end
+        _(result.temporality).must_equal :cumulative
+        _(result.cumulative?).must_equal true
+      end
+
+      it 'returns cumulative for histogram instrument' do
+        result = OpenTelemetry::TestHelpers.with_env('OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE' => 'cumulative') do
+          OpenTelemetry::SDK::Metrics::Aggregation::AggregationTemporality.determine_temporality(
+            aggregation_temporality: ENV['OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE'],
+            instrument_kind: :histogram,
+            default: :cumulative
+          )
+        end
+        _(result.temporality).must_equal :cumulative
+        _(result.cumulative?).must_equal true
+      end
+
+      it 'returns cumulative for up_down_counter instrument' do
+        result = OpenTelemetry::TestHelpers.with_env('OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE' => 'cumulative') do
+          OpenTelemetry::SDK::Metrics::Aggregation::AggregationTemporality.determine_temporality(
+            aggregation_temporality: ENV['OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE'],
+            instrument_kind: :up_down_counter,
+            default: :cumulative
+          )
+        end
+        _(result.temporality).must_equal :cumulative
+        _(result.cumulative?).must_equal true
+      end
+
+      it 'returns cumulative for observable_up_down_counter instrument' do
+        result = OpenTelemetry::TestHelpers.with_env('OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE' => 'CUMULATIVE') do
+          OpenTelemetry::SDK::Metrics::Aggregation::AggregationTemporality.determine_temporality(
+            aggregation_temporality: ENV['OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE'],
+            instrument_kind: :observable_up_down_counter,
+            default: :cumulative
+          )
+        end
+        _(result.temporality).must_equal :cumulative
+        _(result.cumulative?).must_equal true
+      end
+    end
+
+    describe 'with DELTA preference' do
+      it 'returns delta for counter instrument' do
+        result = OpenTelemetry::TestHelpers.with_env('OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE' => 'delta') do
+          OpenTelemetry::SDK::Metrics::Aggregation::AggregationTemporality.determine_temporality(
+            aggregation_temporality: ENV['OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE'],
+            instrument_kind: :counter,
+            default: :cumulative
+          )
+        end
+        _(result.temporality).must_equal :delta
+        _(result.delta?).must_equal true
+        _(result.cumulative?).must_equal false
+      end
+
+      it 'returns delta for observable_counter instrument' do
+        result = OpenTelemetry::TestHelpers.with_env('OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE' => 'delta') do
+          OpenTelemetry::SDK::Metrics::Aggregation::AggregationTemporality.determine_temporality(
+            aggregation_temporality: ENV['OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE'],
+            instrument_kind: :observable_counter,
+            default: :cumulative
+          )
+        end
+        _(result.temporality).must_equal :delta
+        _(result.delta?).must_equal true
+      end
+
+      it 'returns delta for histogram instrument' do
+        result = OpenTelemetry::TestHelpers.with_env('OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE' => 'DELTA') do
+          OpenTelemetry::SDK::Metrics::Aggregation::AggregationTemporality.determine_temporality(
+            aggregation_temporality: ENV['OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE'],
+            instrument_kind: :histogram,
+            default: :cumulative
+          )
+        end
+        _(result.temporality).must_equal :delta
+        _(result.delta?).must_equal true
+      end
+    end
+
+    describe 'with LOWMEMORY preference' do
+      it 'returns delta for counter instrument' do
+        result = OpenTelemetry::TestHelpers.with_env('OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE' => 'lowmemory') do
+          OpenTelemetry::SDK::Metrics::Aggregation::AggregationTemporality.determine_temporality(
+            aggregation_temporality: ENV['OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE'],
+            instrument_kind: :counter,
+            default: :cumulative
+          )
+        end
+        _(result.temporality).must_equal :delta
+        _(result.delta?).must_equal true
+      end
+
+      it 'returns cumulative for observable_counter instrument' do
+        result = OpenTelemetry::TestHelpers.with_env('OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE' => 'lowmemory') do
+          OpenTelemetry::SDK::Metrics::Aggregation::AggregationTemporality.determine_temporality(
+            aggregation_temporality: ENV['OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE'],
+            instrument_kind: :observable_counter,
+            default: :cumulative
+          )
+        end
+        _(result.temporality).must_equal :cumulative
+        _(result.cumulative?).must_equal true
+      end
+
+      it 'returns delta for histogram instrument' do
+        result = OpenTelemetry::TestHelpers.with_env('OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE' => 'LOWMEMORY') do
+          OpenTelemetry::SDK::Metrics::Aggregation::AggregationTemporality.determine_temporality(
+            aggregation_temporality: ENV['OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE'],
+            instrument_kind: :histogram,
+            default: :cumulative
+          )
+        end
+        _(result.temporality).must_equal :delta
+        _(result.delta?).must_equal true
+      end
+    end
+
+    describe 'with symbol parameters' do
+      it 'returns delta when aggregation_temporality is :delta' do
+        result = OpenTelemetry::SDK::Metrics::Aggregation::AggregationTemporality.determine_temporality(
+          aggregation_temporality: :delta,
+          instrument_kind: :counter,
+          default: :cumulative
+        )
+        _(result.temporality).must_equal :delta
+        _(result.delta?).must_equal true
+      end
+
+      it 'returns cumulative when aggregation_temporality is :cumulative' do
+        result = OpenTelemetry::SDK::Metrics::Aggregation::AggregationTemporality.determine_temporality(
+          aggregation_temporality: :cumulative,
+          instrument_kind: :counter,
+          default: :delta
+        )
+        _(result.temporality).must_equal :cumulative
+        _(result.cumulative?).must_equal true
+      end
+    end
+
+    describe 'with case variations' do
+      it 'handles uppercase DELTA' do
+        result = OpenTelemetry::SDK::Metrics::Aggregation::AggregationTemporality.determine_temporality(
+          aggregation_temporality: 'DELTA',
+          instrument_kind: :counter,
+          default: :cumulative
+        )
+        _(result.temporality).must_equal :delta
+      end
+
+      it 'handles uppercase CUMULATIVE' do
+        result = OpenTelemetry::SDK::Metrics::Aggregation::AggregationTemporality.determine_temporality(
+          aggregation_temporality: 'CUMULATIVE',
+          instrument_kind: :counter,
+          default: :delta
+        )
+        _(result.temporality).must_equal :cumulative
+      end
+
+      it 'handles uppercase LOWMEMORY' do
+        result = OpenTelemetry::SDK::Metrics::Aggregation::AggregationTemporality.determine_temporality(
+          aggregation_temporality: 'LOWMEMORY',
+          instrument_kind: :counter,
+          default: :cumulative
+        )
+        _(result.temporality).must_equal :delta
+      end
+
+      it 'handles lowercase delta' do
+        result = OpenTelemetry::SDK::Metrics::Aggregation::AggregationTemporality.determine_temporality(
+          aggregation_temporality: 'delta',
+          instrument_kind: :counter,
+          default: :cumulative
+        )
+        _(result.temporality).must_equal :delta
+      end
+
+      it 'handles lowercase cumulative' do
+        result = OpenTelemetry::SDK::Metrics::Aggregation::AggregationTemporality.determine_temporality(
+          aggregation_temporality: 'cumulative',
+          instrument_kind: :counter,
+          default: :delta
+        )
+        _(result.temporality).must_equal :cumulative
+      end
+
+      it 'handles lowercase lowmemory' do
+        result = OpenTelemetry::SDK::Metrics::Aggregation::AggregationTemporality.determine_temporality(
+          aggregation_temporality: 'lowmemory',
+          instrument_kind: :counter,
+          default: :cumulative
+        )
+        _(result.temporality).must_equal :delta
+      end
+    end
+
+    describe 'with unknown string values' do
+      it 'falls back to default when default is :delta' do
+        result = OpenTelemetry::SDK::Metrics::Aggregation::AggregationTemporality.determine_temporality(
+          aggregation_temporality: 'unknown',
+          instrument_kind: :counter,
+          default: :delta
+        )
+        _(result.temporality).must_equal :delta
+      end
+
+      it 'falls back to cumulative when default is :cumulative' do
+        result = OpenTelemetry::SDK::Metrics::Aggregation::AggregationTemporality.determine_temporality(
+          aggregation_temporality: 'unknown',
+          instrument_kind: :counter,
+          default: :cumulative
+        )
+        _(result.temporality).must_equal :cumulative
+      end
+    end
+
+    describe 'with environment variable integration' do
+      it 'respects OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE set to cumulative' do
+        result = OpenTelemetry::TestHelpers.with_env('OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE' => 'cumulative') do
+          OpenTelemetry::SDK::Metrics::Aggregation::AggregationTemporality.determine_temporality(
+            aggregation_temporality: ENV['OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE'],
+            instrument_kind: :counter,
+            default: :delta
+          )
+        end
+        _(result.temporality).must_equal :cumulative
+      end
+
+      it 'respects OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE set to delta' do
+        result = OpenTelemetry::TestHelpers.with_env('OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE' => 'delta') do
+          OpenTelemetry::SDK::Metrics::Aggregation::AggregationTemporality.determine_temporality(
+            aggregation_temporality: ENV['OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE'],
+            instrument_kind: :histogram,
+            default: :cumulative
+          )
+        end
+        _(result.temporality).must_equal :delta
+      end
+
+      it 'respects OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE set to lowmemory for non-observable counter' do
+        result = OpenTelemetry::TestHelpers.with_env('OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE' => 'lowmemory') do
+          OpenTelemetry::SDK::Metrics::Aggregation::AggregationTemporality.determine_temporality(
+            aggregation_temporality: ENV['OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE'],
+            instrument_kind: :counter,
+            default: :cumulative
+          )
+        end
+        _(result.temporality).must_equal :delta
+      end
+
+      it 'respects OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE set to lowmemory for observable counter' do
+        result = OpenTelemetry::TestHelpers.with_env('OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE' => 'lowmemory') do
+          OpenTelemetry::SDK::Metrics::Aggregation::AggregationTemporality.determine_temporality(
+            aggregation_temporality: ENV['OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE'],
+            instrument_kind: :observable_counter,
+            default: :delta
+          )
+        end
+        _(result.temporality).must_equal :cumulative
+      end
+    end
+  end
+end

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/instrument/observable_up_down_counter_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/instrument/observable_up_down_counter_test.rb
@@ -29,7 +29,7 @@ describe OpenTelemetry::SDK::Metrics::Instrument::ObservableUpDownCounter do
     _(last_snapshot[0].instrumentation_scope.name).must_equal('test')
     _(last_snapshot[0].data_points[0].value).must_equal(10)
     _(last_snapshot[0].data_points[0].attributes).must_equal({})
-    _(last_snapshot[0].aggregation_temporality).must_equal(:delta)
+    _(last_snapshot[0].aggregation_temporality).must_equal(:cumulative)
   end
 
   it 'counts with observe' do
@@ -49,6 +49,6 @@ describe OpenTelemetry::SDK::Metrics::Instrument::ObservableUpDownCounter do
 
     _(last_snapshot[0].data_points[1].value).must_equal(10)
     _(last_snapshot[0].data_points[1].attributes).must_equal({})
-    _(last_snapshot[0].aggregation_temporality).must_equal(:delta)
+    _(last_snapshot[0].aggregation_temporality).must_equal(:cumulative)
   end
 end


### PR DESCRIPTION
Closes https://github.com/open-telemetry/opentelemetry-ruby/issues/1880

Based on [source](https://github.com/open-telemetry/opentelemetry-specification/blob/10acd40725898fff74fb455c788060ce06725540/specification/metrics/sdk_exporters/otlp.md?plain=1#L50-L55), it should follow the diagram:

| Preference Value | Counter    | Async Counter    | Histogram  | UpDownCounter | Async UpDownCounter |
|------------------|------------|------------------|----------- |---------------|-------------------- |
| **Cumulative**   | Cumulative | Cumulative       | Cumulative | Cumulative    | Cumulative          |
| **Delta**        | Delta      | Delta            | Delta      | Cumulative    | Cumulative          |
| **LowMemory**    | Delta      | Cumulative       | Delta      | Cumulative    | Cumulative          |

Updown counter should always be cumulative, unless user specifically define it to delta through view.