### PR TITLE
ci: Use renovate to update semantic conventions gem

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -70,7 +70,9 @@ ignoreWords:
   - Dockerfiles
 words:
   - autocorrection
+  - bigdecimal
   - configurator
+  - confluentinc
   - linkspector
   - loggregator
   - LOGRECORD
@@ -78,12 +80,3 @@ words:
   - semconv
   - traceid
   - tracestate
-  - loggregator
-  - configurator
-
-  - autocorrection
-
-  - linkspector
-  - SARIF
-  - bigdecimal
-  - confluentinc

--- a/.cspell.yml
+++ b/.cspell.yml
@@ -69,7 +69,13 @@ ignoreWords:
   - codegen
   - Dockerfiles
 words:
+  - autocorrection
+  - configurator
+  - linkspector
+  - loggregator
   - LOGRECORD
+  - SARIF
+  - semconv
   - traceid
   - tracestate
   - loggregator

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -81,6 +81,17 @@
       matchUpdateTypes: ["digest"],
       enabled: false,
     },
+    {
+      description: "Create PRs for older semantic conventions versions",
+      separateMultipleMinor: true,
+      separateMinorPatch: true,
+      schedule: ["at any time"],
+      matchDatasources: ["github-releases"],
+      matchDepNames: ["open-telemetry/semantic-conventions"],
+      semanticCommitType: "feat",
+      semanticCommitScope: "semconv",
+      labels: ["dependencies", "semconv"]
+    },
   ],
   customManagers: [
     {
@@ -151,6 +162,18 @@
       datasourceTemplate: "github-runners",
       currentValueTemplate: "{{depVersion}}",
       depTypeTemplate: "github-runner",
+    },
+    {
+      "customType": "regex",
+      "description": "Update Semantic Conventions version in Rake files",
+      "managerFilePatterns": ["/^semantic_conventions/Rakefile$/"],
+      "matchStrings": [
+        "SPEC_VERSION = '(?<currentValue>.*?)'"
+      ],
+      "depNameTemplate": "open-telemetry/semantic-conventions",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     },
   ],
   lockFileMaintenance: {

--- a/.github/workflows/renovate-semconv.yml
+++ b/.github/workflows/renovate-semconv.yml
@@ -1,0 +1,58 @@
+name: Renovate Semantic Conventions Post-Update
+
+on:
+  pull_request:
+    paths:
+      - 'semantic_conventions/Rakefile'
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  regenerate-semconv:
+    # Only run on Renovate PRs
+    if: startsWith(github.head_ref, 'renovate/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+          working-directory: semantic_conventions
+
+      - name: Check if SPEC_VERSION changed
+        id: check_changes
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          if git diff origin/${{ github.base_ref }} HEAD -- semantic_conventions/Rakefile | grep -q "SPEC_VERSION"; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Regenerate semantic conventions
+        if: steps.check_changes.outputs.changed == 'true'
+        working-directory: semantic_conventions
+        run: bundle exec rake generate
+
+      - name: Commit and push changes
+        if: steps.check_changes.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add semantic_conventions/
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: regenerate semantic conventions"
+            git push
+          fi


### PR DESCRIPTION
This is a new action using Renovate to help us update the Semantic Conventions gem when new versions are released:
* We use renovate to check to see if a new version has been released
* Then, we use a GHA workflow to run the rake task to make the update
* The GH version of renovate doesn't have access to Docker, so we leverage GHA's access to run weaver
* Renovate's original version change PR gets updated with the rest of the changes

~~We should release versions 1.38 and 1.39 before we merge this PR. It will run on only the latest version (which at this time is 1.40)~~

This PR now includes code that should allow renovate to open up PRs for older versions (ex. 1.38).