### PR TITLE
chore: docker housekeeping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.3.10-alpine3.21@sha256:e5eafee50c2e178c9fef8973be6180850518d1d60eed116dced53f4478369f42 as ruby
+FROM ruby:3.3.11-alpine3.23@sha256:ba98f4a71edbf747c93b18723f7d91547054d4e9b1337c6d6ab8ca877158f3e2 as ruby
 
 # Metadata
 LABEL maintainer="open-telemetry/opentelemetry-ruby"

--- a/examples/otel-collector/.env
+++ b/examples/otel-collector/.env
@@ -1,2 +1,1 @@
-OTELCOL_IMG=otel/opentelemetry-collector-contrib:0.109.0
 OTELCOL_ARGS=

--- a/examples/otel-collector/docker-compose.yaml
+++ b/examples/otel-collector/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
 
   # Jaeger
   jaeger-all-in-one:
-    image: jaegertracing/all-in-one:latest
+    image: jaegertracing/jaeger:2.19.0@sha256:ede4864215be4cd85bd8c3129a2fea6c5713c5653c7282c429dba123014bc68b
     ports:
       - "16686:16686"
       - "14268"
@@ -11,13 +11,13 @@ services:
 
   # Zipkin
   zipkin-all-in-one:
-    image: openzipkin/zipkin:latest
+    image: openzipkin/zipkin:3.6.1@sha256:d17e856dcbba7ffeefbbfc252f89ab78a4ab6faed47e646d46daad78f91b5ee2
     ports:
       - "9411:9411"
 
   # Collector
   otel-collector:
-    image: ${OTELCOL_IMG}
+    image: otel/opentelemetry-collector:0.154.0@sha256:ea527f0f9a220c7b595863a658c262f31d08c07e034a16b502bfb2206aa987ff
     command: ["--config=/etc/otel-collector-config.yaml", "${OTELCOL_ARGS}"]
     volumes:
       - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml


### PR DESCRIPTION
This sets an explicit docker image tag rather than latest. It also bumps to the latest version.