### PR TITLE
ci: Automate instant semconv release

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -173,9 +173,13 @@
     {
       "customType": "regex",
       "description": "Update Semantic Conventions version in Rake files",
-      "managerFilePatterns": ["/^semantic_conventions/Rakefile$/"],
+      "managerFilePatterns": [
+        "/^semantic_conventions/Rakefile$/",
+        "/^semantic_conventions/semconv.yaml"$/"
+      ],
       "matchStrings": [
-        "SPEC_VERSION = '(?<currentValue>.*?)'"
+        "SPEC_VERSION = '(?<currentValue>.*?)'",
+        "spec_version: '(?<currentValue>.*?)'"
       ],
       "depNameTemplate": "open-telemetry/semantic-conventions",
       "datasourceTemplate": "github-releases",

--- a/.github/workflows/release-request.yml
+++ b/.github/workflows/release-request.yml
@@ -7,6 +7,11 @@ on:
         description: Components to release (leave blank to release all components)
         required: false
         default: ""
+  push:
+    branches:
+      - main
+    paths:
+      - "semantic_conventions/semconv.yaml"
 
 permissions:
   contents: read
@@ -34,11 +39,16 @@ jobs:
         with:
           client-id: ${{ vars.OTELBOT_RUBY_APP_ID }}
           private-key: ${{ secrets.OTELBOT_RUBY_PRIVATE_KEY }}
+      - name: Determine releases
+        id: detect
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          echo "components=opentelemetry-semantic_conventions" >> $GITHUB_OUTPUT
       - name: Open release pull request
         env:
           # Use an app token instead of GITHUB_TOKEN to trigger workflows
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          RELEASE_NAMES: ${{ github.event.inputs.names }}
+          RELEASE_NAMES: ${{ github.event.inputs.names || steps.detect.outputs.components }}
           TARGET_BRANCH: ${{ github.ref }}
         run: |
           bundle exec toys release request --yes --verbose \

--- a/semantic_conventions/semconv.yaml
+++ b/semantic_conventions/semconv.yaml
@@ -1,0 +1,1 @@
+spec_version: '1.40.0'

--- a/semantic_conventions/semconv.yaml
+++ b/semantic_conventions/semconv.yaml
@@ -1,1 +1,1 @@
-spec_version: '1.40.0'
+spec_version: '1.42.0'


### PR DESCRIPTION
This adds in an instant release pr when semconv spec version has been bumped.

this avoids potential scenarios where we have merged a new semconv version and then a new semconv version is released before our weekly pr has been merged.

note it could be a separate workflow but given it is almost purely additive the addition path was chosen to reduce maintenance effort going forward.