### PR TITLE
feat!: Add OTEL_LOGRECORD_ATTRIBUTE_* env vars; Remove OTEL_LOG_RECORD_ATTRIBUTE_* env vars

### DIFF
--- a/logs_sdk/lib/opentelemetry/sdk/logs/log_record_limits.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/log_record_limits.rb
@@ -20,11 +20,13 @@ module OpenTelemetry
         # @return [LogRecordLimits] with the desired values.
         # @raise [ArgumentError] if any of the max numbers are not positive.
         def initialize(attribute_count_limit: Integer(OpenTelemetry::Common::Utilities.config_opt(
+                                                        'OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT',
                                                         'OTEL_LOG_RECORD_ATTRIBUTE_COUNT_LIMIT',
                                                         'OTEL_ATTRIBUTE_COUNT_LIMIT',
                                                         default: 128
                                                       )),
                        attribute_length_limit: OpenTelemetry::Common::Utilities.config_opt(
+                         'OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT',
                          'OTEL_LOG_RECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT',
                          'OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT'
                        ))

--- a/logs_sdk/lib/opentelemetry/sdk/logs/log_record_limits.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/log_record_limits.rb
@@ -21,13 +21,11 @@ module OpenTelemetry
         # @raise [ArgumentError] if any of the max numbers are not positive.
         def initialize(attribute_count_limit: Integer(OpenTelemetry::Common::Utilities.config_opt(
                                                         'OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT',
-                                                        'OTEL_LOG_RECORD_ATTRIBUTE_COUNT_LIMIT',
                                                         'OTEL_ATTRIBUTE_COUNT_LIMIT',
                                                         default: 128
                                                       )),
                        attribute_length_limit: OpenTelemetry::Common::Utilities.config_opt(
                          'OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT',
-                         'OTEL_LOG_RECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT',
                          'OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT'
                        ))
           raise ArgumentError, 'attribute_count_limit must be positive' unless attribute_count_limit.positive?

--- a/logs_sdk/test/opentelemetry/sdk/logs/log_record_limits_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/log_record_limits_test.rb
@@ -15,9 +15,16 @@ describe OpenTelemetry::SDK::Logs::LogRecordLimits do
       _(log_record_limits.attribute_length_limit).must_be_nil
     end
 
-    it 'prioritizes specific environment varibles for attribute value length limits' do
+    it 'prioritizes specific environment variables for attribute value length limits' do
       OpenTelemetry::TestHelpers.with_env('OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '35',
                                           'OTEL_LOG_RECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '33') do
+        _(log_record_limits.attribute_length_limit).must_equal 33
+      end
+    end
+
+    it 'prioritizes the spec naming of the environment variable for attribute value length limits' do
+      OpenTelemetry::TestHelpers.with_env('OTEL_LOG_RECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '35',
+                                          'OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '33') do
         _(log_record_limits.attribute_length_limit).must_equal 33
       end
     end

--- a/logs_sdk/test/opentelemetry/sdk/logs/log_record_limits_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/log_record_limits_test.rb
@@ -17,13 +17,6 @@ describe OpenTelemetry::SDK::Logs::LogRecordLimits do
 
     it 'prioritizes specific environment variables for attribute value length limits' do
       OpenTelemetry::TestHelpers.with_env('OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '35',
-                                          'OTEL_LOG_RECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '33') do
-        _(log_record_limits.attribute_length_limit).must_equal 33
-      end
-    end
-
-    it 'prioritizes the spec naming of the environment variable for attribute value length limits' do
-      OpenTelemetry::TestHelpers.with_env('OTEL_LOG_RECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '35',
                                           'OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '33') do
         _(log_record_limits.attribute_length_limit).must_equal 33
       end
@@ -36,16 +29,16 @@ describe OpenTelemetry::SDK::Logs::LogRecordLimits do
     end
 
     it 'reflects environment variables' do
-      OpenTelemetry::TestHelpers.with_env('OTEL_LOG_RECORD_ATTRIBUTE_COUNT_LIMIT' => '1',
-                                          'OTEL_LOG_RECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '32') do
+      OpenTelemetry::TestHelpers.with_env('OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT' => '1',
+                                          'OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '32') do
         _(log_record_limits.attribute_count_limit).must_equal 1
         _(log_record_limits.attribute_length_limit).must_equal 32
       end
     end
 
     it 'reflects explicit overrides' do
-      OpenTelemetry::TestHelpers.with_env('OTEL_LOG_RECORD_ATTRIBUTE_COUNT_LIMIT' => '1',
-                                          'OTEL_LOG_RECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '4') do
+      OpenTelemetry::TestHelpers.with_env('OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT' => '1',
+                                          'OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '4') do
         log_record_limits = OpenTelemetry::SDK::Logs::LogRecordLimits.new(attribute_count_limit: 10,
                                                                           attribute_length_limit: 32)
         _(log_record_limits.attribute_count_limit).must_equal 10
@@ -62,9 +55,9 @@ describe OpenTelemetry::SDK::Logs::LogRecordLimits do
     end
 
     it 'prefers model-specific attribute env vars over generic attribute env vars' do
-      OpenTelemetry::TestHelpers.with_env('OTEL_LOG_RECORD_ATTRIBUTE_COUNT_LIMIT' => '1',
+      OpenTelemetry::TestHelpers.with_env('OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT' => '1',
                                           'OTEL_ATTRIBUTE_COUNT_LIMIT' => '2',
-                                          'OTEL_LOG_RECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '32',
+                                          'OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '32',
                                           'OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT' => '33') do
         _(log_record_limits.attribute_count_limit).must_equal 1
         _(log_record_limits.attribute_length_limit).must_equal 32


### PR DESCRIPTION
Previously, the configuration option for managing log record attributes spelled log record with an underscore, `LOG_RECORD`. However, the spec does not use an underscore, `LOGRECORD`. Now, both spellings will be checked to set the value, with `LOGRECORD` taking precedence.

**Alternatively,** since the logs work is still technically "In Development" we could remove the `LOG_RECORD_ATTRIBUTE_*` environment variables and mark this PR as a breaking change.