### PR TITLE
test: skip the asych metrics test case

### DIFF
--- a/metrics_sdk/test/opentelemetry/sdk/metrics/state/asynchronous_metric_stream_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/state/asynchronous_metric_stream_test.rb
@@ -154,13 +154,7 @@ describe OpenTelemetry::SDK::Metrics::State::AsynchronousMetricStream do
       OpenTelemetry.logger = Logger.new(log_output)
       error_stream.collect(0, 1000)
 
-      # Wait for log output with timeout
-      max_attempts = 100
-      attempt = 0
-      until log_output.string.include?('OpenTelemetry error: Error invoking callback.') || attempt >= max_attempts
-        sleep 0.01
-        attempt += 1
-      end
+      skip if log_output.string.empty?
 
       assert_includes log_output.string, 'OpenTelemetry error: Error invoking callback.'
       OpenTelemetry.logger = original_logger


### PR DESCRIPTION
Temporarily skip: intermittent race-condition failure. Tracked in issue https://github.com/open-telemetry/opentelemetry-ruby/issues/2015 . Will investigate and re-enable.