### PR TITLE
chore: Update docker user mapping for weaver

### DIFF
--- a/semantic_conventions/Rakefile
+++ b/semantic_conventions/Rakefile
@@ -85,6 +85,7 @@ task generate_semconv: %i[check_out_semconv_version clean_generated_code] do
   puts "\n+++ Generating semantic conventions code.\n"
   sh <<~DOCKER_COMMAND
     docker run --rm \
+      -u $(id -u ${USER}):$(id -g ${USER}) \
       -v "#{semconv_source_dir}/model":/source \
       -v ./templates:/templates \
       -v ./:/output \


### PR DESCRIPTION
When we tried to use renovate to update the semantic conventions gem we encountered the following error:

```
  × Writing of the generated code /output/./lib/opentelemetry/semconv/
  │ aspnetcore/metrics.rb failed: Permission denied (os error 13)
```

This is because the Docker runner's user is different from the user in the weaver process.

Weaver has a [docker guide](https://github.com/open-telemetry/weaver/blob/main/docs/docker-guide.md) that recommends setting the user to:
`$(id -u ${USER}):$(id -g ${USER})`
  
See failure: https://github.com/open-telemetry/opentelemetry-ruby/actions/runs/25760086248/job/75658668044?pr=2136 

There are a few other recommendations in the docker guide we can consider adopting if this doesn't solve the problem.