### PR TITLE
ci: Allow bots to add to renovate pr

### DIFF
--- a/.cspell.yml
+++ b/.cspell.yml
@@ -68,6 +68,8 @@ ignoreWords:
   - rolldice
   - codegen
   - Dockerfiles
+  - opentelemetrybot
+  - otelbot
 words:
   - autocorrection
   - bigdecimal

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,6 +7,9 @@
   ],
   gitIgnoredAuthors: [
     "107717825+opentelemetrybot@users.noreply.github.com",
+    "107717825+opentelemetrybot[bot]@users.noreply.github.com",
+    "197425009+otelbot@users.noreply.github.com",
+    "197425009+otelbot[bot]@users.noreply.github.com",
     "github-actions[bot]@users.noreply.github.com"
   ],
   prConcurrentLimit: 12,

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,7 +5,7 @@
     "helpers:pinGitHubActionDigestsToSemver",
     ":separateMultipleMajorReleases",
   ],
-  gitignoredauthors: [
+  gitIgnoredAuthors: [
     "107717825+opentelemetrybot@users.noreply.github.com",
     "github-actions[bot]@users.noreply.github.com"
   ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,6 +5,10 @@
     "helpers:pinGitHubActionDigestsToSemver",
     ":separateMultipleMajorReleases",
   ],
+  gitignoredauthors: [
+    "107717825+opentelemetrybot@users.noreply.github.com",
+    "github-actions[bot]@users.noreply.github.com"
+  ],
   prConcurrentLimit: 12,
   prHourlyLimit: 12,
   packageRules: [


### PR DESCRIPTION
This allows bots ie gh-action & otelbot to commit on renovate pr's as their changes will be regerated.

This setting is documented at https://docs.renovatebot.com/configuration-options/#gitignoredauthors with email address sourced from github ui & Workflow config.