### PR TITLE
chore: Bump toys-release to 0.8.2

### DIFF
--- a/.toys/release/Gemfile
+++ b/.toys/release/Gemfile
@@ -7,4 +7,4 @@
 source 'https://rubygems.org'
 
 gem 'toys', '= 0.20.0'
-gem 'toys-release', '= 0.8.1'
+gem 'toys-release', '0.8.2'


### PR DESCRIPTION
This should resolve our problem where the `SPEC_VERSION` constant matched before the `VERSION` constant in the `opentelemetry-semantic_conventions` gem.

[Related Slack Convo](https://cloud-native.slack.com/archives/C01NWKKMKMY/p1773867712364609?thread_ts=1773685939.548899&cid=C01NWKKMKMY)