### PR TITLE
chore(deps): Upgrade dependency minitest to v6

### DIFF
--- a/exporter/otlp-grpc/Gemfile
+++ b/exporter/otlp-grpc/Gemfile
@@ -9,7 +9,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test, :development do
-  gem 'minitest', '~> 5.27.0'
+  gem 'minitest', '~> 6.0.0'
   gem 'rake', '~> 13.4.0'
   gem 'rubocop', '~> 1.87.0'
   gem 'rubocop-minitest', '~> 0.39.0'

--- a/logs_api/Gemfile
+++ b/logs_api/Gemfile
@@ -11,7 +11,7 @@ gemspec
 group :test, :development do
   gem 'benchmark-ips', '~> 2.15.0'
   gem 'logger', '~> 1.7.0' # should move to appraisals
-  gem 'minitest', '~> 5.27.0'
+  gem 'minitest', '~> 6.0.0'
   gem 'rake', '~> 13.4.0'
   gem 'rubocop', '~> 1.87.0'
   gem 'rubocop-minitest', '~> 0.39.0'

--- a/metrics_api/Gemfile
+++ b/metrics_api/Gemfile
@@ -10,7 +10,7 @@ gemspec
 
 group :test, :development do
   gem 'benchmark-ips', '~> 2.15.0'
-  gem 'minitest', '~> 5.27.0'
+  gem 'minitest', '~> 6.0.0'
   gem 'rake', '~> 13.4.0'
   gem 'rubocop', '~> 1.87.0'
   gem 'rubocop-minitest', '~> 0.39.0'

--- a/propagator/b3/Gemfile
+++ b/propagator/b3/Gemfile
@@ -9,7 +9,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test, :development do
-  gem 'minitest', '~> 5.27.0'
+  gem 'minitest', '~> 6.0.0'
   gem 'rake', '~> 13.4.0'
   gem 'rubocop', '~> 1.87.0'
   gem 'rubocop-minitest', '~> 0.39.0'

--- a/propagator/jaeger/Gemfile
+++ b/propagator/jaeger/Gemfile
@@ -9,7 +9,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test, :development do
-  gem 'minitest', '~> 5.27.0'
+  gem 'minitest', '~> 6.0.0'
   gem 'rake', '~> 13.4.0'
   gem 'rubocop', '~> 1.87.0'
   gem 'rubocop-minitest', '~> 0.39.0'

--- a/registry/Gemfile
+++ b/registry/Gemfile
@@ -10,7 +10,7 @@ gemspec
 
 group :test, :development do
   gem 'appraisal', '~> 2.5.0'
-  gem 'minitest', '~> 5.27.0'
+  gem 'minitest', '~> 6.0.0'
   gem 'rake', '~> 13.4.0'
   gem 'rspec-mocks', '~> 3.13.7'
   gem 'rubocop', '~> 1.87.0'

--- a/sdk_experimental/Gemfile
+++ b/sdk_experimental/Gemfile
@@ -9,7 +9,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test, :development do
-  gem 'minitest', '~> 5.27.0'
+  gem 'minitest', '~> 6.0.0'
   gem 'rake', '~> 13.4.0'
   gem 'rubocop', '~> 1.87.0'
   gem 'rubocop-minitest', '~> 0.39.0'

--- a/semantic_conventions/Gemfile
+++ b/semantic_conventions/Gemfile
@@ -9,7 +9,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
-  gem 'minitest', '~> 5.27.0'
+  gem 'minitest', '~> 6.0.0'
   gem 'mutex_m' if RUBY_VERSION >= '3.4'
   gem 'rake', '~> 13.4.0'
   gem 'rubocop', '~> 1.87.0'

--- a/test_helpers/Gemfile
+++ b/test_helpers/Gemfile
@@ -9,7 +9,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test, :development do
-  gem 'minitest', '~> 5.27.0'
+  gem 'minitest', '~> 6.0.0'
   gem 'rake', '~> 13.4.0'
   gem 'rubocop', '~> 1.87.0'
   gem 'rubocop-minitest', '~> 0.39.0'


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-ruby/pull/2180 for details.

This PR is a subset of #2180, scoped to the gems which can be updated without changes.

This reduces qty of gems out of date by ensuring they can be updated going forward and avoids the chance changes could be added which would block a v6 update.