### PR TITLE
chore: Disable GHA dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,6 @@
 ---
 version: 2
 updates:
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: daily
 - package-ecosystem: bundler
   directory: "/"
   schedule:


### PR DESCRIPTION
Now that we're using renovate, we're getting a lot of duplicate PRs