### PR TITLE
ci: (workflows & actions) interpolate into env vars

### DIFF
--- a/.github/actions/test_dice_roller/action.yml
+++ b/.github/actions/test_dice_roller/action.yml
@@ -24,13 +24,14 @@ runs:
       shell: bash
       working-directory: examples/dice_roller/${{ inputs.version }}
       env:
+        VERSION: ${{ inputs.version }}
         APPLICATION_PORT: "8080"
         OTEL_TRACES_EXPORTER: none
         OTEL_METRICS_EXPORTER: none
         OTEL_LOGS_EXPORTER: none
         OTEL_SERVICE_NAME: dice_roller_ci
       run: |
-        # 🎲 Start dice roller (${{ inputs.version }}) 🎲
+        # 🎲 Start dice roller ($VERSION) 🎲
         ruby app.rb &
         echo "APP_PID=$!" >> "$GITHUB_ENV"
         echo "Waiting for server to be ready..."

--- a/.github/actions/test_gem/action.yml
+++ b/.github/actions/test_gem/action.yml
@@ -31,9 +31,12 @@ runs:
     - name: Setup
       id: setup
       shell: bash
+      env:
+        GEM: ${{ inputs.gem }}
+        RUBY_VERSION: ${{ inputs.ruby }}
       run: |
         # 🛠️ Setup 🛠️
-        dir=$(find . -iname '${{ inputs.gem }}.gemspec' -exec dirname {} \;)
+        dir=$(find . -iname "${GEM}.gemspec" -exec dirname {} \;)
         echo "gem_dir=${dir}" >> $GITHUB_OUTPUT
 
         # We install multiple ruby versions here, and that makes for some
@@ -43,9 +46,9 @@ runs:
         rm -f "${dir}/Gemfile.lock"
 
         echo "cache_key=mri" >> $GITHUB_OUTPUT
-        if [[ "${{ inputs.ruby }}" == "jruby" ]]; then
+        if [[ "$RUBY_VERSION" == "jruby" ]]; then
           echo "cache_key=jruby" >> $GITHUB_OUTPUT
-        elif [[ "${{ inputs.ruby }}" == "truffleruby" ]]; then
+        elif [[ "$RUBY_VERSION" == "truffleruby" ]]; then
           echo "cache_key=truffleruby" >> $GITHUB_OUTPUT
         fi
 
@@ -119,7 +122,9 @@ runs:
     - name: Build Gem
       shell: bash
       if: "${{ inputs.build == 'true' }}"
+      env:
+        GEM: ${{ inputs.gem }}
       run: |
         # 📦 Build Gem 📦
-        gem build ${{ inputs.gem }}.gemspec
+        gem build "${GEM}.gemspec"
       working-directory: "${{ steps.setup.outputs.gem_dir }}"

--- a/.github/workflows/release-perform.yml
+++ b/.github/workflows/release-perform.yml
@@ -39,9 +39,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+          RELEASE_FLAGS: ${{ github.event.inputs.flags }}
+          RELEASE_NAME: ${{ github.event.inputs.name }}
+          RELEASE_VERSION: ${{ github.event.inputs.version }}
         run: |
           bundle exec toys release perform --yes --verbose \
             "--release-ref=${{ github.sha }}" \
-            ${{ github.event.inputs.flags }} \
-            "${{ github.event.inputs.name }}" "${{ github.event.inputs.version }}" \
+            $RELEASE_FLAGS \
+            "$RELEASE_NAME" "$RELEASE_VERSION" \
             < /dev/null

--- a/.github/workflows/release-request.yml
+++ b/.github/workflows/release-request.yml
@@ -38,8 +38,10 @@ jobs:
         env:
           # Use an app token instead of GITHUB_TOKEN to trigger workflows
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          RELEASE_NAMES: ${{ github.event.inputs.names }}
+          TARGET_BRANCH: ${{ github.ref }}
         run: |
           bundle exec toys release request --yes --verbose \
-            "--target-branch=${{ github.ref }}" \
-            ${{ github.event.inputs.names }} \
+            "--target-branch=$TARGET_BRANCH" \
+            $RELEASE_NAMES \
             < /dev/null

--- a/.github/workflows/release-retry.yml
+++ b/.github/workflows/release-retry.yml
@@ -36,8 +36,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+          RELEASE_FLAGS: ${{ github.event.inputs.flags }}
+          RELEASE_PR: ${{ github.event.inputs.release_pr }}
         run: |
           bundle exec toys release retry --yes --verbose \
-            ${{ github.event.inputs.flags }} \
-            "${{ github.event.inputs.release_pr }}" \
+            $RELEASE_FLAGS \
+            "$RELEASE_PR" \
             < /dev/null


### PR DESCRIPTION
Move ${{ ... }} interpolations from 'run:' scripts to env vars to avoid shell injection shenanigans. YAML string handling works as hoped for the variables whose values are strings with spaces in them, like flags and named-things-to-be-released.