### PR TITLE
fix: update total_recorded_attributes when LogRecord#attributes= is called

### DIFF
--- a/exporter/otlp-logs/lib/opentelemetry/exporter/otlp/logs/logs_exporter.rb
+++ b/exporter/otlp-logs/lib/opentelemetry/exporter/otlp/logs/logs_exporter.rb
@@ -309,7 +309,7 @@ module OpenTelemetry
               severity_text: log_record_data.severity_text,
               body: as_otlp_any_value(log_record_data.body),
               attributes: log_record_data.attributes&.map { |k, v| as_otlp_key_value(k, v) },
-              dropped_attributes_count: log_record_data.total_recorded_attributes - log_record_data.attributes&.size.to_i,
+              dropped_attributes_count: log_record_data.dropped_attributes_count,
               event_name: log_record_data.event_name,
               flags: log_record_data.trace_flags.instance_variable_get(:@flags),
               trace_id: log_record_data.trace_id,

--- a/exporter/otlp-logs/test/opentelemetry/exporter/otlp/logs_exporter_test.rb
+++ b/exporter/otlp-logs/test/opentelemetry/exporter/otlp/logs_exporter_test.rb
@@ -636,7 +636,7 @@ describe OpenTelemetry::Exporter::OTLP::Logs::LogsExporter do
       OpenTelemetry.logger = ::Logger.new(log_stream)
 
       stub_request(:post, 'http://localhost:4318/v1/logs').to_return(status: 200)
-      log_record_data = OpenTelemetry::TestHelpers.create_log_record_data(total_recorded_attributes: 1, attributes: { 'a' => (+"\xC2").force_encoding(::Encoding::ASCII_8BIT) })
+      log_record_data = OpenTelemetry::TestHelpers.create_log_record_data(attributes: { 'a' => (+"\xC2").force_encoding(::Encoding::ASCII_8BIT) })
 
       result = exporter.export([log_record_data])
 
@@ -741,6 +741,10 @@ describe OpenTelemetry::Exporter::OTLP::Logs::LogsExporter do
     it 'translates all the things' do
       stub_request(:post, 'http://localhost:4318/v1/logs').to_return(status: 200)
       processor = OpenTelemetry::SDK::Logs::Export::BatchLogRecordProcessor.new(exporter)
+      logger_provider = OpenTelemetry::SDK::Logs::LoggerProvider.new(
+        resource: OpenTelemetry::SDK::Resources::Resource.telemetry_sdk,
+        log_record_limits: OpenTelemetry::SDK::Logs::LogRecordLimits.new(attribute_count_limit: 6)
+      )
       logger = logger_provider.logger(name: 'logger', version: 'v0.0.1')
       other_logger = logger_provider.logger(name: 'other_logger', version: 'v0.1.0')
 
@@ -786,6 +790,7 @@ describe OpenTelemetry::Exporter::OTLP::Logs::LogsExporter do
           'int' => 42
         },
         attributes: {
+          'drop_me' => 'l8r',
           'kv_list' => { 'a' => 'b' },
           'array' => [1],
           'bool' => true,
@@ -959,7 +964,7 @@ describe OpenTelemetry::Exporter::OTLP::Logs::LogsExporter do
                           )
                         )
                       ],
-                      dropped_attributes_count: 0,
+                      dropped_attributes_count: 1,
                       flags: lr3[:trace_flags].instance_variable_get(:@flags),
                       trace_id: lr3[:trace_id],
                       span_id: lr3[:span_id]

--- a/logs_sdk/lib/opentelemetry/sdk/logs/log_record.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/log_record.rb
@@ -18,13 +18,14 @@ module OpenTelemetry
                       :severity_text,
                       :severity_number,
                       :body,
-                      :attributes,
                       :event_name,
                       :trace_id,
                       :span_id,
                       :trace_flags,
                       :resource,
                       :instrumentation_scope
+
+        attr_reader :attributes
 
         # Creates a new {LogRecord}.
         #
@@ -81,7 +82,6 @@ module OpenTelemetry
           @severity_text = severity_text
           @severity_number = severity_number
           @body = body
-          @attributes = attributes&.to_h # We need a mutable copy of attributes
           @event_name = event_name
           @trace_id = trace_id
           @span_id = span_id
@@ -89,6 +89,18 @@ module OpenTelemetry
           @resource = resource
           @instrumentation_scope = instrumentation_scope
           @log_record_limits = log_record_limits || LogRecordLimits::DEFAULT
+          self.attributes = attributes
+        end
+
+        # Sets the attributes for this {LogRecord}, recalculating the total
+        # recorded attribute count and reapplying the configured attribute
+        # limits.
+        #
+        # @param [optional Hash{String => String, Numeric, Boolean,
+        #   Array<String, Numeric, Boolean>}] new_attributes Attributes to
+        #   associate with the {LogRecord}.
+        def attributes=(new_attributes)
+          @attributes = new_attributes&.to_h # We need a mutable copy of attributes
           @total_recorded_attributes = @attributes&.size || 0
 
           trim_attributes(@attributes)
@@ -115,9 +127,7 @@ module OpenTelemetry
         private
 
         def to_integer_nanoseconds(timestamp)
-          return unless timestamp.is_a?(Time)
-
-          (timestamp.to_r * (10**9)).to_i
+          (timestamp.to_r * (10**9)).to_i if timestamp.is_a?(Time)
         end
 
         def trim_attributes(attributes)

--- a/logs_sdk/lib/opentelemetry/sdk/logs/log_record.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/log_record.rb
@@ -89,21 +89,18 @@ module OpenTelemetry
           @resource = resource
           @instrumentation_scope = instrumentation_scope
           @log_record_limits = log_record_limits || LogRecordLimits::DEFAULT
+          @dropped_attributes_count = 0
           self.attributes = attributes
         end
 
-        # Sets the attributes for this {LogRecord}, recalculating the total
-        # recorded attribute count and reapplying the configured attribute
-        # limits.
+        # Sets the attributes for this {LogRecord} and reapplies the
+        # configured attribute limits.
         #
         # @param [optional Hash{String => String, Numeric, Boolean,
         #   Array<String, Numeric, Boolean>}] new_attributes Attributes to
         #   associate with the {LogRecord}.
         def attributes=(new_attributes)
-          @attributes = new_attributes&.to_h # We need a mutable copy of attributes
-          @total_recorded_attributes = @attributes&.size || 0
-
-          trim_attributes(@attributes)
+          trim_attributes(@attributes = new_attributes&.to_h) # We need a mutable copy of attributes
         end
 
         def to_log_record_data
@@ -120,7 +117,7 @@ module OpenTelemetry
             @trace_flags,
             @resource,
             @instrumentation_scope,
-            @total_recorded_attributes
+            @dropped_attributes_count
           )
         end
 
@@ -130,24 +127,25 @@ module OpenTelemetry
           (timestamp.to_r * (10**9)).to_i if timestamp.is_a?(Time)
         end
 
-        def trim_attributes(attributes)
-          return if attributes.nil?
+        def trim_attributes(attrs)
+          return if attrs.nil?
 
           # truncate total attributes
-          truncate_attributes(attributes, @log_record_limits.attribute_count_limit)
+          truncate_attributes(attrs, @log_record_limits.attribute_count_limit)
 
           # truncate attribute values
-          truncate_attribute_values(attributes, @log_record_limits.attribute_length_limit)
+          truncate_attribute_values(attrs, @log_record_limits.attribute_length_limit)
 
           # validate attributes
-          validate_attributes(attributes)
-
-          nil
+          validate_attributes(attrs)
         end
 
-        def truncate_attributes(attributes, attribute_limit)
-          excess = attributes.size - attribute_limit
-          excess.times { attributes.shift } if excess.positive?
+        def truncate_attributes(attrs, attribute_limit)
+          excess = attrs.size - attribute_limit
+          return unless excess.positive?
+
+          excess.times { attrs.shift }
+          @dropped_attributes_count += excess
         end
 
         def validate_attributes(attrs)

--- a/logs_sdk/lib/opentelemetry/sdk/logs/log_record_data.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/log_record_data.rb
@@ -20,7 +20,7 @@ module OpenTelemetry
                                  :trace_flags,               # optional Integer (8-bit byte of bit flags)
                                  :resource,                  # optional OpenTelemetry::SDK::Resources::Resource
                                  :instrumentation_scope,     # optional OpenTelemetry::SDK::InstrumentationScope
-                                 :total_recorded_attributes) # Integer
+                                 :dropped_attributes_count)  # Integer
     end
   end
 end

--- a/logs_sdk/test/opentelemetry/sdk/logs/log_record_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/log_record_test.rb
@@ -154,6 +154,36 @@ describe OpenTelemetry::SDK::Logs::LogRecord do
       end
     end
 
+    describe '#attributes=' do
+      it 'updates total_recorded_attributes when reassigned' do
+        log_record = Logs::LogRecord.new(attributes: { 'key1' => 'value1' })
+        assert_equal(1, log_record.instance_variable_get(:@total_recorded_attributes))
+
+        log_record.attributes = { 'key1' => 'value1', 'key2' => 'value2', 'key3' => 'value3' }
+
+        assert_equal(3, log_record.instance_variable_get(:@total_recorded_attributes))
+        assert_equal(3, log_record.to_log_record_data.total_recorded_attributes)
+      end
+
+      it 'sets total_recorded_attributes to 0 when set to nil' do
+        log_record = Logs::LogRecord.new(attributes: { 'key1' => 'value1' })
+
+        log_record.attributes = nil
+
+        assert_equal(0, log_record.instance_variable_get(:@total_recorded_attributes))
+        assert_nil(log_record.attributes)
+      end
+
+      it 'applies attribute count limits when reassigned' do
+        limits = Logs::LogRecordLimits.new(attribute_count_limit: 1)
+        log_record = Logs::LogRecord.new(log_record_limits: limits, attributes: { 'a' => 'a' })
+
+        log_record.attributes = { 'old' => 'old', 'new' => 'new' }
+
+        assert_equal({ 'new' => 'new' }, log_record.attributes)
+      end
+    end
+
     describe 'attribute value limit' do
       it 'truncates the values that are too long' do
         length_limit = 32

--- a/logs_sdk/test/opentelemetry/sdk/logs/log_record_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/log_record_test.rb
@@ -155,22 +155,26 @@ describe OpenTelemetry::SDK::Logs::LogRecord do
     end
 
     describe '#attributes=' do
-      it 'updates total_recorded_attributes when reassigned' do
-        log_record = Logs::LogRecord.new(attributes: { 'key1' => 'value1' })
-        assert_equal(1, log_record.instance_variable_get(:@total_recorded_attributes))
+      it 'does not increment dropped_attributes_count when reassigned within the limit' do
+        limits = Logs::LogRecordLimits.new(attribute_count_limit: 2)
+        log_record = Logs::LogRecord.new(log_record_limits: limits, attributes: { 'key1' => 'value1' })
+        assert_equal(0, log_record.instance_variable_get(:@dropped_attributes_count))
 
         log_record.attributes = { 'key1' => 'value1', 'key2' => 'value2', 'key3' => 'value3' }
 
-        assert_equal(3, log_record.instance_variable_get(:@total_recorded_attributes))
-        assert_equal(3, log_record.to_log_record_data.total_recorded_attributes)
+        assert_equal(1, log_record.instance_variable_get(:@dropped_attributes_count))
+        assert_equal(1, log_record.to_log_record_data.dropped_attributes_count)
+        assert_equal({ 'key2' => 'value2', 'key3' => 'value3' }, log_record.to_log_record_data.attributes)
       end
 
-      it 'sets total_recorded_attributes to 0 when set to nil' do
-        log_record = Logs::LogRecord.new(attributes: { 'key1' => 'value1' })
+      it 'does not reset dropped_attributes_count when set to nil' do
+        limits = Logs::LogRecordLimits.new(attribute_count_limit: 1)
+        log_record = Logs::LogRecord.new(log_record_limits: limits, attributes: { 'key1' => 'value1', 'key2' => 'value2' })
+        assert_equal(1, log_record.instance_variable_get(:@dropped_attributes_count))
 
         log_record.attributes = nil
 
-        assert_equal(0, log_record.instance_variable_get(:@total_recorded_attributes))
+        assert_equal(1, log_record.instance_variable_get(:@dropped_attributes_count))
         assert_nil(log_record.attributes)
       end
 
@@ -181,6 +185,40 @@ describe OpenTelemetry::SDK::Logs::LogRecord do
         log_record.attributes = { 'old' => 'old', 'new' => 'new' }
 
         assert_equal({ 'new' => 'new' }, log_record.attributes)
+      end
+
+      it 'increments dropped_attributes_count on initial construction when over the limit' do
+        limits = Logs::LogRecordLimits.new(attribute_count_limit: 1)
+        log_record = Logs::LogRecord.new(log_record_limits: limits, attributes: { 'old' => 'old', 'new' => 'new' })
+
+        assert_equal(1, log_record.instance_variable_get(:@dropped_attributes_count))
+      end
+
+      it 'does not increment dropped_attributes_count for invalid attributes dropped by value validation' do
+        log_record = nil
+
+        OpenTelemetry::TestHelpers.with_test_logger do
+          log_record = Logs::LogRecord.new(attributes: { 'a' => 'a', 'b' => Class.new })
+        end
+
+        assert_equal(0, log_record.instance_variable_get(:@dropped_attributes_count))
+      end
+
+      it 'accumulates dropped_attributes_count across repeated reassignment' do
+        limits = Logs::LogRecordLimits.new(attribute_count_limit: 2)
+        log_record = Logs::LogRecord.new(log_record_limits: limits, attributes: { 'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4 })
+        assert_equal(2, log_record.instance_variable_get(:@dropped_attributes_count))
+
+        log_record.attributes = log_record.attributes.merge('e' => 5)
+        assert_equal(3, log_record.instance_variable_get(:@dropped_attributes_count))
+
+        log_record.attributes = log_record.attributes.except('e')
+        assert_equal(3, log_record.instance_variable_get(:@dropped_attributes_count))
+
+        log_record.attributes = log_record.attributes.merge('f' => 6, 'g' => 7)
+        assert_equal(4, log_record.instance_variable_get(:@dropped_attributes_count))
+
+        assert_equal(4, log_record.to_log_record_data.dropped_attributes_count)
       end
     end
 

--- a/logs_sdk/test/opentelemetry/sdk/logs/log_record_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/log_record_test.rb
@@ -204,6 +204,9 @@ describe OpenTelemetry::SDK::Logs::LogRecord do
         assert_equal(0, log_record.instance_variable_get(:@dropped_attributes_count))
       end
 
+      # our choice to accumulate across reassignment is based on 
+      # a test in the JS implementation:
+      # https://github.com/open-telemetry/opentelemetry-js/blob/7b155b84c86be06b2b6d309c28e61e617af6e779/experimental/packages/sdk-logs/test/common/LogRecord.test.ts#L313-L324
       it 'accumulates dropped_attributes_count across repeated reassignment' do
         limits = Logs::LogRecordLimits.new(attribute_count_limit: 2)
         log_record = Logs::LogRecord.new(log_record_limits: limits, attributes: { 'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4 })

--- a/test_helpers/lib/opentelemetry/test_helpers.rb
+++ b/test_helpers/lib/opentelemetry/test_helpers.rb
@@ -86,7 +86,7 @@ module OpenTelemetry
                                trace_flags: OpenTelemetry::Trace::TraceFlags::DEFAULT,
                                resource: nil,
                                instrumentation_scope: OpenTelemetry::SDK::InstrumentationScope.new('', 'v0.0.1'),
-                               total_recorded_attributes: 0)
+                               dropped_attributes_count: 0)
       resource ||= OpenTelemetry::SDK::Resources::Resource.telemetry_sdk
       OpenTelemetry::SDK::Logs::LogRecordData.new(
         timestamp,
@@ -101,7 +101,7 @@ module OpenTelemetry
         trace_flags,
         resource,
         instrumentation_scope,
-        total_recorded_attributes
+        dropped_attributes_count
       )
     end
   end


### PR DESCRIPTION
Closes https://github.com/open-telemetry/opentelemetry-ruby/issues/2194

The attr_accessor-generated attributes= setter reassigned the attributes hash but left @total_recorded_attributes at its initialization value, so to_log_record_data reported a stale count after mutation (e.g. in a custom LogRecordProcessor#on_emit).

Replace the generated setter with a custom attributes= that recalculates @total_recorded_attributes and reapplies the configured attribute limits, and reuse it from the constructor.