### PR TITLE
chore: Violation fix for latest rubocop

### DIFF
--- a/api/lib/opentelemetry/baggage/propagation/text_map_propagator.rb
+++ b/api/lib/opentelemetry/baggage/propagation/text_map_propagator.rb
@@ -34,7 +34,7 @@ module OpenTelemetry
           return if baggage.nil? || baggage.empty?
 
           encoded_baggage = encode(baggage)
-          setter.set(carrier, BAGGAGE_KEY, encoded_baggage) unless encoded_baggage&.empty?
+          setter.set(carrier, BAGGAGE_KEY, encoded_baggage) if encoded_baggage && !encoded_baggage.empty?
           nil
         end
 


### PR DESCRIPTION
This addresses the new violation introduced in https://github.com/open-telemetry/opentelemetry-ruby/pull/2199