### PR TITLE
ci: Block actions on forks

### DIFF
--- a/.github/workflows/ci-markdown-link.yml
+++ b/.github/workflows/ci-markdown-link.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   markdown-link-check:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby' }}
     permissions:
       pull-requests: write # required for posting review comments
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-markdownlint.yml
+++ b/.github/workflows/ci-markdownlint.yml
@@ -8,6 +8,7 @@ permissions:
 
 jobs:
   markdownlint-check:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   base:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby' }}
     strategy:
       fail-fast: false
       matrix:
@@ -79,6 +80,7 @@ jobs:
           ruby: "truffleruby"
 
   exporters:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby' }}
     strategy:
       fail-fast: false
       matrix:
@@ -164,6 +166,7 @@ jobs:
           ruby: "truffleruby"
 
   propagators:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby' }}
     strategy:
       fail-fast: false
       matrix:
@@ -216,6 +219,7 @@ jobs:
           ruby: "truffleruby"
 
   codespell:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   validate-commits:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby' }}
     name: Conventional Commits Validation
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This adds a constraint to all jobs to prevent them from running on forked repos.

cc: @wsmoak