### PR TITLE
chore: simplify yard rake task

### DIFF
--- a/api/Rakefile
+++ b/api/Rakefile
@@ -10,15 +10,12 @@ require 'yard'
 
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
+YARD::Rake::YardocTask.new
 
 Rake::TestTask.new :test do |t|
   t.libs << 'test'
   t.libs << 'lib'
   t.test_files = FileList['test/**/*_test.rb']
-end
-
-YARD::Rake::YardocTask.new do |t|
-  t.stats_options = ['--list-undoc']
 end
 
 default_tasks =

--- a/common/Rakefile
+++ b/common/Rakefile
@@ -10,16 +10,13 @@ require 'yard'
 require 'rubocop/rake_task'
 
 RuboCop::RakeTask.new
+YARD::Rake::YardocTask.new
 
 Rake::TestTask.new :test do |t|
   t.libs << '../api/lib'
   t.libs << 'test'
   t.libs << 'lib'
   t.test_files = FileList['test/**/*_test.rb']
-end
-
-YARD::Rake::YardocTask.new do |t|
-  t.stats_options = ['--list-undoc']
 end
 
 default_tasks =

--- a/contrib/rubocop.yml
+++ b/contrib/rubocop.yml
@@ -29,6 +29,16 @@ Metrics/MethodLength:
 Metrics/ParameterLists:
   Enabled: false
 
+Style/Documentation:
+  Exclude:
+    - "**/test/**/*"
+    - "**/*test*"
+Style/DocumentationMethod:
+  Enabled: true
+  Severity: info
+  Exclude:
+    - "**/test/**/*"
+    - "**/*test*"
 Style/ModuleFunction:
   Enabled: false
 Style/NumericPredicate:

--- a/exporter/jaeger/Rakefile
+++ b/exporter/jaeger/Rakefile
@@ -10,6 +10,7 @@ require 'yard'
 
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
+YARD::Rake::YardocTask.new
 
 Rake::TestTask.new :test do |t|
   t.libs << 'test'
@@ -17,10 +18,6 @@ Rake::TestTask.new :test do |t|
   t.libs << '../../api/lib'
   t.libs << '../../sdk/lib'
   t.test_files = FileList['test/**/*_test.rb']
-end
-
-YARD::Rake::YardocTask.new do |t|
-  t.stats_options = ['--list-undoc']
 end
 
 default_tasks =

--- a/exporter/otlp-common/Rakefile
+++ b/exporter/otlp-common/Rakefile
@@ -10,6 +10,7 @@ require 'yard'
 
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
+YARD::Rake::YardocTask.new
 
 Rake::TestTask.new :test do |t|
   t.libs << 'test'
@@ -17,10 +18,6 @@ Rake::TestTask.new :test do |t|
   t.libs << '../../api/lib'
   t.libs << '../../sdk/lib'
   t.test_files = FileList['test/**/*_test.rb']
-end
-
-YARD::Rake::YardocTask.new do |t|
-  t.stats_options = ['--list-undoc']
 end
 
 default_tasks =

--- a/exporter/otlp-grpc/Rakefile
+++ b/exporter/otlp-grpc/Rakefile
@@ -10,6 +10,7 @@ require 'yard'
 
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
+YARD::Rake::YardocTask.new
 
 Rake::TestTask.new :test do |t|
   t.libs << 'test'
@@ -17,10 +18,6 @@ Rake::TestTask.new :test do |t|
   t.libs << '../../api/lib'
   t.libs << '../../sdk/lib'
   t.test_files = FileList['test/**/*_test.rb']
-end
-
-YARD::Rake::YardocTask.new do |t|
-  t.stats_options = ['--list-undoc']
 end
 
 default_tasks =

--- a/exporter/otlp-http/Rakefile
+++ b/exporter/otlp-http/Rakefile
@@ -10,6 +10,7 @@ require 'yard'
 
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
+YARD::Rake::YardocTask.new
 
 Rake::TestTask.new :test do |t|
   t.libs << 'test'
@@ -17,10 +18,6 @@ Rake::TestTask.new :test do |t|
   t.libs << '../../api/lib'
   t.libs << '../../sdk/lib'
   t.test_files = FileList['test/**/*_test.rb']
-end
-
-YARD::Rake::YardocTask.new do |t|
-  t.stats_options = ['--list-undoc']
 end
 
 default_tasks =

--- a/exporter/otlp-logs/Rakefile
+++ b/exporter/otlp-logs/Rakefile
@@ -10,6 +10,7 @@ require 'yard'
 
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
+YARD::Rake::YardocTask.new
 
 Rake::TestTask.new :test do |t|
   t.libs << 'test'
@@ -17,10 +18,6 @@ Rake::TestTask.new :test do |t|
   t.libs << '../../api/lib'
   t.libs << '../../sdk/lib'
   t.test_files = FileList['test/**/*_test.rb']
-end
-
-YARD::Rake::YardocTask.new do |t|
-  t.stats_options = ['--list-undoc']
 end
 
 default_tasks =

--- a/exporter/otlp-metrics/Rakefile
+++ b/exporter/otlp-metrics/Rakefile
@@ -10,6 +10,7 @@ require 'yard'
 
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
+YARD::Rake::YardocTask.new
 
 Rake::TestTask.new :test do |t|
   t.libs << 'test'
@@ -17,10 +18,6 @@ Rake::TestTask.new :test do |t|
   t.libs << '../../api/lib'
   t.libs << '../../sdk/lib'
   t.test_files = FileList['test/**/*_test.rb']
-end
-
-YARD::Rake::YardocTask.new do |t|
-  t.stats_options = ['--list-undoc']
 end
 
 default_tasks =

--- a/exporter/otlp/Rakefile
+++ b/exporter/otlp/Rakefile
@@ -10,6 +10,7 @@ require 'yard'
 
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
+YARD::Rake::YardocTask.new
 
 Rake::TestTask.new :test do |t|
   t.libs << 'test'
@@ -17,10 +18,6 @@ Rake::TestTask.new :test do |t|
   t.libs << '../../api/lib'
   t.libs << '../../sdk/lib'
   t.test_files = FileList['test/**/*_test.rb']
-end
-
-YARD::Rake::YardocTask.new do |t|
-  t.stats_options = ['--list-undoc']
 end
 
 default_tasks =

--- a/exporter/zipkin/Rakefile
+++ b/exporter/zipkin/Rakefile
@@ -10,6 +10,7 @@ require 'yard'
 
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
+YARD::Rake::YardocTask.new
 
 Rake::TestTask.new :test do |t|
   t.libs << 'test'
@@ -17,10 +18,6 @@ Rake::TestTask.new :test do |t|
   t.libs << '../../api/lib'
   t.libs << '../../sdk/lib'
   t.test_files = FileList['test/**/*_test.rb']
-end
-
-YARD::Rake::YardocTask.new do |t|
-  t.stats_options = ['--list-undoc']
 end
 
 default_tasks =

--- a/logs_api/Rakefile
+++ b/logs_api/Rakefile
@@ -10,15 +10,12 @@ require 'yard'
 
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
+YARD::Rake::YardocTask.new
 
 Rake::TestTask.new :test do |t|
   t.libs << 'test'
   t.libs << 'lib'
   t.test_files = FileList['test/**/*_test.rb']
-end
-
-YARD::Rake::YardocTask.new do |t|
-  t.stats_options = ['--list-undoc']
 end
 
 default_tasks =

--- a/logs_sdk/Rakefile
+++ b/logs_sdk/Rakefile
@@ -10,15 +10,12 @@ require 'yard'
 
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
+YARD::Rake::YardocTask.new
 
 Rake::TestTask.new :test do |t|
   t.libs << 'test'
   t.libs << 'lib'
   t.test_files = FileList['test/**/*_test.rb']
-end
-
-YARD::Rake::YardocTask.new do |t|
-  t.stats_options = ['--list-undoc']
 end
 
 default_tasks =

--- a/metrics_api/Rakefile
+++ b/metrics_api/Rakefile
@@ -10,15 +10,12 @@ require 'yard'
 
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
+YARD::Rake::YardocTask.new
 
 Rake::TestTask.new :test do |t|
   t.libs << 'test'
   t.libs << 'lib'
   t.test_files = FileList['test/**/*_test.rb']
-end
-
-YARD::Rake::YardocTask.new do |t|
-  t.stats_options = ['--list-undoc']
 end
 
 default_tasks =

--- a/metrics_sdk/Rakefile
+++ b/metrics_sdk/Rakefile
@@ -10,15 +10,12 @@ require 'yard'
 
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
+YARD::Rake::YardocTask.new
 
 Rake::TestTask.new :test do |t|
   t.libs << 'test'
   t.libs << 'lib'
   t.test_files = FileList['test/**/*_test.rb']
-end
-
-YARD::Rake::YardocTask.new do |t|
-  t.stats_options = ['--list-undoc']
 end
 
 default_tasks =

--- a/propagator/b3/Rakefile
+++ b/propagator/b3/Rakefile
@@ -10,15 +10,12 @@ require 'yard'
 require 'rubocop/rake_task'
 
 RuboCop::RakeTask.new
+YARD::Rake::YardocTask.new
 
 Rake::TestTask.new :test do |t|
   t.libs << 'test'
   t.libs << 'lib'
   t.test_files = FileList['test/**/*_test.rb']
-end
-
-YARD::Rake::YardocTask.new do |t|
-  t.stats_options = ['--list-undoc']
 end
 
 default_tasks =

--- a/propagator/jaeger/Rakefile
+++ b/propagator/jaeger/Rakefile
@@ -10,15 +10,12 @@ require 'yard'
 require 'rubocop/rake_task'
 
 RuboCop::RakeTask.new
+YARD::Rake::YardocTask.new
 
 Rake::TestTask.new :test do |t|
   t.libs << 'test'
   t.libs << 'lib'
   t.test_files = FileList['test/**/*_test.rb']
-end
-
-YARD::Rake::YardocTask.new do |t|
-  t.stats_options = ['--list-undoc']
 end
 
 default_tasks =

--- a/registry/Rakefile
+++ b/registry/Rakefile
@@ -10,15 +10,12 @@ require 'yard'
 require 'rubocop/rake_task'
 
 RuboCop::RakeTask.new
+YARD::Rake::YardocTask.new
 
 Rake::TestTask.new :test do |t|
   t.libs << 'test'
   t.libs << 'lib'
   t.test_files = FileList['test/**/*_test.rb']
-end
-
-YARD::Rake::YardocTask.new do |t|
-  t.stats_options = ['--list-undoc']
 end
 
 default_tasks =

--- a/sdk/Rakefile
+++ b/sdk/Rakefile
@@ -10,16 +10,13 @@ require 'yard'
 
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
+YARD::Rake::YardocTask.new
 
 Rake::TestTask.new :test do |t|
   t.libs << 'test'
   t.libs << 'lib'
   t.libs << '../api/lib'
   t.test_files = FileList['test/**/*_test.rb']
-end
-
-YARD::Rake::YardocTask.new do |t|
-  t.stats_options = ['--list-undoc']
 end
 
 default_tasks =

--- a/sdk_experimental/Rakefile
+++ b/sdk_experimental/Rakefile
@@ -10,15 +10,12 @@ require 'yard'
 
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
+YARD::Rake::YardocTask.new
 
 Rake::TestTask.new :test do |t|
   t.libs << 'test'
   t.libs << 'lib'
   t.test_files = FileList['test/**/*_test.rb']
-end
-
-YARD::Rake::YardocTask.new do |t|
-  t.stats_options = ['--list-undoc']
 end
 
 default_tasks =

--- a/semantic_conventions/Rakefile
+++ b/semantic_conventions/Rakefile
@@ -26,16 +26,13 @@ require 'tmpdir'
 require 'pathname'
 
 RuboCop::RakeTask.new
+YARD::Rake::YardocTask.new
 
 Rake::TestTask.new :test do |t|
   t.libs << '../api/lib'
   t.libs << 'test'
   t.libs << 'lib'
   t.test_files = FileList['test/**/*_test.rb']
-end
-
-YARD::Rake::YardocTask.new do |t|
-  t.stats_options = ['--list-undoc']
 end
 
 default_tasks =

--- a/test_helpers/Rakefile
+++ b/test_helpers/Rakefile
@@ -10,16 +10,13 @@ require 'yard'
 
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
+YARD::Rake::YardocTask.new
 
 Rake::TestTask.new :test do |t|
   t.libs << 'test'
   t.libs << 'lib'
   t.libs << '../api/lib'
   t.test_files = FileList['test/**/*_test.rb']
-end
-
-YARD::Rake::YardocTask.new do |t|
-  t.stats_options = ['--list-undoc']
 end
 
 default_tasks =


### PR DESCRIPTION
This ensures yardopts is the authorities source of yard options as done in contrib https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/2292.

Further rubocop is analyzing method documentation coverage.