### PR TITLE
ci: Update keys in create-github-app-token

### DIFF
--- a/.github/workflows/release-request-weekly.yml
+++ b/.github/workflows/release-request-weekly.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ vars.OTELBOT_RUBY_APP_ID }}
+          client-id: ${{ vars.OTELBOT_RUBY_APP_ID }}
           private-key: ${{ secrets.OTELBOT_RUBY_PRIVATE_KEY }}
       - name: Open release pull request
         env:

--- a/.github/workflows/release-request.yml
+++ b/.github/workflows/release-request.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ vars.OTELBOT_RUBY_APP_ID }}
+          client-id: ${{ vars.OTELBOT_RUBY_APP_ID }}
           private-key: ${{ secrets.OTELBOT_RUBY_PRIVATE_KEY }}
       - name: Open release pull request
         env:


### PR DESCRIPTION
app-id is deprecated in favor of client-id

See warnings in this action: https://github.com/open-telemetry/opentelemetry-ruby/actions/runs/27310274449 