### PR TITLE
ci: Change pull_request to pull_request_target for semconv generation

### DIFF
--- a/.github/workflows/renovate-semconv.yml
+++ b/.github/workflows/renovate-semconv.yml
@@ -1,7 +1,8 @@
 name: Renovate Semantic Conventions Post-Update
 
 on:
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize, edited]
     paths:
       - 'semantic_conventions/Rakefile'
     branches:


### PR DESCRIPTION
This will hopefully ensure that the renovate semconv pr's undergo ci checks after the second commit which is the content generation.