### PR TITLE
ci: pin all os images

### DIFF
--- a/.github/workflows/ci-example-dice-roller.yml
+++ b/.github/workflows/ci-example-dice-roller.yml
@@ -31,7 +31,7 @@ jobs:
   dice-roller:
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby' }}
     name: ${{ matrix.version }} / Ruby ${{ matrix.ruby }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -58,7 +58,7 @@ jobs:
   dice-roller-docker:
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby' }}
     name: Docker ${{ matrix.version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-markdown-link.yml
+++ b/.github/workflows/ci-markdown-link.yml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby' }}
     permissions:
       pull-requests: write # required for posting review comments
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/ci-markdownlint.yml
+++ b/.github/workflows/ci-markdownlint.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   markdownlint-check:
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,9 @@ jobs:
           - opentelemetry-semantic_conventions
           - opentelemetry-test-helpers
         os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+          - ubuntu-24.04
+          - macos-15
+          - windows-2025
     name: ${{ matrix.gem }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -56,13 +56,13 @@ jobs:
           rubocop: true
           build: true
       - name: "Test JRuby"
-        if: "${{ matrix.os == 'ubuntu-latest' }}"
+        if: startsWith(matrix.os, 'ubuntu')
         uses: ./.github/actions/test_gem
         with:
           gem: "${{ matrix.gem }}"
           ruby: "jruby"
       - name: "Test truffleruby"
-        if: "${{ matrix.os == 'ubuntu-latest' }}"
+        if: startsWith(matrix.os, 'ubuntu')
         uses: ./.github/actions/test_gem
         with:
           gem: "${{ matrix.gem }}"
@@ -82,12 +82,12 @@ jobs:
           - opentelemetry-exporter-otlp-logs
           - opentelemetry-exporter-otlp-metrics
         os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+          - ubuntu-24.04
+          - macos-15
+          - windows-2025
         exclude:
          # Windows runs Ruby 3.4, which isn't compatible with this gem
-          - os: windows-latest
+          - os: windows-2025
             gem: opentelemetry-exporter-otlp-grpc
     name: ${{ matrix.gem }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -107,7 +107,7 @@ jobs:
           rubocop: true
           build: true
       - name: "Test Zipkin with JRuby"
-        if: "${{ matrix.os == 'ubuntu-latest' && matrix.gem == 'opentelemetry-exporter-zipkin' }}"
+        if: "${{ startsWith(matrix.os, 'ubuntu') && matrix.gem == 'opentelemetry-exporter-zipkin' }}"
         uses: ./.github/actions/test_gem
         with:
           gem: "${{ matrix.gem }}"
@@ -121,7 +121,7 @@ jobs:
           # This is essentially a bash script getting evaluated, so we need to return true or the whole job fails.
           true
       - name: "Test truffleruby"
-        if: "${{ matrix.os == 'ubuntu-latest' && steps.truffleruby_skip.outputs.skip == 'false' }}"
+        if: "${{ startsWith(matrix.os, 'ubuntu') && steps.truffleruby_skip.outputs.skip == 'false' }}"
         uses: ./.github/actions/test_gem
         with:
           gem: "${{ matrix.gem }}"
@@ -136,9 +136,9 @@ jobs:
           - opentelemetry-propagator-b3
           - opentelemetry-propagator-jaeger
         os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+          - ubuntu-24.04
+          - macos-15
+          - windows-2025
     name: ${{ matrix.gem }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -157,13 +157,13 @@ jobs:
           rubocop: true
           build: true
       - name: "Test JRuby"
-        if: "${{ matrix.os == 'ubuntu-latest' }}"
+        if: startsWith(matrix.os, 'ubuntu')
         uses: ./.github/actions/test_gem
         with:
           gem: "${{ matrix.gem }}"
           ruby: "jruby"
       - name: "Test truffleruby"
-        if: "${{ matrix.os == 'ubuntu-latest' }}"
+        if: startsWith(matrix.os, 'ubuntu')
         uses: ./.github/actions/test_gem
         with:
           gem: "${{ matrix.gem }}"
@@ -172,7 +172,7 @@ jobs:
   spelling-check:
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby' }}
     name: Spelling Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # v8.4.0

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -20,7 +20,7 @@ jobs:
   validate-commits:
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby' }}
     name: Conventional Commits Validation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: dev-build-deploy/commit-me@27d14296ec218488c543616d9128d7e75ab7463a # v1.5.3
         env:

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   fossa:
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -13,7 +13,7 @@ permissions: read-all
 jobs:
   analysis:
     if: ${{ github.repository == 'open-telemetry/opentelemetry-ruby' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       # Needed for Code scanning upload
       security-events: write

--- a/.github/workflows/release-hook-on-closed.yml
+++ b/.github/workflows/release-hook-on-closed.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write # required for creating releases
       pull-requests: write # required for updating label on PR, posting comments
       issues: write # required for creating new issues on failed releases
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/.toys/release/Gemfile
     steps:

--- a/.github/workflows/release-hook-on-push.yml
+++ b/.github/workflows/release-hook-on-push.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: write # required for pushing changes
       pull-requests: write # required for updating open release PRs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/.toys/release/Gemfile
     steps:

--- a/.github/workflows/release-perform.yml
+++ b/.github/workflows/release-perform.yml
@@ -24,7 +24,7 @@ jobs:
       contents: write # required for creating releases
       pull-requests: write # required for updating label on PR, posting comments
       issues: write # required for creating new issues on failed releases
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/.toys/release/Gemfile
     steps:

--- a/.github/workflows/release-request-weekly.yml
+++ b/.github/workflows/release-request-weekly.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write # required for pushing changes
       pull-requests: write # required for creating release PRs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/.toys/release/Gemfile
     steps:

--- a/.github/workflows/release-request.yml
+++ b/.github/workflows/release-request.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       contents: write # required for pushing changes
       pull-requests: write # required for creating release PRs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/.toys/release/Gemfile
     steps:

--- a/.github/workflows/release-retry.yml
+++ b/.github/workflows/release-retry.yml
@@ -21,7 +21,7 @@ jobs:
       contents: write # required for creating releases
       pull-requests: write # required for updating label on PR, posting comments
       issues: write # required for creating new issues on failed releases
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/.toys/release/Gemfile
     steps:

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       issues: write # required for managing stale issues
       pull-requests: write # required for managing stale PRs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0


### PR DESCRIPTION
This pins all os images rather than latest as we have renovate to update them. It also makes it explicit in which version we are testing against.