### PR TITLE
docs: fix exporter-otlp-logs gemspec metadata links

### DIFF
--- a/exporter/otlp-logs/opentelemetry-exporter-otlp-logs.gemspec
+++ b/exporter/otlp-logs/opentelemetry-exporter-otlp-logs.gemspec
@@ -50,9 +50,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 
   if spec.respond_to?(:metadata)
-    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-exporter-otlp/v#{OpenTelemetry::Exporter::OTLP::Logs::VERSION}/file.CHANGELOG.html"
-    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/main/exporter/otlp'
+    spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-exporter-otlp-logs/v#{OpenTelemetry::Exporter::OTLP::Logs::VERSION}/file.CHANGELOG.html"
+    spec.metadata['source_code_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/tree/main/exporter/otlp-logs'
     spec.metadata['bug_tracker_uri'] = 'https://github.com/open-telemetry/opentelemetry-ruby/issues'
-    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-exporter-otlp/v#{OpenTelemetry::Exporter::OTLP::Logs::VERSION}"
+    spec.metadata['documentation_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-exporter-otlp-logs/v#{OpenTelemetry::Exporter::OTLP::Logs::VERSION}"
   end
 end


### PR DESCRIPTION
Noticed the links on https://rubygems.org/gems/opentelemetry-exporter-otlp-logs not going where I expected to go.