### PR TITLE
fix(api): apply baggage size and entry caps on extract

### DIFF
--- a/api/lib/opentelemetry/baggage/propagation/text_map_propagator.rb
+++ b/api/lib/opentelemetry/baggage/propagation/text_map_propagator.rb
@@ -54,18 +54,12 @@ module OpenTelemetry
         def extract(carrier, context: Context.current, getter: Context::Propagation.text_map_getter)
           header = getter.get(carrier, BAGGAGE_KEY)
           return context if header.nil? || header.empty?
+          return context if header.bytesize > MAX_TOTAL_LENGTH
 
           entries = header.gsub(/\s/, '').split(',')
 
           OpenTelemetry::Baggage.build(context: context) do |builder|
-            entries.each do |entry|
-              # Note metadata is currently unused in OpenTelemetry, but is part
-              # the W3C spec where it's referred to as properties. We preserve
-              # the properties (as-is) so that they can be propagated elsewhere.
-              kv, meta = entry.split(';', 2)
-              k, v = kv.split('=').map!(&URI.method(:decode_uri_component))
-              builder.set_value(k, v, metadata: meta)
-            end
+            decode_entries(entries, builder)
           end
         rescue StandardError => e
           OpenTelemetry.logger.debug "Error extracting W3C baggage: #{e.message}"
@@ -81,6 +75,22 @@ module OpenTelemetry
         end
 
         private
+
+        def decode_entries(entries, builder)
+          decoded_count = 0
+          entries.each do |entry|
+            break if decoded_count >= MAX_ENTRIES
+            next if entry.bytesize > MAX_ENTRY_LENGTH
+
+            # Note metadata is currently unused in OpenTelemetry, but is part
+            # the W3C spec where it's referred to as properties. We preserve
+            # the properties (as-is) so that they can be propagated elsewhere.
+            kv, meta = entry.split(';', 2)
+            k, v = kv.split('=').map!(&URI.method(:decode_uri_component))
+            builder.set_value(k, v, metadata: meta)
+            decoded_count += 1
+          end
+        end
 
         def encode(baggage)
           result = +''

--- a/api/test/opentelemetry/baggage/propagation/text_map_propagator_test.rb
+++ b/api/test/opentelemetry/baggage/propagation/text_map_propagator_test.rb
@@ -70,6 +70,41 @@ describe OpenTelemetry::Baggage::Propagation::TextMapPropagator do
         _(context.object_id).wont_equal(empty_context.object_id)
       end
     end
+
+    describe 'limits mirroring #inject' do
+      it 'returns the same context object when the header exceeds the total length of 8192 bytes' do
+        header = (['k=' + ('v' * 96)] * 100).join(',')
+        _(header.bytesize).must_be :>, 8192
+        carrier = { header_key => header }
+        empty_context = Context.empty
+        context = propagator.extract(carrier, context: empty_context)
+        _(context.object_id).must_equal(empty_context.object_id)
+      end
+
+      it 'enforces max of 180 entries on extract' do
+        header = (0..199).map { |i| "k#{i}=v#{i}" }.join(',')
+        carrier = { header_key => header }
+        context = propagator.extract(carrier, context: Context.empty)
+        entries = OpenTelemetry::Baggage.raw_entries(context: context)
+        _(entries.size).must_equal(180)
+        _(entries['k0']).wont_be_nil
+        _(entries['k179']).wont_be_nil
+        _(entries['k180']).must_be_nil
+        _(entries['k199']).must_be_nil
+      end
+
+      it 'skips entries whose size exceeds the max entry length of 4096 bytes' do
+        oversize_value = 'v' * 4096
+        header = "big=#{oversize_value},key2=val2"
+        _(header.bytesize).must_be :<=, 8192
+        carrier = { header_key => header }
+        context = propagator.extract(carrier, context: Context.empty)
+        entries = OpenTelemetry::Baggage.raw_entries(context: context)
+        _(entries['big']).must_be_nil
+        _(entries['key2']).wont_be_nil
+        _(entries['key2'].value).must_equal('val2')
+      end
+    end
   end
 
   describe '#inject' do


### PR DESCRIPTION
Fixes #2163.

## Summary

`OpenTelemetry::Baggage::Propagation::TextMapPropagator` declares three private constants for the W3C Baggage spec limits (`MAX_ENTRIES = 180`, `MAX_ENTRY_LENGTH = 4096`, `MAX_TOTAL_LENGTH = 8192`). The private `encode` helper used on inject applies all three, and dedicated tests exist for each one. The `extract` path does not consult any of them, so the inject and extract directions enforce different rules.

This PR hoists the existing inject-side policy into `extract` so the two paths share the same rule, mirroring what `opentelemetry-go`, `opentelemetry-dotnet`, `opentelemetry-cpp`, and recent `opentelemetry-java` already do on their inbound side.

## Changes

`api/lib/opentelemetry/baggage/propagation/text_map_propagator.rb`:

- `extract` returns the original context if the header byte size exceeds `MAX_TOTAL_LENGTH`.
- A new private `decode_entries` helper runs the loop:
  - `break` once `MAX_ENTRIES` entries have been decoded
  - `next` past any entry whose byte size exceeds `MAX_ENTRY_LENGTH`
- The loop body was factored into the helper to keep `extract` within the project's `Metrics/CyclomaticComplexity` and `Metrics/PerceivedComplexity` budgets.

`api/test/opentelemetry/baggage/propagation/text_map_propagator_test.rb`:

- A new `describe 'limits mirroring #inject'` block adds three tests that parallel the existing inject-side cap tests:
  - `returns the same context object when the header exceeds the total length of 8192 bytes`
  - `enforces max of 180 entries on extract`
  - `skips entries whose size exceeds the max entry length of 4096 bytes`

## Verification

```
$ cd api
$ bundle exec rake test
203 runs, 888 assertions, 0 failures, 0 errors, 0 skips

$ bundle exec rubocop lib/opentelemetry/baggage/propagation/text_map_propagator.rb \
                     test/opentelemetry/baggage/propagation/text_map_propagator_test.rb
2 files inspected, no offenses detected
```

## Notes

This change was originally submitted via the private advisory channel (`GHSA-g4r4-95p7-vp43`, now closed) and the project responded that it is not considered a security vulnerability but is worth fixing, and asked for a standard issue + PR. The framing here is consistency between inject and extract, not security.

The behavior change is conservative:
- A header within the spec limits is parsed exactly as before.
- A header exceeding `MAX_TOTAL_LENGTH` becomes a no-op (returns the original context, same as the existing `nil` / `empty?` short-circuit).
- An individual entry exceeding `MAX_ENTRY_LENGTH` is skipped while other entries continue to decode, matching what `encode` does on the inject side.
- Entries beyond `MAX_ENTRIES` stop being decoded, matching the existing inject-side behaviour.