### PR TITLE
chore: remove pry

### DIFF
--- a/common/test/test_helper.rb
+++ b/common/test/test_helper.rb
@@ -12,4 +12,3 @@ end
 require 'opentelemetry-test-helpers'
 require 'opentelemetry/common'
 require 'minitest/autorun'
-require 'pry'

--- a/exporter/otlp-common/opentelemetry-exporter-otlp-common.gemspec
+++ b/exporter/otlp-common/opentelemetry-exporter-otlp-common.gemspec
@@ -32,8 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk', '~> 1.2'
   spec.add_development_dependency 'opentelemetry-test-helpers'
-  spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
   spec.add_development_dependency 'rake', '~> 13.3'
   spec.add_development_dependency 'rubocop', '~> 1.65'
   spec.add_development_dependency 'simplecov', '~> 0.17'

--- a/exporter/otlp-common/test/test_helper.rb
+++ b/exporter/otlp-common/test/test_helper.rb
@@ -16,6 +16,4 @@ require 'opentelemetry-exporter-otlp-common'
 require 'minitest/autorun'
 require 'webmock/minitest'
 
-require 'pry'
-
 OpenTelemetry.logger = Logger.new(File::NULL)

--- a/exporter/otlp-grpc/opentelemetry-exporter-otlp-grpc.gemspec
+++ b/exporter/otlp-grpc/opentelemetry-exporter-otlp-grpc.gemspec
@@ -33,7 +33,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-test-helpers'
-  spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
   spec.add_development_dependency 'rake', '~> 13.3'
   spec.add_development_dependency 'rubocop', '~> 1.65'
   spec.add_development_dependency 'simplecov', '~> 0.17'

--- a/exporter/otlp-grpc/test/test_helper.rb
+++ b/exporter/otlp-grpc/test/test_helper.rb
@@ -9,8 +9,6 @@ if RUBY_ENGINE == 'ruby'
   SimpleCov.start
 end
 
-require 'pry'
-
 require 'opentelemetry-test-helpers'
 require 'opentelemetry/exporter/otlp/grpc'
 require 'minitest/autorun'

--- a/exporter/otlp-http/opentelemetry-exporter-otlp-http.gemspec
+++ b/exporter/otlp-http/opentelemetry-exporter-otlp-http.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-test-helpers'
-  spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
   spec.add_development_dependency 'rake', '~> 13.3'
   spec.add_development_dependency 'rubocop', '~> 1.65'
   spec.add_development_dependency 'simplecov', '~> 0.17'

--- a/exporter/otlp-logs/opentelemetry-exporter-otlp-logs.gemspec
+++ b/exporter/otlp-logs/opentelemetry-exporter-otlp-logs.gemspec
@@ -37,7 +37,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-test-helpers'
-  spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
   spec.add_development_dependency 'rake', '~> 13.3'
   spec.add_development_dependency 'rubocop', '~> 1.3'
   spec.add_development_dependency 'rubocop-minitest', '~> 0.38.0'

--- a/exporter/otlp-metrics/opentelemetry-exporter-otlp-metrics.gemspec
+++ b/exporter/otlp-metrics/opentelemetry-exporter-otlp-metrics.gemspec
@@ -37,7 +37,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-test-helpers'
-  spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
   spec.add_development_dependency 'rake', '~> 13.3'
   spec.add_development_dependency 'rubocop', '~> 1.65'
   spec.add_development_dependency 'rubocop-minitest', '~> 0.38.0'

--- a/exporter/otlp/opentelemetry-exporter-otlp.gemspec
+++ b/exporter/otlp/opentelemetry-exporter-otlp.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'appraisal', '~> 2.2.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-test-helpers'
-  spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
   spec.add_development_dependency 'rake', '~> 13.3'
   spec.add_development_dependency 'rubocop', '~> 1.65'
   spec.add_development_dependency 'rubocop-minitest', '~> 0.38.0'

--- a/metrics_api/Gemfile
+++ b/metrics_api/Gemfile
@@ -13,6 +13,4 @@ eval_gemfile '../contrib/Gemfile.shared'
 group :test, :development do
   gem 'opentelemetry-api', path: '../api', require: false
   gem 'opentelemetry-metrics-sdk', path: '../metrics_sdk', require: false
-  gem 'pry'
-  gem 'pry-byebug' unless RUBY_ENGINE == 'jruby'
 end

--- a/metrics_api/test/test_helper.rb
+++ b/metrics_api/test/test_helper.rb
@@ -11,6 +11,5 @@
 require 'opentelemetry-test-helpers'
 require 'opentelemetry-metrics-api'
 require 'minitest/autorun'
-require 'pry'
 
 OpenTelemetry.logger = Logger.new(File::NULL)

--- a/metrics_sdk/Gemfile
+++ b/metrics_sdk/Gemfile
@@ -18,6 +18,4 @@ group :test, :development do
   gem 'opentelemetry-registry', path: '../registry', require: false
   gem 'opentelemetry-sdk', path: '../sdk', require: false
   gem 'opentelemetry-test-helpers', path: '../test_helpers', require: false
-  gem 'pry'
-  gem 'pry-byebug' unless RUBY_ENGINE == 'jruby'
 end

--- a/metrics_sdk/test/test_helper.rb
+++ b/metrics_sdk/test/test_helper.rb
@@ -11,7 +11,6 @@
 require 'opentelemetry-metrics-sdk'
 require 'opentelemetry-test-helpers'
 require 'minitest/autorun'
-require 'pry'
 
 # reset_metrics_sdk is a test helper used to clear
 # SDK configuration state between calls

--- a/sdk/opentelemetry-sdk.gemspec
+++ b/sdk/opentelemetry-sdk.gemspec
@@ -40,14 +40,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'opentelemetry-exporter-zipkin', '~> 0.19'
   spec.add_development_dependency 'opentelemetry-instrumentation-base', '~> 0.20'
   spec.add_development_dependency 'opentelemetry-test-helpers'
-  spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake', '~> 13.3'
   spec.add_development_dependency 'rubocop', '~> 1.65'
   spec.add_development_dependency 'simplecov', '~> 0.17'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yard-doctest', '~> 0.1.6'
-
-  spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
 
   if spec.respond_to?(:metadata)
     spec.metadata['changelog_uri'] = "https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-sdk/v#{OpenTelemetry::SDK::VERSION}/file.CHANGELOG.html"

--- a/sdk/test/test_helper.rb
+++ b/sdk/test/test_helper.rb
@@ -14,7 +14,6 @@ require 'opentelemetry-test-helpers'
 require 'opentelemetry-sdk'
 require 'opentelemetry-instrumentation-base'
 require 'minitest/autorun'
-require 'pry'
 
 OpenTelemetry.logger = Logger.new(File::NULL)
 

--- a/sdk_experimental/Gemfile
+++ b/sdk_experimental/Gemfile
@@ -16,6 +16,4 @@ group :test, :development do
   gem 'opentelemetry-registry', path: '../registry', require: false
   gem 'opentelemetry-sdk', path: '../sdk', require: false
   gem 'opentelemetry-test-helpers', path: '../test_helpers', require: false
-  gem 'pry'
-  gem 'pry-byebug' unless RUBY_ENGINE == 'jruby'
 end

--- a/sdk_experimental/test/test_helper.rb
+++ b/sdk_experimental/test/test_helper.rb
@@ -11,7 +11,6 @@
 require 'opentelemetry-sdk-experimental'
 require 'opentelemetry-test-helpers'
 require 'minitest/autorun'
-require 'pry'
 
 def call_sampler(sampler, trace_id: nil, parent_context: OpenTelemetry::Context.current, links: nil, name: nil, kind: nil, attributes: nil)
   sampler.should_sample?(

--- a/semantic_conventions/Gemfile
+++ b/semantic_conventions/Gemfile
@@ -13,5 +13,4 @@ eval_gemfile '../contrib/Gemfile.shared'
 group :development, :test do
   gem 'mutex_m' if RUBY_VERSION >= '3.4'
   gem 'opentelemetry-api', path: '../api', require: false
-  gem 'pry'
 end

--- a/semantic_conventions/test/test_helper.rb
+++ b/semantic_conventions/test/test_helper.rb
@@ -11,6 +11,5 @@ if RUBY_ENGINE == 'ruby'
 end
 
 require 'minitest/autorun'
-require 'pry'
 
 Dir[File.join(File.dirname(__FILE__), '..', 'lib', 'opentelemetry', '**', '*.rb')].each { |file| require file }

--- a/test_helpers/opentelemetry-test-helpers.gemspec
+++ b/test_helpers/opentelemetry-test-helpers.gemspec
@@ -27,8 +27,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'opentelemetry-sdk'
-  spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'pry-byebug' unless RUBY_ENGINE == 'jruby'
   spec.add_development_dependency 'rake', '~> 13.3'
   spec.add_development_dependency 'rubocop', '~> 1.65'
   spec.add_development_dependency 'simplecov', '~> 0.17'

--- a/test_helpers/test/test_helper.rb
+++ b/test_helpers/test/test_helper.rb
@@ -7,7 +7,6 @@
 require 'opentelemetry-sdk'
 require 'opentelemetry-test-helpers'
 require 'minitest/autorun'
-require 'pry'
 
 if RUBY_ENGINE == 'ruby'
   require 'simplecov'


### PR DESCRIPTION
This removes pry & pry-byebug as a dev dependency. These dependencies has not been consistently used across the repo.

This has been raised in slack and suggestion was to remove