### PR TITLE
fix: do not report disabled instrumentations as failures

### DIFF
--- a/registry/lib/opentelemetry/instrumentation/registry.rb
+++ b/registry/lib/opentelemetry/instrumentation/registry.rb
@@ -81,6 +81,8 @@ module OpenTelemetry
           OpenTelemetry.logger.info "Instrumentation: #{instrumentation.name} was successfully installed with the following options #{instrumentation.config}"
         elsif !instrumentation.enabled?(config)
           OpenTelemetry.logger.info "Instrumentation: #{instrumentation.name} was not installed, because it is not enabled"
+        elsif !instrumentation.compatible?(config)
+          OpenTelemetry.logger.warn "Instrumentation: #{instrumentation.name} failed to install: compatibility issue"
         else
           OpenTelemetry.logger.warn "Instrumentation: #{instrumentation.name} failed to install"
         end

--- a/registry/lib/opentelemetry/instrumentation/registry.rb
+++ b/registry/lib/opentelemetry/instrumentation/registry.rb
@@ -79,6 +79,8 @@ module OpenTelemetry
           OpenTelemetry.logger.debug "Instrumentation: #{instrumentation.name} skipping install given corresponding dependency not found"
         elsif instrumentation.install(config)
           OpenTelemetry.logger.info "Instrumentation: #{instrumentation.name} was successfully installed with the following options #{instrumentation.config}"
+        elsif !instrumentation.enabled?(config)
+          OpenTelemetry.logger.info "Instrumentation: #{instrumentation.name} was not installed, because it is not enabled"
         else
           OpenTelemetry.logger.warn "Instrumentation: #{instrumentation.name} failed to install"
         end

--- a/registry/lib/opentelemetry/instrumentation/registry.rb
+++ b/registry/lib/opentelemetry/instrumentation/registry.rb
@@ -80,7 +80,7 @@ module OpenTelemetry
         elsif instrumentation.install(config)
           OpenTelemetry.logger.info "Instrumentation: #{instrumentation.name} was successfully installed with the following options #{instrumentation.config}"
         elsif !instrumentation.enabled?(config)
-          OpenTelemetry.logger.info "Instrumentation: #{instrumentation.name} was not installed, because it is not enabled"
+          OpenTelemetry.logger.info "Instrumentation: #{instrumentation.name} was not installed because it is not enabled"
         elsif !instrumentation.compatible?(config)
           OpenTelemetry.logger.warn "Instrumentation: #{instrumentation.name} failed to install: compatibility issue"
         else


### PR DESCRIPTION
It can be very confusing to see a `Instrumentation: OpenTelemetry::Instrumentation::Sinatra failed to install` log line when that instrumentation is in fact just disabled (via `enabled: false`) or `OTEL_RUBY_INSTRUMENTATION_SINATRA_ENABLED=false`. This instead reports it as a not-enabled instrumentation.