### PR TITLE
tests: add test case for metric_store and metric_view

### DIFF
--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/state/asynchronous_metric_stream.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/state/asynchronous_metric_stream.rb
@@ -13,6 +13,8 @@ module OpenTelemetry
         # The AsynchronousMetricStream class provides SDK internal functionality that is not a part of the
         # public API. It extends MetricStream to support asynchronous instruments.
         class AsynchronousMetricStream < MetricStream
+          DEFAULT_TIMEOUT = 30
+
           def initialize(
             name,
             description,
@@ -48,23 +50,21 @@ module OpenTelemetry
           def invoke_callback(timeout, attributes)
             if @registered_views.empty?
               @mutex.synchronize do
-                Timeout.timeout(timeout || 30) do
-                  @callback.each do |cb|
-                    value = cb.call
-                    @default_aggregation.update(value, attributes, @data_points)
-                  end
+                @callback.each do |cb|
+                  value = safe_guard_callback(cb, timeout: timeout)
+                  @default_aggregation.update(value, attributes, @data_points) if value.is_a?(Numeric)
                 end
               end
             else
               @registered_views.each do |view|
                 @mutex.synchronize do
-                  Timeout.timeout(timeout || 30) do
-                    @callback.each do |cb|
-                      value = cb.call
-                      merged_attributes = attributes || {}
-                      merged_attributes.merge!(view.attribute_keys)
-                      view.aggregation.update(value, merged_attributes, @data_points) if view.valid_aggregation?
-                    end
+                  @callback.each do |cb|
+                    value = safe_guard_callback(cb, timeout: timeout)
+                    next unless value.is_a?(Numeric) # ignore if value is not valid number
+
+                    merged_attributes = attributes || {}
+                    merged_attributes.merge!(view.attribute_keys)
+                    view.aggregation.update(value, merged_attributes, @data_points) if view.valid_aggregation?
                   end
                 end
               end
@@ -73,6 +73,18 @@ module OpenTelemetry
 
           def now_in_nano
             (Time.now.to_r * 1_000_000_000).to_i
+          end
+
+          private
+
+          def safe_guard_callback(callback, timeout: DEFAULT_TIMEOUT)
+            Timeout.timeout(timeout) do
+              callback.call
+            end
+          rescue Timeout::Error => e
+            OpenTelemetry.logger.error("Timeout while invoking callback: #{e.message}")
+          rescue StandardError => e
+            OpenTelemetry.logger.error("Error invoking callback: #{e.message}")
           end
         end
       end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/state/metric_stream.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/state/metric_stream.rb
@@ -55,6 +55,7 @@ module OpenTelemetry
             end
           end
 
+          # view will modify the data_point that is not suitable when there are multiple views
           def update(value, attributes)
             if @registered_views.empty?
               @mutex.synchronize { @default_aggregation.update(value, attributes, @data_points) }

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/state/asynchronous_metric_stream_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/state/asynchronous_metric_stream_test.rb
@@ -29,7 +29,7 @@ describe OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream do
   end
 
   describe '#initialize' do
-    it 'initializes with provided parameters' do
+    it 'initializes with provided parameters and async-specific attributes' do
       _(async_metric_stream.name).must_equal('async_counter')
       _(async_metric_stream.description).must_equal('An async counter')
       _(async_metric_stream.unit).must_equal('count')
@@ -37,270 +37,191 @@ describe OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream do
       _(async_metric_stream.instrumentation_scope).must_equal(instrumentation_scope)
       _(async_metric_stream.data_points).must_be_instance_of(Hash)
       _(async_metric_stream.data_points).must_be_empty
+
+      # Verify async-specific attributes
+      _(async_metric_stream.instance_variable_get(:@callback)).must_equal(callback)
+      _(async_metric_stream.instance_variable_get(:@timeout)).must_equal(timeout)
+      _(async_metric_stream.instance_variable_get(:@start_time)).must_be_instance_of(Integer)
+      _(async_metric_stream.instance_variable_get(:@start_time)).must_be :>, 0
     end
 
-    it 'stores callback and timeout' do
-      callback_proc = [proc { 100 }]
+    it 'finds and registers matching views during initialization' do
+      view = OpenTelemetry::SDK::Metrics::View::RegisteredView.new(
+        'async_counter',
+        aggregation: OpenTelemetry::SDK::Metrics::Aggregation::LastValue.new
+      )
+      meter_provider.instance_variable_get(:@registered_views) << view
+
       stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
-        'test',
-        'description',
-        'unit',
+        'async_counter',
+        'An async counter',
+        'count',
         :observable_counter,
         meter_provider,
-        instrumentation_scope,
-        aggregation,
-        callback_proc,
-        30,
-        {}
-      )
-
-      _(stream.instance_variable_get(:@callback)).must_equal(callback_proc)
-      _(stream.instance_variable_get(:@timeout)).must_equal(30)
-    end
-
-    it 'initializes start time' do
-      start_time = async_metric_stream.instance_variable_get(:@start_time)
-      _(start_time).must_be_instance_of(Integer)
-      _(start_time).must_be :>, 0
-    end
-
-    it 'handles nil meter_provider gracefully' do
-      stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
-        'test',
-        'description',
-        'unit',
-        :observable_counter,
-        nil,
         instrumentation_scope,
         aggregation,
         callback,
         timeout,
         attributes
       )
-      _(stream.name).must_equal('test')
+
+      registered_views = stream.instance_variable_get(:@registered_views)
+      _(registered_views.size).must_equal(1)
+      _(registered_views.first.aggregation.class).must_equal ::OpenTelemetry::SDK::Metrics::Aggregation::LastValue
     end
   end
 
   describe '#collect' do
-    it 'invokes callback and returns metric data' do
-      metric_data = async_metric_stream.collect(0, 1000)
+    it 'invokes callback and handles various collection scenarios' do
+      # Test basic collection with callback value and attributes
+      metric_data_array = async_metric_stream.collect(0, 1000)
+      _(metric_data_array).must_be_instance_of(Array)
+      _(metric_data_array.size).must_equal(1)
 
+      metric_data = metric_data_array.first
       _(metric_data).must_be_instance_of(OpenTelemetry::SDK::Metrics::State::MetricData)
       _(metric_data.name).must_equal('async_counter')
-      _(metric_data.description).must_equal('An async counter')
-      _(metric_data.unit).must_equal('count')
-      _(metric_data.instrument_kind).must_equal(:observable_counter)
       _(metric_data.start_time_unix_nano).must_equal(0)
       _(metric_data.time_unix_nano).must_equal(1000)
-    end
-
-    it 'uses callback return value in data points' do
-      callback_value = 123
-      callback_proc = [proc { callback_value }]
-
-      stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
-        'async_counter',
-        'An async counter',
-        'count',
-        :observable_counter,
-        meter_provider,
-        instrumentation_scope,
-        aggregation,
-        callback_proc,
-        timeout,
-        attributes
-      )
-
-      metric_data = stream.collect(0, 1000)
-      _(metric_data.data_points).wont_be_empty
-      _(metric_data.data_points.first.value).must_equal(callback_value)
-    end
-
-    it 'handles multiple callbacks' do
-      callbacks = [proc { 10 }, proc { 20 }, proc { 30 }]
-
-      stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
-        'async_counter',
-        'An async counter',
-        'count',
-        :observable_counter,
-        meter_provider,
-        instrumentation_scope,
-        aggregation,
-        callbacks,
-        timeout,
-        attributes
-      )
-
-      metric_data = stream.collect(0, 1000)
-      # With Sum aggregation, all callback values should be accumulated
-      _(metric_data.data_points.first.value).must_equal(60)
-    end
-
-    it 'uses provided attributes in data points' do
-      metric_data = async_metric_stream.collect(0, 1000)
+      _(metric_data.data_points.first.value).must_equal(42)
       _(metric_data.data_points.first.attributes).must_equal(attributes)
+
+      # Test empty collection when callback returns nil
+      empty_callback = [proc { nil }]
+      empty_stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
+        'async_counter', 'description', 'unit', :observable_counter,
+        meter_provider, instrumentation_scope, aggregation,
+        empty_callback, timeout, {}
+      )
+      _(empty_stream.collect(0, 1000)).must_be_empty
+
+      # Test multiple callbacks accumulation
+      multi_callbacks = [proc { 10 }, proc { 20 }, proc { 30 }]
+      multi_stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
+        'async_counter', 'description', 'unit', :observable_counter,
+        meter_provider, instrumentation_scope, aggregation,
+        multi_callbacks, timeout, attributes
+      )
+      multi_result = multi_stream.collect(0, 1000)
+      _(multi_result.first.data_points.first.value).must_equal(60) # 10 + 20 + 30
     end
 
-    it 'passes correct timestamps to metric data' do
-      start_time = 5000
-      end_time = 6000
-
-      metric_data = async_metric_stream.collect(start_time, end_time)
-      _(metric_data.start_time_unix_nano).must_equal(start_time)
-      _(metric_data.time_unix_nano).must_equal(end_time)
-    end
-
-    it 'handles callback exceptions gracefully' do
-      error_callback = proc { raise StandardError, 'Callback error' }
-
-      stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
+    it 'handles multiple registered views with attribute merging' do
+      view1 = OpenTelemetry::SDK::Metrics::View::RegisteredView.new(
         'async_counter',
-        'An async counter',
-        'count',
-        :observable_counter,
-        meter_provider,
-        instrumentation_scope,
-        aggregation,
-        error_callback,
-        timeout,
-        attributes
+        aggregation: OpenTelemetry::SDK::Metrics::Aggregation::Sum.new
+      )
+      view2 = OpenTelemetry::SDK::Metrics::View::RegisteredView.new(
+        'async_counter',
+        aggregation: OpenTelemetry::SDK::Metrics::Aggregation::LastValue.new,
+        attribute_keys: { 'environment' => 'production', 'service' => 'metrics' }
       )
 
-      # Should not raise an exception, but handle it gracefully
-      _(-> { stream.collect(0, 1000) }).must_raise(StandardError)
+      meter_provider.instance_variable_get(:@registered_views) << view1
+      meter_provider.instance_variable_get(:@registered_views) << view2
+
+      stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
+        'async_counter', 'description', 'unit', :observable_counter,
+        meter_provider, instrumentation_scope, aggregation,
+        callback, timeout, { 'original' => 'value' }
+      )
+
+      metric_data_array = stream.collect(0, 1000)
+      _(metric_data_array.size).must_equal(2)
+
+      # Verify view with attribute merging
+      view_with_attrs = metric_data_array.find { |md| md.data_points.first.attributes.key?('service') }
+      _(view_with_attrs).wont_be_nil
+      attrs = view_with_attrs.data_points.first.attributes
+      _(attrs['environment']).must_equal('production')
+      _(attrs['service']).must_equal('metrics')
+      _(attrs['original']).must_equal('value')
+    end
+
+    it 'handles callback exceptions xuan' do
+      error_callback = [proc { raise StandardError, 'Callback error' }]
+      error_stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
+        'async_counter', 'description', 'unit', :observable_counter,
+        meter_provider, instrumentation_scope, aggregation,
+        error_callback, timeout, attributes
+      )
+
+      # Capture the logged output
+      original_logger = OpenTelemetry.logger
+      log_output = StringIO.new
+      OpenTelemetry.logger = Logger.new(log_output)
+      error_stream.collect(0, 1000)
+      assert_includes log_output.string, 'Error invoking callback: Callback error'
+      OpenTelemetry.logger = original_logger
     end
   end
 
   describe '#invoke_callback' do
-    it 'executes callback with timeout' do
-      callback_executed = false
-      callback_proc = [proc do
-        callback_executed = true
-        42
-      end]
-
-      stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
-        'async_counter',
-        'An async counter',
-        'count',
-        :observable_counter,
-        meter_provider,
-        instrumentation_scope,
-        aggregation,
-        callback_proc,
-        timeout,
-        attributes
-      )
-
-      stream.invoke_callback(timeout, attributes)
-      _(callback_executed).must_equal(true)
-    end
-
-    it 'uses default timeout when none provided' do
-      callback_executed = false
-      callback_proc = [proc do
-        callback_executed = true
-        42
-      end]
-
-      stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
-        'async_counter',
-        'An async counter',
-        'count',
-        :observable_counter,
-        meter_provider,
-        instrumentation_scope,
-        aggregation,
-        callback_proc,
-        nil,
-        attributes
-      )
-
-      # Should use default timeout of 30 seconds
-      stream.invoke_callback(nil, attributes)
-      _(callback_executed).must_equal(true)
-    end
-
-    it 'handles multiple callbacks in array' do
-      execution_count = 0
-      callbacks = [
-        proc { execution_count += 1; 10 },
-        proc { execution_count += 1; 20 },
-        proc { execution_count += 1; 30 }
+    it 'executes callbacks with timeout and handles thread safety with multiple callback' do
+      # Test multiple callbacks in array
+      multi_callbacks = [
+        proc { 10 },
+        proc { 20 },
+        proc { 30 }
       ]
-
-      stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
-        'async_counter',
-        'An async counter',
-        'count',
-        :observable_counter,
-        meter_provider,
-        instrumentation_scope,
-        aggregation,
-        callbacks,
-        timeout,
-        attributes
+      multi_stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
+        'async_counter', 'description', 'unit', :observable_counter,
+        meter_provider, instrumentation_scope, aggregation,
+        multi_callbacks, timeout, attributes
       )
+      multi_stream.invoke_callback(timeout, attributes)
 
-      stream.invoke_callback(timeout, attributes)
-      _(execution_count).must_equal(3)
-    end
-
-    it 'respects timeout setting' do
-      slow_callback = [proc do
-        sleep(0.1) # Sleep longer than timeout
+      # Test thread safety
+      thread_count = 0
+      thread_callback = [proc {
+        thread_count += 1
         42
-      end]
-
-      stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
-        'async_counter',
-        'An async counter',
-        'count',
-        :observable_counter,
-        meter_provider,
-        instrumentation_scope,
-        aggregation,
-        slow_callback,
-        0.05, # Very short timeout
-        attributes
+      }]
+      thread_stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
+        'async_counter', 'description', 'unit', :observable_counter,
+        meter_provider, instrumentation_scope, aggregation,
+        thread_callback, timeout, attributes
       )
 
-      # Should raise timeout error
-      _(-> { stream.invoke_callback(0.05, attributes) }).must_raise(Timeout::Error)
-    end
-
-    it 'is thread-safe xuan' do
-      execution_count = 0
-      callback_proc = [proc do
-        execution_count += 1
-        42
-      end]
-
-      stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
-        'async_counter',
-        'An async counter',
-        'count',
-        :observable_counter,
-        meter_provider,
-        instrumentation_scope,
-        aggregation,
-        callback_proc,
-        timeout,
-        attributes
-      )
-
-      threads = 5.times.map do
-        Thread.new { stream.invoke_callback(timeout, attributes) }
+      metric_data = nil
+      threads = Array.new(5) do
+        # Thread.new { thread_stream.invoke_callback(timeout, attributes) }
+        Thread.new { metric_data = thread_stream.collect(0, 10_000) }
       end
-
       threads.each(&:join)
-      _(execution_count).must_equal(5)
+
+      _(thread_count).must_equal(5)
+      _(metric_data.first.data_points.first.value).must_equal 210
+      _(metric_data.first.data_points.first.attributes['environment']).must_equal 'test'
+      _(metric_data.first.start_time_unix_nano).must_equal 0
+      _(metric_data.first.time_unix_nano).must_equal 10_000
+    end
+
+    it 'respects timeout settings and handles slow callbacks' do
+      # Test timeout handling
+      slow_callback = [proc {
+        sleep(0.1)
+        42
+      }]
+      stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
+        'async_counter', 'description', 'unit', :observable_counter,
+        meter_provider, instrumentation_scope, aggregation,
+        slow_callback, 0.05, attributes # Very short timeout
+      )
+
+      stream.invoke_callback(0.05, attributes)
+
+      original_logger = OpenTelemetry.logger
+      log_output = StringIO.new
+      OpenTelemetry.logger = Logger.new(log_output)
+      stream.invoke_callback(0.05, attributes)
+      assert_includes log_output.string, 'Timeout while invoking callback'
+      OpenTelemetry.logger = original_logger
     end
   end
 
   describe '#now_in_nano' do
-    it 'returns current time in nanoseconds' do
+    it 'returns current time in nanoseconds with increasing values' do
       nano_time = async_metric_stream.now_in_nano
       _(nano_time).must_be_instance_of(Integer)
       _(nano_time).must_be :>, 0
@@ -308,67 +229,85 @@ describe OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream do
       # Should be a reasonable timestamp (not too old, not in future)
       current_time_nano = (Time.now.to_r * 1_000_000_000).to_i
       _(nano_time).must_be_close_to(current_time_nano, 1_000_000_000) # Within 1 second
-    end
 
-    it 'returns increasing values on successive calls' do
-      time1 = async_metric_stream.now_in_nano
+      # Test successive calls return increasing values
       sleep(0.001) # Small delay
       time2 = async_metric_stream.now_in_nano
-
-      _(time2).must_be :>, time1
+      _(time2).must_be :>, nano_time
     end
   end
 
-  describe 'integration with aggregation' do
-    it 'updates aggregation correctly with callback values' do
+  describe 'aggregation and view integration' do
+    it 'supports different aggregation types and accumulation' do
+      # Test Sum aggregation accumulation
       callback_value = 100
       callback_proc = [proc { callback_value }]
-
       stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
-        'async_counter',
-        'An async counter',
-        'count',
-        :observable_counter,
-        meter_provider,
-        instrumentation_scope,
-        aggregation,
-        callback_proc,
-        timeout,
-        attributes
+        'async_counter', 'description', 'unit', :observable_counter,
+        meter_provider, instrumentation_scope, aggregation,
+        callback_proc, timeout, attributes
       )
 
-      # First collection
-      metric_data1 = stream.collect(0, 1000)
-      value1 = metric_data1.data_points.first.value
+      stream.collect(0, 1000)
+      metric_data = stream.collect(1000, 2000)
+      _(metric_data.first.data_points.first.value).must_equal 200
 
-      # Second collection (should accumulate for Sum aggregation)
-      metric_data2 = stream.collect(1000, 2000)
-      value2 = metric_data2.data_points.first.value
+      # Test LastValue aggregation
+      last_value_aggregation = OpenTelemetry::SDK::Metrics::Aggregation::LastValue.new
+      stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
+        'async_gauge', 'description', 'units', :observable_gauge,
+        meter_provider, instrumentation_scope, last_value_aggregation,
+        callback_proc, timeout, attributes
+      )
 
-      # For Sum aggregation, values should accumulate
-      _(value2).must_be :>=, value1
+      # Calling it twice but last value should preserve last one instead of sum
+      stream.collect(0, 1000)
+      metric_data = stream.collect(0, 1000)
+      _(metric_data.first.data_points.first.value).must_equal 100
     end
 
-    it 'works with different aggregation types' do
-      last_value_aggregation = OpenTelemetry::SDK::Metrics::Aggregation::LastValue.new
-      callback_value = 50
-      callback_proc = [proc { callback_value }]
+    it 'handles view filtering and drop aggregation' do
+      # Test view filtering by instrument name (non-matching)
+      non_matching_view = OpenTelemetry::SDK::Metrics::View::RegisteredView.new(
+        'different_counter',
+        aggregation: OpenTelemetry::SDK::Metrics::Aggregation::LastValue.new
+      )
+
+      # Test view filtering by instrument type (matching)
+      type_matching_view = OpenTelemetry::SDK::Metrics::View::RegisteredView.new(
+        nil, type: :observable_counter,
+             aggregation: OpenTelemetry::SDK::Metrics::Aggregation::LastValue.new
+      )
+
+      meter_provider.instance_variable_get(:@registered_views) << non_matching_view
+      meter_provider.instance_variable_get(:@registered_views) << type_matching_view
 
       stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
-        'async_gauge',
-        'An async gauge',
-        'units',
-        :observable_gauge,
-        meter_provider,
-        instrumentation_scope,
-        last_value_aggregation,
-        callback_proc,
-        timeout,
-        attributes
+        'async_counter', 'description', 'unit', :observable_counter,
+        meter_provider, instrumentation_scope, aggregation,
+        callback, timeout, attributes
       )
 
       metric_data = stream.collect(0, 1000)
-      _(metric_data.data_points.first.value).must_equal(callback_value)
+      _(metric_data.size).must_equal(1) # Should match type-based view
+
+      # Test Drop aggregation
+      drop_view = OpenTelemetry::SDK::Metrics::View::RegisteredView.new(
+        'async_counter',
+        aggregation: OpenTelemetry::SDK::Metrics::Aggregation::Drop.new
+      )
+      meter_provider.instance_variable_get(:@registered_views).clear
+      meter_provider.instance_variable_get(:@registered_views) << drop_view
+
+      drop_stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
+        'async_counter', 'description', 'unit', :observable_counter,
+        meter_provider, instrumentation_scope, aggregation,
+        callback, timeout, attributes
+      )
+
+      dropped_data = drop_stream.collect(0, 1000)
+      _(dropped_data.size).must_equal(1)
+      _(dropped_data.first.data_points.first.value).must_equal(0) # Dropped value
     end
   end
 end

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/state/asynchronous_metric_stream_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/state/asynchronous_metric_stream_test.rb
@@ -1,0 +1,374 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+describe OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream do
+  let(:meter_provider) { OpenTelemetry::SDK::Metrics::MeterProvider.new }
+  let(:instrumentation_scope) { OpenTelemetry::SDK::InstrumentationScope.new('test_scope', '1.0.0') }
+  let(:aggregation) { OpenTelemetry::SDK::Metrics::Aggregation::Sum.new }
+  let(:callback) { proc { 42 } }
+  let(:timeout) { 10 }
+  let(:attributes) { { 'environment' => 'test' } }
+  let(:async_metric_stream) do
+    OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
+      'async_counter',
+      'An async counter',
+      'count',
+      :observable_counter,
+      meter_provider,
+      instrumentation_scope,
+      aggregation,
+      callback,
+      timeout,
+      attributes
+    )
+  end
+
+  describe '#initialize' do
+    it 'initializes with provided parameters' do
+      _(async_metric_stream.name).must_equal('async_counter')
+      _(async_metric_stream.description).must_equal('An async counter')
+      _(async_metric_stream.unit).must_equal('count')
+      _(async_metric_stream.instrument_kind).must_equal(:observable_counter)
+      _(async_metric_stream.instrumentation_scope).must_equal(instrumentation_scope)
+      _(async_metric_stream.data_points).must_be_instance_of(Hash)
+      _(async_metric_stream.data_points).must_be_empty
+    end
+
+    it 'stores callback and timeout' do
+      callback_proc = proc { 100 }
+      stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
+        'test',
+        'description',
+        'unit',
+        :observable_counter,
+        meter_provider,
+        instrumentation_scope,
+        aggregation,
+        callback_proc,
+        30,
+        {}
+      )
+
+      _(stream.instance_variable_get(:@callback)).must_equal(callback_proc)
+      _(stream.instance_variable_get(:@timeout)).must_equal(30)
+    end
+
+    it 'initializes start time' do
+      start_time = async_metric_stream.instance_variable_get(:@start_time)
+      _(start_time).must_be_instance_of(Integer)
+      _(start_time).must_be :>, 0
+    end
+
+    it 'handles nil meter_provider gracefully' do
+      stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
+        'test',
+        'description',
+        'unit',
+        :observable_counter,
+        nil,
+        instrumentation_scope,
+        aggregation,
+        callback,
+        timeout,
+        attributes
+      )
+      _(stream.name).must_equal('test')
+    end
+  end
+
+  describe '#collect' do
+    it 'invokes callback and returns metric data' do
+      metric_data = async_metric_stream.collect(0, 1000)
+
+      _(metric_data).must_be_instance_of(OpenTelemetry::SDK::Metrics::MetricData)
+      _(metric_data.name).must_equal('async_counter')
+      _(metric_data.description).must_equal('An async counter')
+      _(metric_data.unit).must_equal('count')
+      _(metric_data.instrument_kind).must_equal(:observable_counter)
+      _(metric_data.start_time_unix_nano).must_equal(0)
+      _(metric_data.end_time_unix_nano).must_equal(1000)
+    end
+
+    it 'uses callback return value in data points' do
+      callback_value = 123
+      callback_proc = proc { callback_value }
+
+      stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
+        'async_counter',
+        'An async counter',
+        'count',
+        :observable_counter,
+        meter_provider,
+        instrumentation_scope,
+        aggregation,
+        callback_proc,
+        timeout,
+        attributes
+      )
+
+      metric_data = stream.collect(0, 1000)
+      _(metric_data.data_points).wont_be_empty
+      _(metric_data.data_points.first.value).must_equal(callback_value)
+    end
+
+    it 'handles multiple callbacks' do
+      callbacks = [proc { 10 }, proc { 20 }, proc { 30 }]
+
+      stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
+        'async_counter',
+        'An async counter',
+        'count',
+        :observable_counter,
+        meter_provider,
+        instrumentation_scope,
+        aggregation,
+        callbacks,
+        timeout,
+        attributes
+      )
+
+      metric_data = stream.collect(0, 1000)
+      # With Sum aggregation, all callback values should be accumulated
+      _(metric_data.data_points.first.value).must_equal(60)
+    end
+
+    it 'uses provided attributes in data points' do
+      metric_data = async_metric_stream.collect(0, 1000)
+      _(metric_data.data_points.first.attributes).must_equal(attributes)
+    end
+
+    it 'passes correct timestamps to metric data' do
+      start_time = 5000
+      end_time = 6000
+
+      metric_data = async_metric_stream.collect(start_time, end_time)
+      _(metric_data.start_time_unix_nano).must_equal(start_time)
+      _(metric_data.end_time_unix_nano).must_equal(end_time)
+    end
+
+    it 'handles callback exceptions gracefully' do
+      error_callback = proc { raise StandardError, 'Callback error' }
+
+      stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
+        'async_counter',
+        'An async counter',
+        'count',
+        :observable_counter,
+        meter_provider,
+        instrumentation_scope,
+        aggregation,
+        error_callback,
+        timeout,
+        attributes
+      )
+
+      # Should not raise an exception, but handle it gracefully
+      _(-> { stream.collect(0, 1000) }).must_raise(StandardError)
+    end
+  end
+
+  describe '#invoke_callback' do
+    it 'executes callback with timeout' do
+      callback_executed = false
+      callback_proc = proc do
+        callback_executed = true
+        42
+      end
+
+      stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
+        'async_counter',
+        'An async counter',
+        'count',
+        :observable_counter,
+        meter_provider,
+        instrumentation_scope,
+        aggregation,
+        callback_proc,
+        timeout,
+        attributes
+      )
+
+      stream.invoke_callback(timeout, attributes)
+      _(callback_executed).must_equal(true)
+    end
+
+    it 'uses default timeout when none provided' do
+      callback_executed = false
+      callback_proc = proc do
+        callback_executed = true
+        42
+      end
+
+      stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
+        'async_counter',
+        'An async counter',
+        'count',
+        :observable_counter,
+        meter_provider,
+        instrumentation_scope,
+        aggregation,
+        callback_proc,
+        nil,
+        attributes
+      )
+
+      # Should use default timeout of 30 seconds
+      stream.invoke_callback(nil, attributes)
+      _(callback_executed).must_equal(true)
+    end
+
+    it 'handles multiple callbacks in array' do
+      execution_count = 0
+      callbacks = [
+        proc { execution_count += 1; 10 },
+        proc { execution_count += 1; 20 },
+        proc { execution_count += 1; 30 }
+      ]
+
+      stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
+        'async_counter',
+        'An async counter',
+        'count',
+        :observable_counter,
+        meter_provider,
+        instrumentation_scope,
+        aggregation,
+        callbacks,
+        timeout,
+        attributes
+      )
+
+      stream.invoke_callback(timeout, attributes)
+      _(execution_count).must_equal(3)
+    end
+
+    it 'respects timeout setting' do
+      slow_callback = proc do
+        sleep(0.1) # Sleep longer than timeout
+        42
+      end
+
+      stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
+        'async_counter',
+        'An async counter',
+        'count',
+        :observable_counter,
+        meter_provider,
+        instrumentation_scope,
+        aggregation,
+        slow_callback,
+        0.05, # Very short timeout
+        attributes
+      )
+
+      # Should raise timeout error
+      _(-> { stream.invoke_callback(0.05, attributes) }).must_raise(Timeout::Error)
+    end
+
+    it 'is thread-safe' do
+      execution_count = 0
+      callback_proc = proc do
+        execution_count += 1
+        42
+      end
+
+      stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
+        'async_counter',
+        'An async counter',
+        'count',
+        :observable_counter,
+        meter_provider,
+        instrumentation_scope,
+        aggregation,
+        callback_proc,
+        timeout,
+        attributes
+      )
+
+      threads = 5.times.map do
+        Thread.new { stream.invoke_callback(timeout, attributes) }
+      end
+
+      threads.each(&:join)
+      _(execution_count).must_equal(5)
+    end
+  end
+
+  describe '#now_in_nano' do
+    it 'returns current time in nanoseconds' do
+      nano_time = async_metric_stream.now_in_nano
+      _(nano_time).must_be_instance_of(Integer)
+      _(nano_time).must_be :>, 0
+
+      # Should be a reasonable timestamp (not too old, not in future)
+      current_time_nano = (Time.now.to_r * 1_000_000_000).to_i
+      _(nano_time).must_be_close_to(current_time_nano, 1_000_000_000) # Within 1 second
+    end
+
+    it 'returns increasing values on successive calls' do
+      time1 = async_metric_stream.now_in_nano
+      sleep(0.001) # Small delay
+      time2 = async_metric_stream.now_in_nano
+
+      _(time2).must_be :>, time1
+    end
+  end
+
+  describe 'integration with aggregation' do
+    it 'updates aggregation correctly with callback values' do
+      callback_value = 100
+      callback_proc = proc { callback_value }
+
+      stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
+        'async_counter',
+        'An async counter',
+        'count',
+        :observable_counter,
+        meter_provider,
+        instrumentation_scope,
+        aggregation,
+        callback_proc,
+        timeout,
+        attributes
+      )
+
+      # First collection
+      metric_data1 = stream.collect(0, 1000)
+      value1 = metric_data1.data_points.first.value
+
+      # Second collection (should accumulate for Sum aggregation)
+      metric_data2 = stream.collect(1000, 2000)
+      value2 = metric_data2.data_points.first.value
+
+      # For Sum aggregation, values should accumulate
+      _(value2).must_be :>=, value1
+    end
+
+    it 'works with different aggregation types' do
+      last_value_aggregation = OpenTelemetry::SDK::Metrics::Aggregation::LastValue.new
+      callback_value = 50
+      callback_proc = proc { callback_value }
+
+      stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
+        'async_gauge',
+        'An async gauge',
+        'units',
+        :observable_gauge,
+        meter_provider,
+        instrumentation_scope,
+        last_value_aggregation,
+        callback_proc,
+        timeout,
+        attributes
+      )
+
+      metric_data = stream.collect(0, 1000)
+      _(metric_data.data_points.first.value).must_equal(callback_value)
+    end
+  end
+end

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/state/asynchronous_metric_stream_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/state/asynchronous_metric_stream_test.rb
@@ -138,7 +138,7 @@ describe OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream do
       _(attrs['original']).must_equal('value')
     end
 
-    it 'handles callback exceptions xuan' do
+    it 'handles callback exceptions' do
       error_callback = [proc { raise StandardError, 'Callback error' }]
       error_stream = OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream.new(
         'async_counter', 'description', 'unit', :observable_counter,

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/state/metric_store_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/state/metric_store_test.rb
@@ -98,7 +98,6 @@ describe OpenTelemetry::SDK::Metrics::State::MetricStore do
       # First collection
       metric_stream.update(10, {})
       snapshot1 = metric_store.collect
-      start_time1 = snapshot1.first.start_time_unix_nano
       end_time1 = snapshot1.first.time_unix_nano
 
       sleep(0.001) # Small delay to ensure different timestamps
@@ -115,7 +114,7 @@ describe OpenTelemetry::SDK::Metrics::State::MetricStore do
 
     it 'is thread-safe when adding metric streams' do
       # Create metric streams in multiple threads
-      threads = 10.times.map do |i|
+      threads = Array.new(10) do |i|
         Thread.new do
           metric_stream = OpenTelemetry::SDK::Metrics::State::MetricStream.new(
             "counter_#{i}",

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/state/metric_store_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/state/metric_store_test.rb
@@ -7,9 +7,189 @@
 require 'test_helper'
 
 describe OpenTelemetry::SDK::Metrics::State::MetricStore do
+  let(:metric_store) { OpenTelemetry::SDK::Metrics::State::MetricStore.new }
+  let(:meter_provider) { OpenTelemetry::SDK::Metrics::MeterProvider.new }
+  let(:instrumentation_scope) { OpenTelemetry::SDK::InstrumentationScope.new('test_scope', '1.0.0') }
+  let(:aggregation) { OpenTelemetry::SDK::Metrics::Aggregation::Sum.new }
+
+  describe '#initialize' do
+    it 'initializes with empty metric streams' do
+      store = OpenTelemetry::SDK::Metrics::State::MetricStore.new
+      _(store).must_be_instance_of(OpenTelemetry::SDK::Metrics::State::MetricStore)
+    end
+  end
+
   describe '#collect' do
+    it 'returns empty array when no metric streams are added' do
+      snapshot = metric_store.collect
+      _(snapshot).must_be_instance_of(Array)
+      _(snapshot).must_be_empty
+    end
+
+    it 'collects data from added metric streams' do
+      metric_stream = OpenTelemetry::SDK::Metrics::State::MetricStream.new(
+        'test_counter',
+        'A test counter',
+        'count',
+        :counter,
+        meter_provider,
+        instrumentation_scope,
+        aggregation
+      )
+
+      # Add some data to the metric stream
+      metric_stream.update(10, {})
+      metric_store.add_metric_stream(metric_stream)
+
+      snapshot = metric_store.collect
+      _(snapshot).must_be_instance_of(Array)
+      _(snapshot.size).must_equal(1)
+      _(snapshot.first).must_be_instance_of(OpenTelemetry::SDK::Metrics::MetricData)
+      _(snapshot.first.name).must_equal('test_counter')
+    end
+
+    it 'collects data from multiple metric streams' do
+      metric_stream1 = OpenTelemetry::SDK::Metrics::State::MetricStream.new(
+        'test_counter1',
+        'A test counter 1',
+        'count',
+        :counter,
+        meter_provider,
+        instrumentation_scope,
+        aggregation
+      )
+
+      metric_stream2 = OpenTelemetry::SDK::Metrics::State::MetricStream.new(
+        'test_counter2',
+        'A test counter 2',
+        'count',
+        :counter,
+        meter_provider,
+        instrumentation_scope,
+        aggregation
+      )
+
+      metric_stream1.update(10, {})
+      metric_stream2.update(20, {})
+
+      metric_store.add_metric_stream(metric_stream1)
+      metric_store.add_metric_stream(metric_stream2)
+
+      snapshot = metric_store.collect
+      _(snapshot.size).must_equal(2)
+      names = snapshot.map(&:name)
+      _(names).must_include('test_counter1')
+      _(names).must_include('test_counter2')
+    end
+
+    it 'updates epoch times on each collection' do
+      metric_stream = OpenTelemetry::SDK::Metrics::State::MetricStream.new(
+        'test_counter',
+        'A test counter',
+        'count',
+        :counter,
+        meter_provider,
+        instrumentation_scope,
+        aggregation
+      )
+
+      metric_stream.update(10, {})
+      metric_store.add_metric_stream(metric_stream)
+
+      # First collection
+      snapshot1 = metric_store.collect
+      start_time1 = snapshot1.first.start_time_unix_nano
+      end_time1 = snapshot1.first.end_time_unix_nano
+
+      sleep(0.001) # Small delay to ensure different timestamps
+
+      # Second collection
+      snapshot2 = metric_store.collect
+      start_time2 = snapshot2.first.start_time_unix_nano
+      end_time2 = snapshot2.first.end_time_unix_nano
+
+      _(start_time2).must_equal(end_time1)
+      _(end_time2).must_be :>, end_time1
+    end
   end
 
   describe '#add_metric_stream' do
+    it 'adds a metric stream to the store' do
+      metric_stream = OpenTelemetry::SDK::Metrics::State::MetricStream.new(
+        'test_counter',
+        'A test counter',
+        'count',
+        :counter,
+        meter_provider,
+        instrumentation_scope,
+        aggregation
+      )
+
+      result = metric_store.add_metric_stream(metric_stream)
+      _(result).must_be_nil
+
+      # Verify the metric stream was added by checking collection
+      metric_stream.update(5, {})
+      snapshot = metric_store.collect
+      _(snapshot.size).must_equal(1)
+    end
+
+    it 'handles multiple metric streams' do
+      metric_stream1 = OpenTelemetry::SDK::Metrics::State::MetricStream.new(
+        'counter1',
+        'Counter 1',
+        'count',
+        :counter,
+        meter_provider,
+        instrumentation_scope,
+        aggregation
+      )
+
+      metric_stream2 = OpenTelemetry::SDK::Metrics::State::MetricStream.new(
+        'counter2',
+        'Counter 2',
+        'count',
+        :counter,
+        meter_provider,
+        instrumentation_scope,
+        aggregation
+      )
+
+      metric_store.add_metric_stream(metric_stream1)
+      metric_store.add_metric_stream(metric_stream2)
+
+      metric_stream1.update(1, {})
+      metric_stream2.update(2, {})
+
+      snapshot = metric_store.collect
+      _(snapshot.size).must_equal(2)
+    end
+
+    it 'is thread-safe when adding metric streams' do
+      metric_streams = []
+
+      # Create metric streams in multiple threads
+      threads = 10.times.map do |i|
+        Thread.new do
+          metric_stream = OpenTelemetry::SDK::Metrics::State::MetricStream.new(
+            "counter_#{i}",
+            "Counter #{i}",
+            'count',
+            :counter,
+            meter_provider,
+            instrumentation_scope,
+            aggregation
+          )
+          metric_stream.update(i, {})
+          metric_store.add_metric_stream(metric_stream)
+          metric_streams << metric_stream
+        end
+      end
+
+      threads.each(&:join)
+
+      snapshot = metric_store.collect
+      _(snapshot.size).must_equal(10)
+    end
   end
 end

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/state/metric_stream_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/state/metric_stream_test.rb
@@ -7,6 +7,304 @@
 require 'test_helper'
 
 describe OpenTelemetry::SDK::Metrics::State::MetricStream do
+  let(:meter_provider) { OpenTelemetry::SDK::Metrics::MeterProvider.new }
+  let(:instrumentation_scope) { OpenTelemetry::SDK::InstrumentationScope.new('test_scope', '1.0.0') }
+  let(:aggregation) { OpenTelemetry::SDK::Metrics::Aggregation::Sum.new }
+  let(:metric_stream) do
+    OpenTelemetry::SDK::Metrics::State::MetricStream.new(
+      'test_counter',
+      'A test counter',
+      'count',
+      :counter,
+      meter_provider,
+      instrumentation_scope,
+      aggregation
+    )
+  end
+
+  describe '#initialize' do
+    it 'initializes with provided parameters' do
+      _(metric_stream.name).must_equal('test_counter')
+      _(metric_stream.description).must_equal('A test counter')
+      _(metric_stream.unit).must_equal('count')
+      _(metric_stream.instrument_kind).must_equal(:counter)
+      _(metric_stream.instrumentation_scope).must_equal(instrumentation_scope)
+      _(metric_stream.data_points).must_be_instance_of(Hash)
+      _(metric_stream.data_points).must_be_empty
+    end
+
+    it 'handles nil meter_provider gracefully' do
+      stream = OpenTelemetry::SDK::Metrics::State::MetricStream.new(
+        'test',
+        'description',
+        'unit',
+        :counter,
+        nil,
+        instrumentation_scope,
+        aggregation
+      )
+      _(stream.name).must_equal('test')
+    end
+
+    it 'initializes registered views from meter provider' do
+      # Create a view that matches our metric stream
+      view = OpenTelemetry::SDK::Metrics::View::RegisteredView.new(
+        'test_counter',
+        aggregation: OpenTelemetry::SDK::Metrics::Aggregation::LastValue.new
+      )
+      meter_provider.instance_variable_get(:@registered_views) << view
+
+      stream = OpenTelemetry::SDK::Metrics::State::MetricStream.new(
+        'test_counter',
+        'A test counter',
+        'count',
+        :counter,
+        meter_provider,
+        instrumentation_scope,
+        aggregation
+      )
+
+      registered_views = stream.instance_variable_get(:@registered_views)
+      _(registered_views.size).must_equal(1)
+      _(registered_views.first).must_equal(view)
+    end
+  end
+
   describe '#update' do
+    it 'updates aggregation with value and attributes' do
+      metric_stream.update(10, { 'key' => 'value' })
+      _(metric_stream.data_points).wont_be_empty
+    end
+
+    it 'handles nil attributes' do
+      metric_stream.update(10, nil)
+      _(metric_stream.data_points).wont_be_empty
+    end
+
+    it 'updates multiple times with same attributes' do
+      metric_stream.update(10, { 'key' => 'value' })
+      metric_stream.update(20, { 'key' => 'value' })
+
+      # Should accumulate values for sum aggregation
+      snapshot = metric_stream.collect(0, 1000)
+      _(snapshot.size).must_equal(1)
+      _(snapshot.first.data_points.first.value).must_equal(30)
+    end
+
+    it 'updates with different attributes' do
+      metric_stream.update(10, { 'key1' => 'value1' })
+      metric_stream.update(20, { 'key2' => 'value2' })
+
+      snapshot = metric_stream.collect(0, 1000)
+      _(snapshot.size).must_equal(1)
+      _(snapshot.first.data_points.size).must_equal(2)
+    end
+
+    it 'handles registered views with attribute merging' do
+      view = OpenTelemetry::SDK::Metrics::View::RegisteredView.new(
+        'test_counter',
+        aggregation: OpenTelemetry::SDK::Metrics::Aggregation::Sum.new,
+        attribute_keys: { 'environment' => 'test' }
+      )
+      meter_provider.instance_variable_get(:@registered_views) << view
+
+      stream = OpenTelemetry::SDK::Metrics::State::MetricStream.new(
+        'test_counter',
+        'A test counter',
+        'count',
+        :counter,
+        meter_provider,
+        instrumentation_scope,
+        aggregation
+      )
+
+      stream.update(10, { 'original' => 'value' })
+
+      snapshot = stream.collect(0, 1000)
+      _(snapshot.size).must_equal(1)
+
+      # Check that attributes were merged
+      attributes = snapshot.first.data_points.first.attributes
+      _(attributes['environment']).must_equal('test')
+      _(attributes['original']).must_equal('value')
+    end
+
+    it 'is thread-safe' do
+      threads = 10.times.map do |i|
+        Thread.new do
+          10.times { metric_stream.update(1, { 'thread' => i.to_s }) }
+        end
+      end
+
+      threads.each(&:join)
+
+      snapshot = metric_stream.collect(0, 1000)
+      _(snapshot.size).must_equal(1)
+      # With 10 threads each adding 10 times, and 10 different attribute sets
+      _(snapshot.first.data_points.size).must_equal(10)
+    end
+  end
+
+  describe '#collect' do
+    it 'returns empty array when no data points' do
+      snapshot = metric_stream.collect(0, 1000)
+      _(snapshot).must_be_instance_of(Array)
+      _(snapshot).must_be_empty
+    end
+
+    it 'returns metric data when data points exist' do
+      metric_stream.update(10, { 'key' => 'value' })
+      snapshot = metric_stream.collect(0, 1000)
+
+      _(snapshot.size).must_equal(1)
+      metric_data = snapshot.first
+      _(metric_data).must_be_instance_of(OpenTelemetry::SDK::Metrics::MetricData)
+      _(metric_data.name).must_equal('test_counter')
+      _(metric_data.description).must_equal('A test counter')
+      _(metric_data.unit).must_equal('count')
+      _(metric_data.instrument_kind).must_equal(:counter)
+    end
+
+    it 'handles multiple registered views' do
+      view1 = OpenTelemetry::SDK::Metrics::View::RegisteredView.new(
+        'test_counter',
+        aggregation: OpenTelemetry::SDK::Metrics::Aggregation::Sum.new
+      )
+      view2 = OpenTelemetry::SDK::Metrics::View::RegisteredView.new(
+        'test_counter',
+        aggregation: OpenTelemetry::SDK::Metrics::Aggregation::LastValue.new
+      )
+
+      meter_provider.instance_variable_get(:@registered_views) << view1
+      meter_provider.instance_variable_get(:@registered_views) << view2
+
+      stream = OpenTelemetry::SDK::Metrics::State::MetricStream.new(
+        'test_counter',
+        'A test counter',
+        'count',
+        :counter,
+        meter_provider,
+        instrumentation_scope,
+        aggregation
+      )
+
+      stream.update(10, {})
+      snapshot = stream.collect(0, 1000)
+
+      # Should have one metric data per view
+      _(snapshot.size).must_equal(2)
+    end
+
+    it 'passes correct timestamps to metric data' do
+      metric_stream.update(10, {})
+      start_time = 1000
+      end_time = 2000
+
+      snapshot = metric_stream.collect(start_time, end_time)
+      metric_data = snapshot.first
+
+      _(metric_data.start_time_unix_nano).must_equal(start_time)
+      _(metric_data.end_time_unix_nano).must_equal(end_time)
+    end
+  end
+
+  describe '#aggregate_metric_data' do
+    it 'creates metric data with default aggregation' do
+      metric_stream.update(10, {})
+      metric_data = metric_stream.aggregate_metric_data(0, 1000)
+
+      _(metric_data).must_be_instance_of(OpenTelemetry::SDK::Metrics::MetricData)
+      _(metric_data.name).must_equal('test_counter')
+    end
+
+    it 'creates metric data with custom aggregation' do
+      metric_stream.update(10, {})
+      custom_aggregation = OpenTelemetry::SDK::Metrics::Aggregation::LastValue.new
+      metric_data = metric_stream.aggregate_metric_data(0, 1000, aggregation: custom_aggregation)
+
+      _(metric_data).must_be_instance_of(OpenTelemetry::SDK::Metrics::MetricData)
+    end
+
+    it 'handles monotonic aggregations' do
+      metric_stream.update(10, {})
+      # Sum aggregation should be monotonic for counters
+      metric_data = metric_stream.aggregate_metric_data(0, 1000)
+
+      # Check that is_monotonic is set correctly (this depends on aggregation implementation)
+      _(metric_data.instance_variable_get(:@is_monotonic)).wont_be_nil
+    end
+  end
+
+  describe '#find_registered_view' do
+    it 'finds matching views by name' do
+      view = OpenTelemetry::SDK::Metrics::View::RegisteredView.new(
+        'test_counter',
+        aggregation: OpenTelemetry::SDK::Metrics::Aggregation::LastValue.new
+      )
+      meter_provider.instance_variable_get(:@registered_views) << view
+
+      stream = OpenTelemetry::SDK::Metrics::State::MetricStream.new(
+        'test_counter',
+        'A test counter',
+        'count',
+        :counter,
+        meter_provider,
+        instrumentation_scope,
+        aggregation
+      )
+
+      registered_views = stream.instance_variable_get(:@registered_views)
+      _(registered_views).must_include(view)
+    end
+
+    it 'ignores non-matching views' do
+      view = OpenTelemetry::SDK::Metrics::View::RegisteredView.new(
+        'other_counter',
+        aggregation: OpenTelemetry::SDK::Metrics::Aggregation::LastValue.new
+      )
+      meter_provider.instance_variable_get(:@registered_views) << view
+
+      stream = OpenTelemetry::SDK::Metrics::State::MetricStream.new(
+        'test_counter',
+        'A test counter',
+        'count',
+        :counter,
+        meter_provider,
+        instrumentation_scope,
+        aggregation
+      )
+
+      registered_views = stream.instance_variable_get(:@registered_views)
+      _(registered_views).wont_include(view)
+    end
+  end
+
+  describe '#to_s' do
+    it 'returns string representation without data points' do
+      str = metric_stream.to_s
+      _(str).must_be_instance_of(String)
+      _(str).must_be_empty # No data points yet
+    end
+
+    it 'includes data points in string representation' do
+      metric_stream.update(10, { 'key' => 'value' })
+      str = metric_stream.to_s
+
+      _(str).must_include('test_counter')
+      _(str).must_include('A test counter')
+      _(str).must_include('count')
+      _(str).must_include('key')
+      _(str).must_include('value')
+    end
+
+    it 'handles multiple data points' do
+      metric_stream.update(10, { 'key1' => 'value1' })
+      metric_stream.update(20, { 'key2' => 'value2' })
+      str = metric_stream.to_s
+
+      _(str).must_include('key1')
+      _(str).must_include('key2')
+      _(str.lines.size).must_be :>=, 2
+    end
   end
 end

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/state/metric_stream_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/state/metric_stream_test.rb
@@ -158,7 +158,7 @@ describe OpenTelemetry::SDK::Metrics::State::MetricStream do
 
       _(snapshot.size).must_equal(1)
       metric_data = snapshot.first
-      _(metric_data).must_be_instance_of(OpenTelemetry::SDK::Metrics::MetricData)
+      _(metric_data).must_be_instance_of(OpenTelemetry::SDK::Metrics::State::MetricData)
       _(metric_data.name).must_equal('test_counter')
       _(metric_data.description).must_equal('A test counter')
       _(metric_data.unit).must_equal('count')
@@ -204,7 +204,7 @@ describe OpenTelemetry::SDK::Metrics::State::MetricStream do
       metric_data = snapshot.first
 
       _(metric_data.start_time_unix_nano).must_equal(start_time)
-      _(metric_data.end_time_unix_nano).must_equal(end_time)
+      _(metric_data.time_unix_nano).must_equal(end_time)
     end
   end
 
@@ -213,7 +213,7 @@ describe OpenTelemetry::SDK::Metrics::State::MetricStream do
       metric_stream.update(10, {})
       metric_data = metric_stream.aggregate_metric_data(0, 1000)
 
-      _(metric_data).must_be_instance_of(OpenTelemetry::SDK::Metrics::MetricData)
+      _(metric_data).must_be_instance_of(OpenTelemetry::SDK::Metrics::State::MetricData)
       _(metric_data.name).must_equal('test_counter')
     end
 
@@ -222,7 +222,7 @@ describe OpenTelemetry::SDK::Metrics::State::MetricStream do
       custom_aggregation = OpenTelemetry::SDK::Metrics::Aggregation::LastValue.new
       metric_data = metric_stream.aggregate_metric_data(0, 1000, aggregation: custom_aggregation)
 
-      _(metric_data).must_be_instance_of(OpenTelemetry::SDK::Metrics::MetricData)
+      _(metric_data).must_be_instance_of(OpenTelemetry::SDK::Metrics::State::MetricData)
     end
 
     it 'handles monotonic aggregations' do
@@ -231,7 +231,7 @@ describe OpenTelemetry::SDK::Metrics::State::MetricStream do
       metric_data = metric_stream.aggregate_metric_data(0, 1000)
 
       # Check that is_monotonic is set correctly (this depends on aggregation implementation)
-      _(metric_data.instance_variable_get(:@is_monotonic)).wont_be_nil
+      _(metric_data.is_monotonic).wont_be_nil
     end
   end
 


### PR DESCRIPTION
Closes https://github.com/open-telemetry/opentelemetry-ruby/issues/1890

### Description

Found a couple of issues while developing the test case:
1. The current callback timeout applies to the entire set of callbacks of the instrument instead of each callback individually. This PR fixes that.
2. A faulty callback that raises an error can crash the entire application. This update adds a safeguard to log the error while allowing the application to continue running. Also we shouldn't update to instrument and merge attributes if callback return non-numeric data or nil. ([Reference](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.48.0/specification/metrics/sdk.md#observations-inside-asynchronous-callbacks))
3. Currently, each instrument supports only one view. Assigning multiple views to the same instrument can lead to inconsistent data_point values, as each view may modify the underlying data. This PR does not address the issue, but it will be resolved in the future.

Each metric_stream should be bound to its own instrument. While most functionality is tested through instruments, here we focus on fundamental correctness, which will be important when views and exemplars are updated.