### PR TITLE
chore: remove kramdown

### DIFF
--- a/semantic_conventions/.yardopts
+++ b/semantic_conventions/.yardopts
@@ -1,7 +1,6 @@
 --no-private
 --title=OpenTelemetry Semantic Conventions
 --markup=markdown
---markup-provider=kramdown
 --main=README.md
 ./lib/opentelemetry/**/*.rb
 -

--- a/semantic_conventions/opentelemetry-semantic_conventions.gemspec
+++ b/semantic_conventions/opentelemetry-semantic_conventions.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentelemetry-api', '~> 1.0'
 
-  spec.add_development_dependency 'kramdown', '~> 2.3'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 13.3'
   spec.add_development_dependency 'rubocop', '~> 1.65'


### PR DESCRIPTION
Remove kramdown from sem conv gem which appears not to be used.

Also The docs appear to not be published as link points to a url which lacks a link to sem-conv.