### PR TITLE
fix(metrics): return false if it is noop_exemplar_reservoir

### DIFF
--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/exemplar_reservoir.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/exemplar_reservoir.rb
@@ -32,6 +32,18 @@ module OpenTelemetry
           def collect(attributes: nil, aggregation_temporality: :delta)
             raise NotImplementedError, "#{self.class} must implement #collect"
           end
+
+          # Called after dup to reset internal state before reuse for a new attribute set.
+          # Subclasses that hold mutable per-attribute state must override this.
+          def reset; end
+
+          # Returns true if this reservoir never stores exemplars.
+          # Used to skip the exemplar filter and timestamp lookups entirely.
+          #
+          # @return [Boolean]
+          def noop?
+            false
+          end
         end
       end
     end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/noop_exemplar_reservoir.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/noop_exemplar_reservoir.rb
@@ -15,6 +15,10 @@ module OpenTelemetry
           def collect(attributes: nil, aggregation_temporality: :delta)
             []
           end
+
+          def noop?
+            true
+          end
         end
       end
     end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/state/metric_stream.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/state/metric_stream.rb
@@ -120,6 +120,8 @@ module OpenTelemetry
           end
 
           def should_offer_exemplar?(value, attributes)
+            return false if @exemplar_reservoir&.noop?
+
             context = OpenTelemetry::Context.current
             time = OpenTelemetry::Common::Utilities.time_in_nanoseconds
             @exemplar_filter&.should_sample?(value, time, attributes, context)


### PR DESCRIPTION
## Description
The reservoir operation remains active for noop_exemplar_reservoir, even though it doesn't store anything; however, it still slows down the operation.

