### PR TITLE
chore: Remove faraday from dev dependencies

### DIFF
--- a/api/opentelemetry-api.gemspec
+++ b/api/opentelemetry-api.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'benchmark-ipsa', '~> 0.2.0'
   spec.add_development_dependency 'concurrent-ruby', '~> 1.3'
-  spec.add_development_dependency 'faraday', '~> 0.13'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rake', '~> 13.3'

--- a/exporter/jaeger/opentelemetry-exporter-jaeger.gemspec
+++ b/exporter/jaeger/opentelemetry-exporter-jaeger.gemspec
@@ -33,7 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-semantic_conventions'
   spec.add_dependency 'thrift'
 
-  spec.add_development_dependency 'faraday', '~> 0.13'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rake', '~> 13.3'

--- a/exporter/otlp-common/opentelemetry-exporter-otlp-common.gemspec
+++ b/exporter/otlp-common/opentelemetry-exporter-otlp-common.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'google-protobuf', '~> 3.19'
   spec.add_dependency 'opentelemetry-api', '~> 1.1'
 
-  spec.add_development_dependency 'faraday', '~> 0.13'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.2'
   spec.add_development_dependency 'opentelemetry-test-helpers'

--- a/exporter/otlp-grpc/opentelemetry-exporter-otlp-grpc.gemspec
+++ b/exporter/otlp-grpc/opentelemetry-exporter-otlp-grpc.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-exporter-otlp-common'
   spec.add_dependency 'opentelemetry-sdk', '~> 1.2'
 
-  spec.add_development_dependency 'faraday', '~> 0.13'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'

--- a/exporter/otlp-http/opentelemetry-exporter-otlp-http.gemspec
+++ b/exporter/otlp-http/opentelemetry-exporter-otlp-http.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-exporter-otlp-common'
   spec.add_dependency 'opentelemetry-sdk', '~> 1.2'
 
-  spec.add_development_dependency 'faraday', '~> 0.13'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'

--- a/exporter/otlp-logs/opentelemetry-exporter-otlp-logs.gemspec
+++ b/exporter/otlp-logs/opentelemetry-exporter-otlp-logs.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-semantic_conventions'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
-  spec.add_development_dependency 'faraday', '~> 0.13'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'

--- a/exporter/otlp-metrics/opentelemetry-exporter-otlp-metrics.gemspec
+++ b/exporter/otlp-metrics/opentelemetry-exporter-otlp-metrics.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-semantic_conventions'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
-  spec.add_development_dependency 'faraday', '~> 0.13'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'

--- a/exporter/otlp/opentelemetry-exporter-otlp.gemspec
+++ b/exporter/otlp/opentelemetry-exporter-otlp.gemspec
@@ -33,7 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-semantic_conventions'
 
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
-  spec.add_development_dependency 'faraday', '~> 0.13'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'

--- a/exporter/zipkin/opentelemetry-exporter-zipkin.gemspec
+++ b/exporter/zipkin/opentelemetry-exporter-zipkin.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-sdk', '~> 1.2'
   spec.add_dependency 'opentelemetry-semantic_conventions'
 
-  spec.add_development_dependency 'faraday', '~> 0.13'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rake', '~> 13.3'

--- a/metrics_api/opentelemetry-metrics-api.gemspec
+++ b/metrics_api/opentelemetry-metrics-api.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
 
   spec.add_development_dependency 'benchmark-ipsa', '~> 0.2.0'
-  spec.add_development_dependency 'faraday', '~> 0.13'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3.0'
   spec.add_development_dependency 'rake', '~> 13.3'

--- a/metrics_sdk/opentelemetry-metrics-sdk.gemspec
+++ b/metrics_sdk/opentelemetry-metrics-sdk.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-sdk', '~> 1.2'
 
   spec.add_development_dependency 'benchmark-ipsa', '~> 0.2.0'
-  spec.add_development_dependency 'faraday', '~> 0.13'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rake', '~> 13.3'

--- a/sdk/opentelemetry-sdk.gemspec
+++ b/sdk/opentelemetry-sdk.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |spec|
   # initial release of opentelemetry-semantic_conventions, so we feel it is safe.
   spec.add_dependency 'opentelemetry-semantic_conventions'
 
-  spec.add_development_dependency 'faraday', '~> 0.13'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-exporter-zipkin', '~> 0.19'
   spec.add_development_dependency 'opentelemetry-instrumentation-base', '~> 0.20'

--- a/sdk_experimental/opentelemetry-sdk-experimental.gemspec
+++ b/sdk_experimental/opentelemetry-sdk-experimental.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-sdk', '~> 1.2'
 
   spec.add_development_dependency 'benchmark-ipsa', '~> 0.2.0'
-  spec.add_development_dependency 'faraday', '~> 0.13'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rake', '~> 13.3'


### PR DESCRIPTION
Faraday isn't being used. 

PR #2045 sought to update the version, but when I looked into it, we aren't using it in our gems. 