### PR TITLE
chore: Add Xuan to approvers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,5 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @kaylareopelle
+* @fbogsany @mwear @robertlaurin @dazuma @ericmustin @arielvalentin @ahayworth @plantfansam @robbkidd @kaylareopelle @xuan-cao-swi
+

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ For more information about the maintainer role, see the [community repository](h
 - [Eric Mustin](https://github.com/ericmustin)
 - [Robb Kidd](https://github.com/robbkidd), Honeycomb
 - [Sam Handler](https://github.com/plantfansam), Shopify
+- [Xuan Cao](https://github.com/xuan-cao-swi), Solarwinds
 
 For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).
 


### PR DESCRIPTION
@xuan-cao-swi has made numerous valuable contributions to opentelemetry-ruby, especially in the realm of Metrics, and we'd like to promote him to approver. Here is a summary of his work:

- [PRs authored](https://github.com/open-telemetry/opentelemetry-ruby/pulls?q=author%3Axuan-cao-swi+is%3Apr)
- [PRs commented upon](https://github.com/open-telemetry/opentelemetry-ruby/issues?q=commenter%3Axuan-cao-swi++)
- [Issues opened](https://github.com/open-telemetry/opentelemetry-ruby/issues?q=is%3Aissue+author%3Axuan-cao-swi+)
- [Issues commented upon](https://github.com/open-telemetry/opentelemetry-ruby/issues?q=is%3Aissue+commenter%3Axuan-cao-swi+)