### PR TITLE
fix: use mapping scale outside rescale logic

### DIFF
--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/aggregation/exponential_bucket_histogram.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/aggregation/exponential_bucket_histogram.rb
@@ -142,12 +142,13 @@ module OpenTelemetry
               scale_change = get_scale_change(low, high)
               downscale(scale_change, hdp.positive, hdp.negative)
               new_scale = @mapping.scale - scale_change
-              hdp.scale = new_scale
               @mapping = new_mapping(new_scale)
               bucket_index = @mapping.map_to_index(amount)
 
               OpenTelemetry.logger.debug "Rescaled with new scale #{new_scale} from #{low} and #{high}; bucket_index is updated to #{bucket_index}"
             end
+
+            hdp.scale = @mapping.scale
 
             # adjust buckets based on the bucket_index
             if bucket_index < buckets.index_start

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/aggregation/exponential_bucket_histogram_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/aggregation/exponential_bucket_histogram_test.rb
@@ -136,6 +136,28 @@ describe OpenTelemetry::SDK::Metrics::Aggregation::ExponentialBucketHistogram do
       _(exphdps[0].zero_threshold).must_equal(0)
     end
 
+    it 'adjusts_scale_after_initial_zero_value' do
+      expbh = OpenTelemetry::SDK::Metrics::Aggregation::ExponentialBucketHistogram.new(
+        aggregation_temporality: aggregation_temporality,
+        record_min_max: record_min_max,
+        zero_threshold: 0
+      )
+
+      expbh.update(0, {}, data_points)
+      expbh.update(10_000, {}, data_points)
+
+      exphdps = expbh.collect(start_time, end_time, data_points)
+
+      _(exphdps.size).must_equal(1)
+      _(exphdps[0].count).must_equal(2)
+      _(exphdps[0].sum).must_equal(10_000)
+      _(exphdps[0].min).must_equal(0)
+      _(exphdps[0].max).must_equal(10_000)
+      _(exphdps[0].scale).must_equal(20)
+      _(exphdps[0].zero_count).must_equal(1)
+      _(exphdps[0].zero_threshold).must_equal(0)
+    end
+
     it 'test_permutations' do
       test_cases = [
         [


### PR DESCRIPTION
### Description

This fix addresses an issue where providing a value of 0 followed by a value that doesn’t trigger rescaling kept the exponential histogram’s scale at 0, causing the data to be omitted from export (e.g. 0,10000). Following the [Python implementation](https://github.com/open-telemetry/opentelemetry-python/blob/v1.36.0/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/aggregation.py#L790), the scale is now set outside the downscale logic.