### PR TITLE
chore: Deprecate Jaeger Exporter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,10 +18,6 @@ updates:
   schedule:
     interval: weekly
 - package-ecosystem: bundler
-  directory: "/exporter/jaeger"
-  schedule:
-    interval: weekly
-- package-ecosystem: bundler
   directory: "/exporter/otlp"
   schedule:
     interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,6 @@ jobs:
       fail-fast: false
       matrix:
         gem:
-          - opentelemetry-exporter-jaeger
           - opentelemetry-exporter-otlp
           - opentelemetry-exporter-otlp-common
           - opentelemetry-exporter-otlp-grpc
@@ -96,12 +95,7 @@ jobs:
           - macos-latest
           - windows-latest
         exclude:
-          # Doesn't build on macos
-          - os: macos-latest
-            gem: opentelemetry-exporter-jaeger
          # Windows runs Ruby 3.4, which isn't compatible with this gem
-          - os: windows-latest
-            gem: opentelemetry-exporter-jaeger
           - os: windows-latest
             gem: opentelemetry-exporter-otlp-grpc
     name: ${{ matrix.gem }} / ${{ matrix.os }}
@@ -109,19 +103,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: "Test Ruby 3.4"
-        if: "${{ matrix.gem != 'opentelemetry-exporter-jaeger' }}"
         uses: ./.github/actions/test_gem
         with:
           gem: "${{ matrix.gem }}"
           ruby: "3.4"
       - name: "Test Ruby 3.3"
-        if: "${{ matrix.gem != 'opentelemetry-exporter-jaeger' }}"
         uses: ./.github/actions/test_gem
         with:
           gem: "${{ matrix.gem }}"
           ruby: "3.3"
       - name: "Test Ruby 3.2"
-        if: "${{ matrix.gem != 'opentelemetry-exporter-jaeger' }}"
         uses: ./.github/actions/test_gem
         with:
           gem: "${{ matrix.gem }}"
@@ -141,19 +132,12 @@ jobs:
         with:
           gem: "${{ matrix.gem }}"
           ruby: "jruby"
-      - name: "Test Jaeger with JRuby"
-        if: "${{ matrix.os == 'ubuntu-latest' && matrix.gem == 'opentelemetry-exporter-jaeger' }}"
-        uses: ./.github/actions/test_gem
-        with:
-          gem: "${{ matrix.gem }}"
-          ruby: "jruby-9.4"
       - name: "Truffleruby Filter"
         id: truffleruby_skip
         shell: bash
         run: |
           echo "skip=false" >> $GITHUB_OUTPUT
           [[ "${{ matrix.gem }}" == "opentelemetry-exporter-otlp-grpc" ]] && echo "skip=true" >> $GITHUB_OUTPUT
-          [[ "${{ matrix.gem }}" == "opentelemetry-exporter-jaeger" ]] && echo "skip=true" >> $GITHUB_OUTPUT
           # This is essentially a bash script getting evaluated, so we need to return true or the whole job fails.
           true
       - name: "Test truffleruby"

--- a/.toys/.data/releases.yml
+++ b/.toys/.data/releases.yml
@@ -55,10 +55,6 @@ gems:
     version_rb_path: lib/opentelemetry/common/version.rb
     version_constant: [OpenTelemetry, Common, VERSION]
 
-  - name: opentelemetry-exporter-jaeger
-    directory: exporter/jaeger
-    version_constant: [OpenTelemetry, Exporter, Jaeger, VERSION]
-
   - name: opentelemetry-exporter-otlp
     # we append a slash here to avoid the naive substring start_with? directory-matching condition in underlying toys gem
     # which casues exporter/otlp to incorrectly match when changes occur in exporter/otlp-logs or exporter/otlp-metrics

--- a/exporter/jaeger/README.md
+++ b/exporter/jaeger/README.md
@@ -1,5 +1,10 @@
 # opentelemetry-exporter-jaeger
 
+## :warning: EOL NOTICE 2025-12-31
+
+  The `opentelemetry-exporter-jaeger` gem is deprecated and will no longer be maintained. Users are encouraged to migrate to the `opentelemetry-exporter-otlp` gem for future-proof OpenTelemetry integration. See the offical docs for details <https://www.jaegertracing.io/docs/latest/migration/>
+
+
 The `opentelemetry-exporter-jaeger` gem provides Jaeger exporters for OpenTelemetry for Ruby. Using `opentelemetry-exporter-jaeger`, an application can configure OpenTelemetry to export collected tracing data to [Jaeger][jaeger-home]. Two exporters are included: the `AgentExporter` exports in Thrift Compact format over UDP to the Jaeger agent; and the `CollectorExporter` exports in Thrift Binary format over HTTP to the Jaeger collector.
 
 ## What is OpenTelemetry?


### PR DESCRIPTION
Jaeger Exporter formatter reached EOL on 2025-12-31 <https://github.com/jaegertracing/jaeger/issues/6321>

This change removes the gem from CI and releases. The code is left in place for legacy versions.