### PR TITLE
fix: Update attribute type conformance validations to be in line with current OpenTelemetry Semantic Conventions

### DIFF
--- a/sdk/lib/opentelemetry/sdk/internal.rb
+++ b/sdk/lib/opentelemetry/sdk/internal.rb
@@ -28,21 +28,31 @@ module OpenTelemetry
         value.instance_of?(String) || boolean?(value) || numeric?(value) || value.nil?
       end
 
-      def valid_array_value?(value)
-        return false unless value.is_a?(Array)
-
-        value.all? { |v| valid_value?(v) }
-      end
-
-      def valid_mapping_value?(value)
-        return false unless value.is_a?(Hash)
-        return false unless value.keys.all? { |k| valid_key?(k) }
-
-        value.values.all? { |v| valid_value?(v) }
-      end
-
       def valid_value?(value)
-        valid_simple_value?(value) || valid_array_value?(value) || valid_mapping_value?(value)
+        to_check = [value]
+        seen = Set.new
+        until to_check.empty?
+          current = to_check.pop
+          next if valid_simple_value?(current)
+
+          return false if seen.include?(current.object_id)
+
+          seen << current.object_id
+
+          case current
+          when Array
+            current.each { |v| to_check << v }
+          when Hash
+            current.each do |k, v|
+              return false unless valid_key?(k)
+
+              to_check << v
+            end
+          else
+            return false
+          end
+        end
+        true
       end
 
       def valid_attributes?(owner, kind, attrs)

--- a/sdk/lib/opentelemetry/sdk/internal.rb
+++ b/sdk/lib/opentelemetry/sdk/internal.rb
@@ -25,27 +25,24 @@ module OpenTelemetry
       end
 
       def valid_simple_value?(value)
-        value.instance_of?(String) || boolean?(value) || numeric?(value)
+        value.instance_of?(String) || boolean?(value) || numeric?(value) || value.nil?
       end
 
       def valid_array_value?(value)
         return false unless value.is_a?(Array)
-        return true if value.empty?
 
-        case value.first
-        when String
-          value.all? { |v| v.instance_of?(String) }
-        when TrueClass, FalseClass
-          value.all? { |v| boolean?(v) }
-        when Numeric
-          value.all? { |v| numeric?(v) }
-        else
-          false
-        end
+        value.all? { |v| valid_value?(v) }
+      end
+
+      def valid_mapping_value?(value)
+        return false unless value.is_a?(Hash)
+        return false unless value.keys.all? { |k| valid_key?(k) }
+
+        value.values.all? { |v| valid_value?(v) }
       end
 
       def valid_value?(value)
-        valid_simple_value?(value) || valid_array_value?(value)
+        valid_simple_value?(value) || valid_array_value?(value) || valid_mapping_value?(value)
       end
 
       def valid_attributes?(owner, kind, attrs)

--- a/sdk/test/opentelemetry/sdk/trace/span_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/span_test.rb
@@ -114,11 +114,11 @@ describe OpenTelemetry::SDK::Trace::Span do
       end
     end
 
-    it 'reports an error for a NilClass value, which is invalid' do
+    it 'does not report an error for a NilClass value, as empty values are valid' do
       OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
         span.set_attribute('foo', nil)
         span.finish
-        _(log_stream.string).must_match(/invalid span attribute value type NilClass for key 'foo' on span 'name'/)
+        _(log_stream.string.length).must_equal(0)
       end
     end
 
@@ -223,12 +223,12 @@ describe OpenTelemetry::SDK::Trace::Span do
       _(events.first.attributes).must_equal(attrs)
     end
 
-    it 'does not keep nil-valued attributes' do
+    it 'keeps nil-valued attributes' do
       attrs = { 'foo' => nil }
       span.add_event('added', attributes: attrs)
       events = span.events
       _(events.size).must_equal(1)
-      _(events.first.attributes).must_equal({})
+      _(events.first.attributes).must_equal({ 'foo' => nil })
     end
 
     it 'accepts array-valued attributes' do
@@ -247,12 +247,12 @@ describe OpenTelemetry::SDK::Trace::Span do
       _(events.first.attributes).must_equal({})
     end
 
-    it 'does not accept array-valued attributes if the elements are different types' do
+    it 'accepts array-valued attributes even if the elements are different types' do
       attrs = { 'foo' => [1, 2, 'bar'] }
       span.add_event('added', attributes: attrs)
       events = span.events
       _(events.size).must_equal(1)
-      _(events.first.attributes).must_equal({})
+      _(events.first.attributes).must_equal({ 'foo' => [1, 2, 'bar'] })
     end
 
     it 'accepts array-valued attributes if the elements are true and false' do


### PR DESCRIPTION
OpenTelemetry v1.51.0 introduced a wider definition of [AnyValue](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.51.0/specification/common/README.md). This PR aims to validate attribute values against that newer spec rather than the older one.