### PR TITLE
fix!: fix the issue of mixed scale with multiple attributes

### DIFF
--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/aggregation/exponential_bucket_histogram.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/aggregation/exponential_bucket_histogram.rb
@@ -44,8 +44,6 @@ module OpenTelemetry
             @size           = validate_size(max_size)
             @scale          = validate_scale(max_scale)
 
-            @mapping = new_mapping(@scale)
-
             # Previous state for cumulative aggregation
             @previous_positive = {} # nil
             @previous_negative = {} # nil
@@ -55,6 +53,10 @@ module OpenTelemetry
             @previous_count = {} # 0
             @previous_zero_count = {} # 0
             @previous_scale = {} # nil
+
+            # Cache mappings per attribute set
+            @mappings = {}
+            @previous_mappings = {}
           end
 
           # when aggregation temporality is cumulative, merge and downscale will happen.
@@ -68,6 +70,7 @@ module OpenTelemetry
                 hdp
               end
               data_points.clear
+              @mappings.clear
               hdps
             else
               # CUMULATIVE temporality - merge current data_points to previous data_points
@@ -161,6 +164,7 @@ module OpenTelemetry
                 )
 
                 merged_data_points[attributes] = merged_hdp
+                @previous_mappings[attributes] = @mappings[attributes] if @mappings[attributes] # Preserve mapping for next collection
               end
               # rubocop:enable Metrics/BlockLength
 
@@ -188,6 +192,10 @@ module OpenTelemetry
                 end
               end
 
+              # Swap current with previous mappings for next cycle
+              @mappings = @previous_mappings
+              @previous_mappings = {}
+
               # clear data_points since the data is merged into previous_* already;
               # otherwise we will have duplicated data_points in the next collect
               data_points.clear
@@ -197,7 +205,7 @@ module OpenTelemetry
           # rubocop:enable Metrics/MethodLength
 
           # this is aggregate in python; there is no merge in aggregate; but rescale happened
-          # rubocop:disable Metrics/MethodLength
+          # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
           def update(amount, attributes, data_points)
             # fetch or initialize the ExponentialHistogramDataPoint
             hdp = data_points.fetch(attributes) do
@@ -215,13 +223,13 @@ module OpenTelemetry
                 0,                                                                 # :sum
                 @scale,                                                            # :scale
                 @zero_count,                                                       # :zero_count
-                ExponentialHistogram::Buckets.new,  # :positive
-                ExponentialHistogram::Buckets.new,  # :negative
+                ExponentialHistogram::Buckets.new,                                 # :positive
+                ExponentialHistogram::Buckets.new,                                 # :negative
                 0,                                                                 # :flags
                 nil,                                                               # :exemplars
                 min,                                                               # :min
                 max,                                                               # :max
-                @zero_threshold # :zero_threshold)
+                @zero_threshold                                                    # :zero_threshold
               )
             end
 
@@ -244,7 +252,15 @@ module OpenTelemetry
             buckets = amount.positive? ? hdp.positive : hdp.negative
             amount = -amount if amount.negative?
 
-            bucket_index = @mapping.map_to_index(amount)
+            # Reset scale to max_scale if transitioning from all-zeros to first non-zero value
+            if buckets.counts == [0] && hdp.scale == 0 && hdp.count > hdp.zero_count
+              hdp.scale = @scale
+              @mappings.delete(attributes) # Clear any cached mapping
+            end
+
+            # Get or create mapping for this attribute set
+            mapping = @mappings[attributes] ||= new_mapping(hdp.scale)
+            bucket_index = mapping.map_to_index(amount)
 
             rescaling_needed = false
             low = high = 0
@@ -268,14 +284,15 @@ module OpenTelemetry
             if rescaling_needed
               scale_change = get_scale_change(low, high)
               downscale(scale_change, hdp.positive, hdp.negative)
-              new_scale = @mapping.scale - scale_change
-              @mapping = new_mapping(new_scale)
-              bucket_index = @mapping.map_to_index(amount)
+              new_scale = mapping.scale - scale_change
+              mapping = new_mapping(new_scale)
+              @mappings[attributes] = mapping # Update cache
+              bucket_index = mapping.map_to_index(amount)
 
               OpenTelemetry.logger.debug "Rescaled with new scale #{new_scale} from #{low} and #{high}; bucket_index is updated to #{bucket_index}"
             end
 
-            hdp.scale = @mapping.scale
+            hdp.scale = mapping.scale
 
             # adjust buckets based on the bucket_index
             if bucket_index < buckets.index_start
@@ -294,7 +311,7 @@ module OpenTelemetry
             buckets.increment_bucket(bucket_index)
             nil
           end
-          # rubocop:enable Metrics/MethodLength
+          # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity
 
           def aggregation_temporality
             @aggregation_temporality.temporality


### PR DESCRIPTION
## Description

Fix the issue that multiple attributes mix up the scale.
The fix is aiming to store the mapping for each data point with unique attributes instead of share the same `@mapping` for all data point.

Resolve https://github.com/open-telemetry/opentelemetry-ruby/issues/2000