### PR TITLE
chore: Update .cspell.yml

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -65,6 +65,7 @@ ignoreWords:
   - MILLIS
   - otcorrelations
   - Rubyish
+  - codegen
 words:
   - LOGRECORD
   - traceid


### PR DESCRIPTION
Add codegen to list of words cspell ignore's so release can proceed. Will look to add a spell checker lint  to catch the issues earlier. See https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/2123