### PR TITLE
chore: cleanup usages of benchmark-ipsa

### DIFF
--- a/metrics_api/opentelemetry-metrics-api.gemspec
+++ b/metrics_api/opentelemetry-metrics-api.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
 
-  spec.add_development_dependency 'benchmark-ipsa', '~> 0.2.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-test-helpers', '~> 0.3.0'
   spec.add_development_dependency 'rake', '~> 13.3'

--- a/metrics_sdk/opentelemetry-metrics-sdk.gemspec
+++ b/metrics_sdk/opentelemetry-metrics-sdk.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-metrics-api', '~> 0.2'
   spec.add_dependency 'opentelemetry-sdk', '~> 1.2'
 
-  spec.add_development_dependency 'benchmark-ipsa', '~> 0.2.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rake', '~> 13.3'

--- a/sdk_experimental/opentelemetry-sdk-experimental.gemspec
+++ b/sdk_experimental/opentelemetry-sdk-experimental.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opentelemetry-api', '~> 1.1'
   spec.add_dependency 'opentelemetry-sdk', '~> 1.2'
 
-  spec.add_development_dependency 'benchmark-ipsa', '~> 0.2.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-test-helpers'
   spec.add_development_dependency 'rake', '~> 13.3'


### PR DESCRIPTION
This removes unused benchmark-ipsa dev depency.

Note it is used in the api gem.