### PR TITLE
chore: update for rubocop 1.84.1

### DIFF
--- a/exporter/otlp-common/lib/opentelemetry/exporter/otlp/common.rb
+++ b/exporter/otlp-common/lib/opentelemetry/exporter/otlp/common.rb
@@ -46,25 +46,25 @@ module OpenTelemetry
         def as_etsr(span_data)
           Opentelemetry::Proto::Collector::Trace::V1::ExportTraceServiceRequest.new(
             resource_spans: span_data
-              .group_by(&:resource)
-              .map do |resource, span_datas|
-                Opentelemetry::Proto::Trace::V1::ResourceSpans.new(
-                  resource: Opentelemetry::Proto::Resource::V1::Resource.new(
-                    attributes: resource.attribute_enumerator.map { |key, value| as_otlp_key_value(key, value) }
-                  ),
-                  scope_spans: span_datas
-                    .group_by(&:instrumentation_scope)
-                    .map do |il, sds|
-                      Opentelemetry::Proto::Trace::V1::ScopeSpans.new(
-                        scope: Opentelemetry::Proto::Common::V1::InstrumentationScope.new(
-                          name: il.name,
-                          version: il.version
-                        ),
-                        spans: sds.map { |sd| as_otlp_span(sd) }
-                      )
-                    end
-                )
-              end
+                            .group_by(&:resource)
+                            .map do |resource, span_datas|
+                              Opentelemetry::Proto::Trace::V1::ResourceSpans.new(
+                                resource: Opentelemetry::Proto::Resource::V1::Resource.new(
+                                  attributes: resource.attribute_enumerator.map { |key, value| as_otlp_key_value(key, value) }
+                                ),
+                                scope_spans: span_datas
+                                             .group_by(&:instrumentation_scope)
+                                             .map do |il, sds|
+                                               Opentelemetry::Proto::Trace::V1::ScopeSpans.new(
+                                                 scope: Opentelemetry::Proto::Common::V1::InstrumentationScope.new(
+                                                   name: il.name,
+                                                   version: il.version
+                                                 ),
+                                                 spans: sds.map { |sd| as_otlp_span(sd) }
+                                               )
+                                             end
+                              )
+                            end
           )
         end
 

--- a/exporter/otlp-logs/lib/opentelemetry/exporter/otlp/logs/logs_exporter.rb
+++ b/exporter/otlp-logs/lib/opentelemetry/exporter/otlp/logs/logs_exporter.rb
@@ -273,25 +273,25 @@ module OpenTelemetry
             Opentelemetry::Proto::Collector::Logs::V1::ExportLogsServiceRequest.encode(
               Opentelemetry::Proto::Collector::Logs::V1::ExportLogsServiceRequest.new(
                 resource_logs: log_record_data
-                  .group_by(&:resource)
-                  .map do |resource, log_record_datas|
-                    Opentelemetry::Proto::Logs::V1::ResourceLogs.new(
-                      resource: Opentelemetry::Proto::Resource::V1::Resource.new(
-                        attributes: resource.attribute_enumerator.map { |key, value| as_otlp_key_value(key, value) }
-                      ),
-                      scope_logs: log_record_datas
-                        .group_by(&:instrumentation_scope)
-                        .map do |il, lrd|
-                          Opentelemetry::Proto::Logs::V1::ScopeLogs.new(
-                            scope: Opentelemetry::Proto::Common::V1::InstrumentationScope.new(
-                              name: il.name,
-                              version: il.version
-                            ),
-                            log_records: lrd.map { |lr| as_otlp_log_record(lr) }
-                          )
-                        end
-                    )
-                  end
+                               .group_by(&:resource)
+                               .map do |resource, log_record_datas|
+                                 Opentelemetry::Proto::Logs::V1::ResourceLogs.new(
+                                   resource: Opentelemetry::Proto::Resource::V1::Resource.new(
+                                     attributes: resource.attribute_enumerator.map { |key, value| as_otlp_key_value(key, value) }
+                                   ),
+                                   scope_logs: log_record_datas
+                                               .group_by(&:instrumentation_scope)
+                                               .map do |il, lrd|
+                                                 Opentelemetry::Proto::Logs::V1::ScopeLogs.new(
+                                                   scope: Opentelemetry::Proto::Common::V1::InstrumentationScope.new(
+                                                     name: il.name,
+                                                     version: il.version
+                                                   ),
+                                                   log_records: lrd.map { |lr| as_otlp_log_record(lr) }
+                                                 )
+                                               end
+                                 )
+                               end
               )
             )
           rescue StandardError => e

--- a/exporter/otlp-metrics/lib/opentelemetry/exporter/otlp/metrics/metrics_exporter.rb
+++ b/exporter/otlp-metrics/lib/opentelemetry/exporter/otlp/metrics/metrics_exporter.rb
@@ -187,25 +187,25 @@ module OpenTelemetry
             Opentelemetry::Proto::Collector::Metrics::V1::ExportMetricsServiceRequest.encode(
               Opentelemetry::Proto::Collector::Metrics::V1::ExportMetricsServiceRequest.new(
                 resource_metrics: metrics_data
-                  .group_by(&:resource)
-                  .map do |resource, scope_metrics|
-                    Opentelemetry::Proto::Metrics::V1::ResourceMetrics.new(
-                      resource: Opentelemetry::Proto::Resource::V1::Resource.new(
-                        attributes: resource.attribute_enumerator.map { |key, value| as_otlp_key_value(key, value) }
-                      ),
-                      scope_metrics: scope_metrics
-                        .group_by(&:instrumentation_scope)
-                        .map do |instrumentation_scope, metrics|
-                          Opentelemetry::Proto::Metrics::V1::ScopeMetrics.new(
-                            scope: Opentelemetry::Proto::Common::V1::InstrumentationScope.new(
-                              name: instrumentation_scope.name,
-                              version: instrumentation_scope.version
-                            ),
-                            metrics: metrics.map { |sd| as_otlp_metrics(sd) }
-                          )
-                        end
-                    )
-                  end
+                                  .group_by(&:resource)
+                                  .map do |resource, scope_metrics|
+                                    Opentelemetry::Proto::Metrics::V1::ResourceMetrics.new(
+                                      resource: Opentelemetry::Proto::Resource::V1::Resource.new(
+                                        attributes: resource.attribute_enumerator.map { |key, value| as_otlp_key_value(key, value) }
+                                      ),
+                                      scope_metrics: scope_metrics
+                                                     .group_by(&:instrumentation_scope)
+                                                     .map do |instrumentation_scope, metrics|
+                                                       Opentelemetry::Proto::Metrics::V1::ScopeMetrics.new(
+                                                         scope: Opentelemetry::Proto::Common::V1::InstrumentationScope.new(
+                                                           name: instrumentation_scope.name,
+                                                           version: instrumentation_scope.version
+                                                         ),
+                                                         metrics: metrics.map { |sd| as_otlp_metrics(sd) }
+                                                       )
+                                                     end
+                                    )
+                                  end
               )
             )
           rescue StandardError => e

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -299,25 +299,25 @@ module OpenTelemetry
           Opentelemetry::Proto::Collector::Trace::V1::ExportTraceServiceRequest.encode(
             Opentelemetry::Proto::Collector::Trace::V1::ExportTraceServiceRequest.new(
               resource_spans: span_data
-                .group_by(&:resource)
-                .map do |resource, span_datas|
-                  Opentelemetry::Proto::Trace::V1::ResourceSpans.new(
-                    resource: Opentelemetry::Proto::Resource::V1::Resource.new(
-                      attributes: resource.attribute_enumerator.map { |key, value| as_otlp_key_value(key, value) }
-                    ),
-                    scope_spans: span_datas
-                      .group_by(&:instrumentation_scope)
-                      .map do |il, sds|
-                        Opentelemetry::Proto::Trace::V1::ScopeSpans.new(
-                          scope: Opentelemetry::Proto::Common::V1::InstrumentationScope.new(
-                            name: il.name,
-                            version: il.version
-                          ),
-                          spans: sds.map { |sd| as_otlp_span(sd) }
-                        )
-                      end
-                  )
-                end
+                              .group_by(&:resource)
+                              .map do |resource, span_datas|
+                                Opentelemetry::Proto::Trace::V1::ResourceSpans.new(
+                                  resource: Opentelemetry::Proto::Resource::V1::Resource.new(
+                                    attributes: resource.attribute_enumerator.map { |key, value| as_otlp_key_value(key, value) }
+                                  ),
+                                  scope_spans: span_datas
+                                               .group_by(&:instrumentation_scope)
+                                               .map do |il, sds|
+                                                 Opentelemetry::Proto::Trace::V1::ScopeSpans.new(
+                                                   scope: Opentelemetry::Proto::Common::V1::InstrumentationScope.new(
+                                                     name: il.name,
+                                                     version: il.version
+                                                   ),
+                                                   spans: sds.map { |sd| as_otlp_span(sd) }
+                                                 )
+                                               end
+                                )
+                              end
             )
           )
         rescue StandardError => e

--- a/logs_sdk/test/opentelemetry/sdk/logs/export/batch_log_record_processor_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/export/batch_log_record_processor_test.rb
@@ -6,7 +6,6 @@
 
 require 'test_helper'
 
-# rubocop:disable Lint/ConstantDefinitionInBlock, Style/Documentation
 describe OpenTelemetry::SDK::Logs::Export::BatchLogRecordProcessor do
   BatchLogRecordProcessor = OpenTelemetry::SDK::Logs::Export::BatchLogRecordProcessor
   SUCCESS = OpenTelemetry::SDK::Logs::Export::SUCCESS
@@ -545,4 +544,3 @@ describe OpenTelemetry::SDK::Logs::Export::BatchLogRecordProcessor do
     end
   end
 end
-# rubocop:enable Lint/ConstantDefinitionInBlock, Style/Documentation


### PR DESCRIPTION
## Description

Certain workflows failed due to the rubocop update to version 1.84.1, requiring code modifications to comply with the new rules.