### PR TITLE
Expose a setter to configure service namespace resource.

### DIFF
--- a/sdk/lib/opentelemetry/sdk/configurator.rb
+++ b/sdk/lib/opentelemetry/sdk/configurator.rb
@@ -90,6 +90,16 @@ module OpenTelemetry
         )
       end
 
+      # Accepts a string that is merged in as the service.namespace resource attribute.
+      # The most recent assigned value will be used in the event of repeated
+      # calls to this setter.
+      # @param [String] service_namespace The value to be used as the service namespace
+      def service_namespace=(service_namespace)
+        self.resource = OpenTelemetry::SDK::Resources::Resource.create(
+          OpenTelemetry::SemanticConventions::Resource::SERVICE_NAMESPACE => service_namespace
+        )
+      end
+
       # Install an instrumentation with specified optional +config+.
       # Use can be called multiple times to install multiple instrumentation.
       # Only +use+ or +use_all+, but not both when installing

--- a/sdk/test/opentelemetry/sdk/configurator_test.rb
+++ b/sdk/test/opentelemetry/sdk/configurator_test.rb
@@ -133,6 +133,17 @@ describe OpenTelemetry::SDK::Configurator do
     end
   end
 
+  describe '#service_namespace=' do
+    let(:configurator_resource) { configurator.instance_variable_get(:@resource) }
+    let(:configurator_resource_attributes) { configurator_resource.attribute_enumerator.to_h }
+    let(:expected_resource_attributes) { default_resource_attributes.merge('service.namespace' => 'Otel') }
+
+    it 'assigns the service_namespace resource' do
+      configurator.service_namespace = 'Otel'
+      _(configurator_resource_attributes).must_equal(expected_resource_attributes)
+    end
+  end
+
   describe '#use' do
     it 'can be called multiple times' do
       configurator.use('TestInstrumentation', enabled: true)


### PR DESCRIPTION
Add `Configurator#service_namespace` so that we can configure the service namespace when setting up the sdk

example
```ruby
OpenTelemetry::SDK.configure do |c|
  c.service_name = 'demo OTEL app'
  c.service_version = '2.0'
  c.service_namespace = 'OTEL'
    
  c.use_all
end
```