### PR TITLE
chore: Update otelbot token workflows to use client IDs

### DIFF
--- a/.github/workflows/release-request-weekly.yml
+++ b/.github/workflows/release-request-weekly.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ vars.OTELBOT_RUBY_APP_ID }}
+          client-id: ${{ vars.OTELBOT_RUBY_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_RUBY_PRIVATE_KEY }}
       - name: Open release pull request
         env:

--- a/.github/workflows/release-request.yml
+++ b/.github/workflows/release-request.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ vars.OTELBOT_RUBY_APP_ID }}
+          client-id: ${{ vars.OTELBOT_RUBY_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_RUBY_PRIVATE_KEY }}
       - name: Determine releases
         id: detect

--- a/.github/workflows/renovate-semconv.yml
+++ b/.github/workflows/renovate-semconv.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ vars.OTELBOT_RUBY_APP_ID }}
+          client-id: ${{ vars.OTELBOT_RUBY_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_RUBY_PRIVATE_KEY }}
 
       - name: Commit and push changes


### PR DESCRIPTION
Update otelbot token creation to use GitHub App client IDs.

The `app-id` input for `actions/create-github-app-token` is deprecated in favor of `client-id`. The matching `OTELBOT_*_CLIENT_ID` organization variables have been provisioned, so this updates direct token creation from `app-id` / `*_APP_ID` to `client-id` / `*_CLIENT_ID`.

Tracking issue: https://github.com/open-telemetry/admin/issues/744