### PR TITLE
chore: bump simplecov

### DIFF
--- a/propagator/b3/opentelemetry-propagator-b3.gemspec
+++ b/propagator/b3/opentelemetry-propagator-b3.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 13.3'
   spec.add_development_dependency 'rubocop', '~> 1.65'
-  spec.add_development_dependency 'simplecov', '~> 0.17.1'
+  spec.add_development_dependency 'simplecov', '~> 0.22.0'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 

--- a/propagator/jaeger/opentelemetry-propagator-jaeger.gemspec
+++ b/propagator/jaeger/opentelemetry-propagator-jaeger.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.2'
   spec.add_development_dependency 'rake', '~> 13.3'
   spec.add_development_dependency 'rubocop', '~> 1.65'
-  spec.add_development_dependency 'simplecov', '~> 0.17.1'
+  spec.add_development_dependency 'simplecov', '~> 0.22.0'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 

--- a/registry/opentelemetry-registry.gemspec
+++ b/registry/opentelemetry-registry.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.3'
   spec.add_development_dependency 'rspec-mocks'
   spec.add_development_dependency 'rubocop', '~> 1.65'
-  spec.add_development_dependency 'simplecov', '~> 0.17.1'
+  spec.add_development_dependency 'simplecov', '~> 0.22.0'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
 


### PR DESCRIPTION
This bumps simplecov to the same version as used elsewhere.

Note I have raised https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/2031 which would detect updates such as these in contrib but have them behind an approval gate.

This will hopefully also reduce our Fossa Warnings for this project.