### PR TITLE
fix!: Remove Span APIs for attributes and events

### DIFF
--- a/api/lib/opentelemetry/trace/span.rb
+++ b/api/lib/opentelemetry/trace/span.rb
@@ -78,18 +78,6 @@ module OpenTelemetry
         self
       end
 
-      # Retrieve attributes
-      #
-      # Note that the OpenTelemetry project
-      # {https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md
-      # documents} certain "standard attributes" that have prescribed semantic
-      # meanings.
-      #
-      # @return [hash] returns empty hash
-      def attributes
-        {}
-      end
-
       # Add a link to a {Span}.
       #
       # Adding links at span creation using the `links` option is preferred
@@ -133,18 +121,6 @@ module OpenTelemetry
       # @return [self] returns itself
       def add_event(name, attributes: nil, timestamp: nil)
         self
-      end
-
-      # Retrieve events
-      #
-      # Note that the OpenTelemetry project
-      # {https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md
-      # documents} certain "standard event names and keys" which have
-      # prescribed semantic meanings.
-      #
-      # @return [array] returns empty array
-      def events
-        []
       end
 
       # Record an exception during the execution of this span. Multiple exceptions

--- a/api/test/opentelemetry/trace/span_test.rb
+++ b/api/test/opentelemetry/trace/span_test.rb
@@ -36,17 +36,6 @@ describe OpenTelemetry::Trace::Span do
     end
   end
 
-  describe '#attributes' do
-    it 'returns empty hash' do
-      _(span.attributes).must_equal({})
-    end
-
-    it 'returns empty hash even after modification attempts' do
-      span.attributes['test'] = 'value'
-      _(span.attributes).must_equal({})
-    end
-  end
-
   describe '#add_link' do
     it 'returns self' do
       _(span.add_link(OpenTelemetry::Trace::Link.new(span_context))).must_equal(span)
@@ -70,11 +59,6 @@ describe OpenTelemetry::Trace::Span do
       _(span.add_event('event-name', timestamp: Time.now)).must_equal(span)
     end
   end
-
-  describe '#events' do
-    it 'returns empty array' do
-      _(span.events).must_equal([])
-    end
 
     it 'returns empty array even after modification attempts' do
       span.events << 'test event'


### PR DESCRIPTION
These APIs are not spec compliant. The SDK description makes this clear. This reverts #1881.

We need to find another solution for AWS Lambda instrumentation.

cc @xuan-cao-swi @fbogsany 