### PR TITLE
fix: Move the logs-sdk and metrics-sdk requires

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -11,5 +11,5 @@ gemspec
 eval_gemfile '../contrib/Gemfile.shared'
 
 group :test, :development do
-  gem 'opentelemetry-test-helpers', path: '../test_helpers'
+  gem 'opentelemetry-test-helpers', path: '../test_helpers', require: false
 end

--- a/common/Gemfile
+++ b/common/Gemfile
@@ -12,6 +12,6 @@ eval_gemfile '../contrib/Gemfile.shared'
 
 group :development, :test do
   # Use the opentelemetry-api gem from source
-  gem 'opentelemetry-api', path: '../api'
+  gem 'opentelemetry-api', path: '../api', require: false
   gem 'pry'
 end

--- a/exporter/jaeger/Gemfile
+++ b/exporter/jaeger/Gemfile
@@ -11,10 +11,10 @@ gemspec
 eval_gemfile '../../contrib/Gemfile.shared'
 
 group :test, :development do
-  gem 'opentelemetry-api', path: '../../api'
-  gem 'opentelemetry-common', path: '../../common'
-  gem 'opentelemetry-registry', path: '../../registry'
-  gem 'opentelemetry-sdk', path: '../../sdk'
-  gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions'
-  gem 'opentelemetry-test-helpers', path: '../../test_helpers'
+  gem 'opentelemetry-api', path: '../../api', require: false
+  gem 'opentelemetry-common', path: '../../common', require: false
+  gem 'opentelemetry-registry', path: '../../registry', require: false
+  gem 'opentelemetry-sdk', path: '../../sdk', require: false
+  gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions', require: false
+  gem 'opentelemetry-test-helpers', path: '../../test_helpers', require: false
 end

--- a/exporter/otlp-common/Gemfile
+++ b/exporter/otlp-common/Gemfile
@@ -11,9 +11,9 @@ gemspec
 eval_gemfile '../../contrib/Gemfile.shared'
 
 group :test, :development do
-  gem 'opentelemetry-api', path: '../../api'
-  gem 'opentelemetry-common', path: '../../common'
-  gem 'opentelemetry-registry', path: '../../registry'
-  gem 'opentelemetry-sdk', path: '../../sdk'
-  gem 'opentelemetry-test-helpers', path: '../../test_helpers'
+  gem 'opentelemetry-api', path: '../../api', require: false
+  gem 'opentelemetry-common', path: '../../common', require: false
+  gem 'opentelemetry-registry', path: '../../registry', require: false
+  gem 'opentelemetry-sdk', path: '../../sdk', require: false
+  gem 'opentelemetry-test-helpers', path: '../../test_helpers', require: false
 end

--- a/exporter/otlp-grpc/Gemfile
+++ b/exporter/otlp-grpc/Gemfile
@@ -11,11 +11,11 @@ gemspec
 eval_gemfile '../../contrib/Gemfile.shared'
 
 group :test, :development do
-  gem 'opentelemetry-api', path: '../../api'
-  gem 'opentelemetry-common', path: '../../common'
-  gem 'opentelemetry-exporter-otlp-common', path: '../otlp-common'
-  gem 'opentelemetry-registry', path: '../../registry'
-  gem 'opentelemetry-sdk', path: '../../sdk'
-  gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions'
-  gem 'opentelemetry-test-helpers', path: '../../test_helpers'
+  gem 'opentelemetry-api', path: '../../api', require: false
+  gem 'opentelemetry-common', path: '../../common', require: false
+  gem 'opentelemetry-exporter-otlp-common', path: '../otlp-common', require: false
+  gem 'opentelemetry-registry', path: '../../registry', require: false
+  gem 'opentelemetry-sdk', path: '../../sdk', require: false
+  gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions', require: false
+  gem 'opentelemetry-test-helpers', path: '../../test_helpers', require: false
 end

--- a/exporter/otlp-http/Gemfile
+++ b/exporter/otlp-http/Gemfile
@@ -11,11 +11,11 @@ gemspec
 eval_gemfile '../../contrib/Gemfile.shared'
 
 group :test, :development do
-  gem 'opentelemetry-api', path: '../../api'
-  gem 'opentelemetry-common', path: '../../common'
-  gem 'opentelemetry-exporter-otlp-common', path: '../otlp-common'
-  gem 'opentelemetry-registry', path: '../../registry'
-  gem 'opentelemetry-sdk', path: '../../sdk'
-  gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions'
-  gem 'opentelemetry-test-helpers', path: '../../test_helpers'
+  gem 'opentelemetry-api', path: '../../api', require: false
+  gem 'opentelemetry-common', path: '../../common', require: false
+  gem 'opentelemetry-exporter-otlp-common', path: '../otlp-common', require: false
+  gem 'opentelemetry-registry', path: '../../registry', require: false
+  gem 'opentelemetry-sdk', path: '../../sdk', require: false
+  gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions', require: false
+  gem 'opentelemetry-test-helpers', path: '../../test_helpers', require: false
 end

--- a/exporter/otlp-logs/Gemfile
+++ b/exporter/otlp-logs/Gemfile
@@ -9,14 +9,14 @@ source 'https://rubygems.org'
 gemspec
 
 group :test, :development do
-  gem 'opentelemetry-api', path: '../../api'
-  gem 'opentelemetry-common', path: '../../common'
-  gem 'opentelemetry-logs-api', path: '../../logs_api'
-  gem 'opentelemetry-logs-sdk', path: '../../logs_sdk'
-  gem 'opentelemetry-registry', path: '../../registry'
-  gem 'opentelemetry-sdk', path: '../../sdk'
-  gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions'
-  gem 'opentelemetry-test-helpers', path: '../../test_helpers'
+  gem 'opentelemetry-api', path: '../../api', require: false
+  gem 'opentelemetry-common', path: '../../common', require: false
+  gem 'opentelemetry-logs-api', path: '../../logs_api', require: false
+  gem 'opentelemetry-logs-sdk', path: '../../logs_sdk', require: false
+  gem 'opentelemetry-registry', path: '../../registry', require: false
+  gem 'opentelemetry-sdk', path: '../../sdk', require: false
+  gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions', require: false
+  gem 'opentelemetry-test-helpers', path: '../../test_helpers', require: false
 end
 
 group :test do

--- a/exporter/otlp-metrics/Gemfile
+++ b/exporter/otlp-metrics/Gemfile
@@ -9,12 +9,12 @@ source 'https://rubygems.org'
 gemspec
 
 group :test, :development do
-  gem 'opentelemetry-api', path: '../../api'
-  gem 'opentelemetry-common', path: '../../common'
-  gem 'opentelemetry-metrics-api', path: '../../metrics_api'
-  gem 'opentelemetry-metrics-sdk', path: '../../metrics_sdk'
-  gem 'opentelemetry-registry', path: '../../registry'
-  gem 'opentelemetry-sdk', path: '../../sdk'
-  gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions'
-  gem 'opentelemetry-test-helpers', path: '../../test_helpers'
+  gem 'opentelemetry-api', path: '../../api', require: false
+  gem 'opentelemetry-common', path: '../../common', require: false
+  gem 'opentelemetry-metrics-api', path: '../../metrics_api', require: false
+  gem 'opentelemetry-metrics-sdk', path: '../../metrics_sdk', require: false
+  gem 'opentelemetry-registry', path: '../../registry', require: false
+  gem 'opentelemetry-sdk', path: '../../sdk', require: false
+  gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions', require: false
+  gem 'opentelemetry-test-helpers', path: '../../test_helpers', require: false
 end

--- a/exporter/otlp/Gemfile
+++ b/exporter/otlp/Gemfile
@@ -9,10 +9,10 @@ source 'https://rubygems.org'
 gemspec
 
 group :test, :development do
-  gem 'opentelemetry-api', path: '../../api'
-  gem 'opentelemetry-common', path: '../../common'
-  gem 'opentelemetry-registry', path: '../../registry'
-  gem 'opentelemetry-sdk', path: '../../sdk'
-  gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions'
-  gem 'opentelemetry-test-helpers', path: '../../test_helpers'
+  gem 'opentelemetry-api', path: '../../api', require: false
+  gem 'opentelemetry-common', path: '../../common', require: false
+  gem 'opentelemetry-registry', path: '../../registry', require: false
+  gem 'opentelemetry-sdk', path: '../../sdk', require: false
+  gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions', require: false
+  gem 'opentelemetry-test-helpers', path: '../../test_helpers', require: false
 end

--- a/exporter/zipkin/Gemfile
+++ b/exporter/zipkin/Gemfile
@@ -11,10 +11,10 @@ gemspec
 eval_gemfile '../../contrib/Gemfile.shared'
 
 group :test, :development do
-  gem 'opentelemetry-api', path: '../../api'
-  gem 'opentelemetry-common', path: '../../common'
-  gem 'opentelemetry-registry', path: '../../registry'
-  gem 'opentelemetry-sdk', path: '../../sdk'
-  gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions'
-  gem 'opentelemetry-test-helpers', path: '../../test_helpers'
+  gem 'opentelemetry-api', path: '../../api', require: false
+  gem 'opentelemetry-common', path: '../../common', require: false
+  gem 'opentelemetry-registry', path: '../../registry', require: false
+  gem 'opentelemetry-sdk', path: '../../sdk', require: false
+  gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions', require: false
+  gem 'opentelemetry-test-helpers', path: '../../test_helpers', require: false
 end

--- a/logs_sdk/Gemfile
+++ b/logs_sdk/Gemfile
@@ -11,9 +11,9 @@ gemspec
 eval_gemfile '../contrib/Gemfile.shared'
 
 group :test, :development do
-  gem 'opentelemetry-api', path: '../api'
-  gem 'opentelemetry-exporter-otlp-logs', path: '../exporter/otlp-logs'
-  gem 'opentelemetry-logs-api', path: '../logs_api'
-  gem 'opentelemetry-sdk', path: '../sdk'
-  gem 'opentelemetry-test-helpers', path: '../test_helpers'
+  gem 'opentelemetry-api', path: '../api', require: false
+  gem 'opentelemetry-exporter-otlp-logs', path: '../exporter/otlp-logs', require: false
+  gem 'opentelemetry-logs-api', path: '../logs_api', require: false
+  gem 'opentelemetry-sdk', path: '../sdk', require: false
+  gem 'opentelemetry-test-helpers', path: '../test_helpers', require: false
 end

--- a/logs_sdk/lib/opentelemetry-logs-sdk.rb
+++ b/logs_sdk/lib/opentelemetry-logs-sdk.rb
@@ -4,6 +4,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'opentelemetry/sdk'
-require 'opentelemetry-logs-api'
 require 'opentelemetry/sdk/logs'

--- a/logs_sdk/lib/opentelemetry/sdk/logs.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs.rb
@@ -4,6 +4,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require 'opentelemetry/sdk'
+require 'opentelemetry-logs-api'
+
 require_relative 'logs/version'
 require_relative 'logs/configurator_patch'
 require_relative 'logs/logger'

--- a/metrics_api/Gemfile
+++ b/metrics_api/Gemfile
@@ -11,7 +11,7 @@ gemspec
 eval_gemfile '../contrib/Gemfile.shared'
 
 group :test, :development do
-  gem 'opentelemetry-api', path: '../api'
+  gem 'opentelemetry-api', path: '../api', require: false
   gem 'pry'
   gem 'pry-byebug' unless RUBY_ENGINE == 'jruby'
 end

--- a/metrics_sdk/Gemfile
+++ b/metrics_sdk/Gemfile
@@ -11,13 +11,13 @@ gemspec
 eval_gemfile '../contrib/Gemfile.shared'
 
 group :test, :development do
-  gem 'opentelemetry-api', path: '../api'
-  gem 'opentelemetry-common', path: '../common'
-  gem 'opentelemetry-exporter-otlp-metrics', path: '../exporter/otlp-metrics' unless RUBY_ENGINE == 'jruby'
-  gem 'opentelemetry-metrics-api', path: '../metrics_api'
-  gem 'opentelemetry-registry', path: '../registry'
-  gem 'opentelemetry-sdk', path: '../sdk'
-  gem 'opentelemetry-test-helpers', path: '../test_helpers'
+  gem 'opentelemetry-api', path: '../api', require: false
+  gem 'opentelemetry-common', path: '../common', require: false
+  gem 'opentelemetry-exporter-otlp-metrics', path: '../exporter/otlp-metrics', require: false unless RUBY_ENGINE == 'jruby'
+  gem 'opentelemetry-metrics-api', path: '../metrics_api', require: false
+  gem 'opentelemetry-registry', path: '../registry', require: false
+  gem 'opentelemetry-sdk', path: '../sdk', require: false
+  gem 'opentelemetry-test-helpers', path: '../test_helpers', require: false
   gem 'pry'
   gem 'pry-byebug' unless RUBY_ENGINE == 'jruby'
 end

--- a/metrics_sdk/lib/opentelemetry-metrics-sdk.rb
+++ b/metrics_sdk/lib/opentelemetry-metrics-sdk.rb
@@ -4,6 +4,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-require 'opentelemetry/sdk'
-require 'opentelemetry-metrics-api'
 require 'opentelemetry/sdk/metrics'

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics.rb
@@ -4,6 +4,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+require 'opentelemetry/sdk'
+require 'opentelemetry-metrics-api'
+
 module OpenTelemetry
   module SDK
     # The Metrics module contains the OpenTelemetry metrics reference
@@ -13,6 +16,7 @@ module OpenTelemetry
   end
 end
 
+require 'opentelemetry/sdk/metrics/version'
 require 'opentelemetry/sdk/metrics/exemplar'
 require 'opentelemetry/sdk/metrics/aggregation'
 require 'opentelemetry/sdk/metrics/configurator_patch'

--- a/propagator/b3/Gemfile
+++ b/propagator/b3/Gemfile
@@ -11,5 +11,5 @@ gemspec
 eval_gemfile '../../contrib/Gemfile.shared'
 
 group :test do
-  gem 'opentelemetry-api', path: '../../api'
+  gem 'opentelemetry-api', path: '../../api', require: false
 end

--- a/propagator/jaeger/Gemfile
+++ b/propagator/jaeger/Gemfile
@@ -11,8 +11,8 @@ gemspec
 eval_gemfile '../../contrib/Gemfile.shared'
 
 group :test do
-  gem 'opentelemetry-api', path: '../../api'
-  gem 'opentelemetry-common', path: '../../common'
-  gem 'opentelemetry-registry', path: '../../registry'
-  gem 'opentelemetry-sdk', path: '../../sdk'
+  gem 'opentelemetry-api', path: '../../api', require: false
+  gem 'opentelemetry-common', path: '../../common', require: false
+  gem 'opentelemetry-registry', path: '../../registry', require: false
+  gem 'opentelemetry-sdk', path: '../../sdk', require: false
 end

--- a/registry/Gemfile
+++ b/registry/Gemfile
@@ -11,5 +11,5 @@ gemspec
 eval_gemfile '../contrib/Gemfile.shared'
 
 group :test do
-  gem 'opentelemetry-api', path: '../api'
+  gem 'opentelemetry-api', path: '../api', require: false
 end

--- a/sdk/Gemfile
+++ b/sdk/Gemfile
@@ -11,10 +11,10 @@ gemspec
 eval_gemfile '../contrib/Gemfile.shared'
 
 group :test, :development do
-  gem 'opentelemetry-api', path: '../api'
-  gem 'opentelemetry-common', path: '../common'
-  gem 'opentelemetry-exporter-zipkin', path: '../exporter/zipkin'
-  gem 'opentelemetry-registry', path: '../registry'
-  gem 'opentelemetry-semantic_conventions', path: '../semantic_conventions'
-  gem 'opentelemetry-test-helpers', path: '../test_helpers'
+  gem 'opentelemetry-api', path: '../api', require: false
+  gem 'opentelemetry-common', path: '../common', require: false
+  gem 'opentelemetry-exporter-zipkin', path: '../exporter/zipkin', require: false
+  gem 'opentelemetry-registry', path: '../registry', require: false
+  gem 'opentelemetry-semantic_conventions', path: '../semantic_conventions', require: false
+  gem 'opentelemetry-test-helpers', path: '../test_helpers', require: false
 end

--- a/sdk_experimental/Gemfile
+++ b/sdk_experimental/Gemfile
@@ -11,11 +11,11 @@ gemspec
 eval_gemfile '../contrib/Gemfile.shared'
 
 group :test, :development do
-  gem 'opentelemetry-api', path: '../api'
-  gem 'opentelemetry-common', path: '../common'
-  gem 'opentelemetry-registry', path: '../registry'
-  gem 'opentelemetry-sdk', path: '../sdk'
-  gem 'opentelemetry-test-helpers', path: '../test_helpers'
+  gem 'opentelemetry-api', path: '../api', require: false
+  gem 'opentelemetry-common', path: '../common', require: false
+  gem 'opentelemetry-registry', path: '../registry', require: false
+  gem 'opentelemetry-sdk', path: '../sdk', require: false
+  gem 'opentelemetry-test-helpers', path: '../test_helpers', require: false
   gem 'pry'
   gem 'pry-byebug' unless RUBY_ENGINE == 'jruby'
 end

--- a/semantic_conventions/Gemfile
+++ b/semantic_conventions/Gemfile
@@ -12,6 +12,6 @@ eval_gemfile '../contrib/Gemfile.shared'
 
 group :development, :test do
   gem 'mutex_m' if RUBY_VERSION >= '3.4'
-  gem 'opentelemetry-api', path: '../api'
+  gem 'opentelemetry-api', path: '../api', require: false
   gem 'pry'
 end

--- a/test_helpers/Gemfile
+++ b/test_helpers/Gemfile
@@ -11,8 +11,8 @@ gemspec
 eval_gemfile '../contrib/Gemfile.shared'
 
 group :test, :development do
-  gem 'opentelemetry-api', path: '../api'
-  gem 'opentelemetry-common', path: '../common'
-  gem 'opentelemetry-registry', path: '../registry'
-  gem 'opentelemetry-sdk', path: '../sdk'
+  gem 'opentelemetry-api', path: '../api', require: false
+  gem 'opentelemetry-common', path: '../common', require: false
+  gem 'opentelemetry-registry', path: '../registry', require: false
+  gem 'opentelemetry-sdk', path: '../sdk', require: false
 end


### PR DESCRIPTION
This makes it so the logs and metrics will work when you require like
```ruby
require 'opentelemetry/sdk/logs'
require 'opentelemetry/sdk/metrics'
```
Without requiring 'opentelemetry-logs-api' or 'opentelemetry-logs-metrics' earlier.

The opentelemetry-exporter-otlp-logs gem works around this, but I'm leaving that workaround there for now, so it will work with old versions of the opentelemetry-logs-sdk gem that are still locked.

Also added a missing `require 'opentelemetry/sdk/metrics/version'`.

To verify the fixes, I added `require: false` to the Gemfile files for the internal gem overrides. If you don't include `require: false` in the gem override declarations in the Gemfile, it will require those dependency files, which will hide bad requires in the code itself. If you specify `require: false`, the actual gem code requires will apply.

[Fixes #1955]