### PR TITLE
fix: Correct spec-compliance of API Tracer.start_span

### DIFF
--- a/api/lib/opentelemetry/trace/tracer.rb
+++ b/api/lib/opentelemetry/trace/tracer.rb
@@ -58,10 +58,13 @@ module OpenTelemetry
       def start_span(name, with_parent: nil, attributes: nil, links: nil, start_timestamp: nil, kind: nil)
         span = OpenTelemetry::Trace.current_span(with_parent)
 
-        if span.context.valid?
-          span
+        if span.recording?
+          OpenTelemetry::Trace.non_recording_span(span.context)
         else
-          Span::INVALID
+          # Either the span is valid and non-recording, in which case we return it,
+          # or there was no span in the Context and Trace.current_span returned Span::INVALID,
+          # which is what we're supposed to return.
+          span
         end
       end
     end


### PR DESCRIPTION
The [spec states](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#behavior-of-the-api-in-the-absence-of-an-installed-sdk):
> The API MUST return a non-recording Span with the SpanContext in the
  parent Context (whether explicitly given or implicit current). If the
  Span in the parent Context is already non-recording, it SHOULD be
  returned directly without instantiating a new Span. If the parent
  Context contains no Span, an empty non-recording Span MUST be returned
  instead (i.e., having a SpanContext with all-zero Span and Trace IDs,
  empty Tracestate, and unsampled TraceFlags).

With new tests that match the spec, the current implementation fails with:

``` OpenTelemetry::Trace::Tracer::#start_span#test_0002_returns a
non-recording span with the parent span context if the parent span is
recording [test/opentelemetry/trace/tracer_test.rb:97]: Expected
@context=#<OpenTelemetry::Trace::SpanContext:0x0000000120e17140
@trace_id="E\xC6d\xD5S+h\x8B\xC6u\xE6\xD5\ePQ\xDD",
@span_id="\xE2\xB3\x01\x99\xEC\xA0\xC1\x81",
@trace_flags=#<OpenTelemetry::Trace::TraceFlags:0x00000001052a50c0
@flags=0>,
@tracestate=#<OpenTelemetry::Trace::Tracestate:0x000000012085fdd8
@hash={}>, @remote=false>> to not be equal to
@context=#<OpenTelemetry::Trace::SpanContext:0x0000000120e17140
@trace_id="E\xC6d\xD5S+h\x8B\xC6u\xE6\xD5\ePQ\xDD",
@span_id="\xE2\xB3\x01\x99\xEC\xA0\xC1\x81",
@trace_flags=#<OpenTelemetry::Trace::TraceFlags:0x00000001052a50c0
@flags=0>,
@tracestate=#<OpenTelemetry::Trace::Tracestate:0x000000012085fdd8
@hash={}>, @remote=false>>.
```

The new implementation correctly passes this test (and the old tests). Shopify has been running with a similar patch in production for several years, based on a belief that the spec was incorrect - instead the _implementation_ was wrong 🤦 .

Context: IIRC the API Tracer was written assuming that it would be used only when no SDK was present, however that is not necessarily true (anyone can create a no-op API Tracer instance even if the SDK TracerProvider is installed) and the [spec for `TracerConfig`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#tracerconfig) states:

> If a Tracer is disabled, it MUST behave equivalently to a [No-op Tracer](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#behavior-of-the-api-in-the-absence-of-an-installed-sdk).

The obvious implementation of `TracerConfig` would delegate to an API Tracer instance when a Tracer is disabled.