### PR TITLE
fix(sdk): consistent labels for otel.bsp.dropped_spans metric

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/export/batch_span_processor.rb
@@ -206,7 +206,7 @@ module OpenTelemetry
           end
 
           def report_dropped_spans(dropped_spans, reason:, function: nil)
-            @metrics_reporter.add_to_counter('otel.bsp.dropped_spans', increment: dropped_spans.size, labels: { 'reason' => reason, OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION => function }.compact)
+            @metrics_reporter.add_to_counter('otel.bsp.dropped_spans', increment: dropped_spans.size, labels: { 'reason' => reason, OpenTelemetry::SemanticConventions::Trace::CODE_FUNCTION => function })
           end
 
           def lock

--- a/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
@@ -387,6 +387,27 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
     end
   end
 
+  describe 'dropped spans metrics' do
+    let(:metrics_reporter) { TestMetricsReporter.new }
+
+    it 'reports consistent label keys' do
+      exporter = TestExporter.new(status_codes: [FAILURE])
+      bsp = BatchSpanProcessor.new(exporter,
+                                   metrics_reporter: metrics_reporter,
+                                   max_queue_size: 1,
+                                   max_export_batch_size: 1)
+
+      bsp.on_finish(TestSpan.new('dropped-because-buffer-full'))
+      bsp.on_finish(TestSpan.new('causes-export-failure'))
+      bsp.shutdown # triggers export failure, no function associated
+
+      dropped = metrics_reporter.reported_metrics['otel.bsp.dropped_spans']
+      _(dropped).wont_be_nil
+      dropped_buffer_full_label_names, dropped_export_failure_label_names = dropped.map { |_count, labels| labels.keys.sort }
+      _(dropped_buffer_full_label_names).must_equal(dropped_export_failure_label_names)
+    end
+  end
+
   describe 'fork safety test' do
     let(:exporter) { TestExporter.new }
     let(:bsp) do


### PR DESCRIPTION
Fixes #2040 

`report_dropped_spans()` is used in several of places and not all of them include a `function` name in the call. The `.compact` on the labels hash within `report_dropped_spans()` was removing `nil`s. This produces inconsistent label sets for the `'otel.bsp.dropped_spans'` metric. And that makes metrics reporters like prometheus-client unhappy because they require a stable set of label names.

This change leaves how to handle `nil`-value labels to concrete implementations of `MetricsReporter` instead.