### PR TITLE
chore: Fix Ruby version format in fossa.yml

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Ruby
         uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
-          ruby-version: 4.0
+          ruby-version: "4.0"
       - name: Generate Gemfile.lock
         run: |
           echo "Finding all Gemfiles in the project..."


### PR DESCRIPTION
Currently renovate is having trouble updating the ruby version, looking at what is updating and that this instance is being misidentified as 4 not 4.0. I think this is the cause. This is backed up by contrib having no issue updating from 4.0 to 4.0.3 when it was quoted.