### PR TITLE
chore: Remove minitest rubocop overrides

### DIFF
--- a/api/.rubocop.yml
+++ b/api/.rubocop.yml
@@ -2,10 +2,6 @@ inherit_from: ../contrib/rubocop.yml
 
 Gemspec/DevelopmentDependencies:
  Enabled: false
-Minitest/AssertPredicate:
-  Enabled: false
-Minitest/RefutePredicate:
-  Enabled: false
 Style/EmptyClassDefinition:
   Exclude:
     - 'benchmarks/context_bench.rb'

--- a/api/test/opentelemetry/trace/propagation/trace_context/trace_parent_test.rb
+++ b/api/test/opentelemetry/trace/propagation/trace_context/trace_parent_test.rb
@@ -78,9 +78,9 @@ describe OpenTelemetry::Trace::Propagation::TraceContext::TraceParent do
 
     it 'must ignore flags it doesn\'t know (use the mask)' do
       value = '00-0000000000000000000000000000000a-000000000000000a-ff'
-      assert TraceParent.from_string(value).sampled?
+      assert_predicate TraceParent.from_string(value), :sampled?
       value = '00-0000000000000000000000000000000a-000000000000000a-04'
-      refute TraceParent.from_string(value).sampled?
+      refute_predicate TraceParent.from_string(value), :sampled?
     end
 
     it 'must have a trace id of 16 hex bytes' do

--- a/common/.rubocop.yml
+++ b/common/.rubocop.yml
@@ -1,6 +1,1 @@
 inherit_from: ../contrib/rubocop.yml
-
-Minitest/AssertPredicate:
-  Enabled: false
-Minitest/RefutePredicate:
-  Enabled: false

--- a/common/test/opentelemetry/common/utilities_test.rb
+++ b/common/test/opentelemetry/common/utilities_test.rb
@@ -24,14 +24,14 @@ describe OpenTelemetry::Common::Utilities do
 
     it 'returns false outside an untraced block' do
       common_utils.untraced {}
-      refute(common_utils.untraced?)
+      refute_predicate common_utils, :untraced?
     end
 
     it 'supports non block format' do
       token = OpenTelemetry::Context.attach(common_utils.untraced)
-      assert(common_utils.untraced?)
+      assert_predicate common_utils, :untraced?
       OpenTelemetry::Context.detach(token)
-      refute(common_utils.untraced?)
+      refute_predicate common_utils, :untraced?
     end
   end
 

--- a/exporter/zipkin/.rubocop.yml
+++ b/exporter/zipkin/.rubocop.yml
@@ -14,5 +14,3 @@ Metrics/PerceivedComplexity:
   Max: 13
 Metrics/CyclomaticComplexity:
   Max: 16
-Minitest/SkipEnsure:
-  Enabled: false

--- a/exporter/zipkin/test/opentelemetry/exporters/zipkin/exporter_test.rb
+++ b/exporter/zipkin/test/opentelemetry/exporters/zipkin/exporter_test.rb
@@ -83,15 +83,19 @@ describe OpenTelemetry::Exporter::Zipkin::Exporter do
       OpenTelemetry.tracer_provider = OpenTelemetry::SDK::Trace::TracerProvider.new
     end
 
-    it 'integrates with collector' do
-      skip unless ENV['TRACING_INTEGRATION_TEST']
-      WebMock.disable_net_connect!(allow: 'localhost')
-      resource = OpenTelemetry::SDK::Resources::Resource.telemetry_sdk
-      span_data = create_resource_span_data(name: 'collector-integration-test', resource: resource)
-      result = exporter.export([span_data], timeout: nil)
-      _(result).must_equal(OpenTelemetry::SDK::Trace::Export::SUCCESS)
-    ensure
-      WebMock.disable_net_connect!
+    describe 'collector integration' do
+      def teardown
+        WebMock.disable_net_connect!
+      end
+
+      it 'integrates with collector' do
+        skip unless ENV['TRACING_INTEGRATION_TEST']
+        WebMock.disable_net_connect!(allow: 'localhost')
+        resource = OpenTelemetry::SDK::Resources::Resource.telemetry_sdk
+        span_data = create_resource_span_data(name: 'collector-integration-test', resource: resource)
+        result = exporter.export([span_data], timeout: nil)
+        _(result).must_equal(OpenTelemetry::SDK::Trace::Export::SUCCESS)
+      end
     end
 
     it 'retries on timeout' do

--- a/logs_sdk/.rubocop.yml
+++ b/logs_sdk/.rubocop.yml
@@ -10,7 +10,3 @@ Metrics/PerceivedComplexity:
   Max: 10
 Metrics/CyclomaticComplexity:
   Max: 10
-Minitest/AssertWithExpectedArgument:
-  Enabled: false
-Minitest/UselessAssertion:
-  Enabled: false

--- a/logs_sdk/test/opentelemetry/sdk/logs/export/batch_log_record_processor_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/export/batch_log_record_processor_test.rb
@@ -152,7 +152,7 @@ describe OpenTelemetry::SDK::Logs::Export::BatchLogRecordProcessor do
 
     it 'does not spawn a thread on boot if OTEL_RUBY_BLRP_START_THREAD_ON_BOOT is false' do
       mock = Minitest::Mock.new
-      mock.expect(:call, nil) { assert false }
+      mock.expect(:call, nil)
 
       Thread.stub(:new, mock) do
         OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_BLRP_START_THREAD_ON_BOOT' => 'false') do
@@ -163,7 +163,7 @@ describe OpenTelemetry::SDK::Logs::Export::BatchLogRecordProcessor do
 
     it 'prefers explicit start_thread_on_boot parameter rather than the environment' do
       mock = Minitest::Mock.new
-      mock.expect(:call, nil) { assert false }
+      mock.expect(:call, nil)
 
       Thread.stub(:new, mock) do
         OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_BLRP_START_THREAD_ON_BOOT' => 'true') do

--- a/logs_sdk/test/opentelemetry/sdk/logs/export/log_record_exporter_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/export/log_record_exporter_test.rb
@@ -34,6 +34,6 @@ describe OpenTelemetry::SDK::Logs::Export::LogRecordExporter do
   end
 
   it 'returns SUCCESS when #force_flush is called' do
-    assert(export::SUCCESS, exporter.force_flush)
+    assert_equal(export::SUCCESS, exporter.force_flush)
   end
 end

--- a/logs_sdk/test/opentelemetry/sdk/logs/log_record_processor_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/log_record_processor_test.rb
@@ -20,7 +20,7 @@ describe OpenTelemetry::SDK::Logs::LogRecordProcessor do
   end
 
   it 'returns a success code when #force_flush is called' do
-    assert(OpenTelemetry::SDK::Logs::Export::SUCCESS, processor.force_flush)
+    assert_equal(OpenTelemetry::SDK::Logs::Export::SUCCESS, processor.force_flush)
   end
 
   it 'implements #shutdown' do
@@ -28,6 +28,6 @@ describe OpenTelemetry::SDK::Logs::LogRecordProcessor do
   end
 
   it 'returns a success code when #shutdown is called' do
-    assert(OpenTelemetry::SDK::Logs::Export::SUCCESS, processor.shutdown)
+    assert_equal(OpenTelemetry::SDK::Logs::Export::SUCCESS, processor.shutdown)
   end
 end

--- a/metrics_api/.rubocop.yml
+++ b/metrics_api/.rubocop.yml
@@ -3,5 +3,3 @@ inherit_from:
 
 Metrics/CyclomaticComplexity:
   Max: 9
-Minitest/AssertKindOf:
-  Enabled: false

--- a/metrics_api/test/opentelemetry/metrics/meter_provider_test.rb
+++ b/metrics_api/test/opentelemetry/metrics/meter_provider_test.rb
@@ -17,7 +17,7 @@ describe OpenTelemetry::Metrics::MeterProvider do
     it 'returns an instance of Meter' do
       meter_provider = build_meter_provider
 
-      assert(meter_provider.meter('test', version: '1.0.0').is_a?(OpenTelemetry::Metrics::Meter))
+      assert_kind_of(OpenTelemetry::Metrics::Meter, meter_provider.meter('test', version: '1.0.0'))
     end
   end
 

--- a/metrics_api/test/opentelemetry/opentelemetry_test.rb
+++ b/metrics_api/test/opentelemetry/opentelemetry_test.rb
@@ -18,7 +18,7 @@ describe OpenTelemetry do
 
   describe '#meter_provider and #meter_provider=' do
     it 'initializes with a global instance of ProxyMeterProvider' do
-      assert(OpenTelemetry.meter_provider.is_a?(OpenTelemetry::Internal::ProxyMeterProvider))
+      assert_kind_of(OpenTelemetry::Internal::ProxyMeterProvider, OpenTelemetry.meter_provider)
     end
 
     it 'sets global MeterProvider to the given meter_provider' do

--- a/sdk/.rubocop.yml
+++ b/sdk/.rubocop.yml
@@ -6,5 +6,3 @@ Lint/EmptyClass:
     - 'test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb'
 Metrics/CyclomaticComplexity:
   Max: 9
-Minitest/UselessAssertion:
-  Enabled: false

--- a/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
@@ -174,7 +174,7 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
 
     it 'does not spawn a thread on boot if OTEL_RUBY_BSP_START_THREAD_ON_BOOT is false' do
       mock = Minitest::Mock.new
-      mock.expect(:call, nil) { assert false }
+      mock.expect(:call, nil)
 
       Thread.stub(:new, mock) do
         OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_BSP_START_THREAD_ON_BOOT' => 'false') do
@@ -185,7 +185,7 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
 
     it 'prefers explicit start_thread_on_boot parameter rather than the environment' do
       mock = Minitest::Mock.new
-      mock.expect(:call, nil) { assert false }
+      mock.expect(:call, nil)
 
       Thread.stub(:new, mock) do
         OpenTelemetry::TestHelpers.with_env('OTEL_RUBY_BSP_START_THREAD_ON_BOOT' => 'true') do


### PR DESCRIPTION
This is the last lot of rubocop override removals and ensures that wherever possible we are using the project default settings.