### PR TITLE
feat: Use common conversion including supporting flags

### DIFF
--- a/exporter/otlp-common/.rubocop.yml
+++ b/exporter/otlp-common/.rubocop.yml
@@ -8,6 +8,6 @@ AllCops:
 Metrics/CyclomaticComplexity:
   Max: 16
 Metrics/MethodLength:
-  Max: 35
+  Max: 22
 Metrics/PerceivedComplexity:
   Max: 16

--- a/exporter/otlp-common/lib/opentelemetry/exporter/otlp/common.rb
+++ b/exporter/otlp-common/lib/opentelemetry/exporter/otlp/common.rb
@@ -70,7 +70,7 @@ module OpenTelemetry
 
         private
 
-        def as_otlp_span(span_data)
+        def as_otlp_span(span_data) # rubocop:disable Metrics/MethodLength
           Opentelemetry::Proto::Trace::V1::Span.new(
             trace_id: span_data.trace_id,
             span_id: span_data.span_id,
@@ -96,8 +96,9 @@ module OpenTelemetry
                 trace_id: link.span_context.trace_id,
                 span_id: link.span_context.span_id,
                 trace_state: link.span_context.tracestate.to_s,
-                attributes: link.attributes&.map { |k, v| as_otlp_key_value(k, v) }
+                attributes: link.attributes&.map { |k, v| as_otlp_key_value(k, v) },
                 # TODO: track dropped_attributes_count in Span#trim_links
+                flags: build_span_flags(link.span_context.remote?, link.span_context.trace_flags)
               )
             end,
             dropped_links_count: span_data.total_recorded_links - span_data.links&.size.to_i,
@@ -106,8 +107,29 @@ module OpenTelemetry
                 code: as_otlp_status_code(status.code),
                 message: status.description
               )
-            end
+            end,
+            flags: build_span_flags(span_data.parent_span_is_remote, span_data.trace_flags)
           )
+        end
+
+        # Builds span flags based on whether the parent span context is remote.
+        # This follows the OTLP specification for span flags.
+        def build_span_flags(parent_span_is_remote, base_flags)
+          # Extract integer value from TraceFlags object if needed
+          # Derive the low 8-bit W3C trace flags using the public API.
+          base_flags_int =
+            if base_flags.sampled?
+              1
+            else
+              0
+            end
+
+          has_remote_mask = Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK
+          is_remote_mask = Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK
+
+          flags = base_flags_int | has_remote_mask
+          flags |= is_remote_mask if parent_span_is_remote
+          flags
         end
 
         def as_otlp_status_code(code)

--- a/exporter/otlp-common/test/opentelemetry/exporter/otlp/common/common_test.rb
+++ b/exporter/otlp-common/test/opentelemetry/exporter/otlp/common/common_test.rb
@@ -163,6 +163,10 @@ describe OpenTelemetry::Exporter::OTLP::Common do
                       end_time_unix_nano: (end_timestamp.to_r * 1_000_000_000).to_i,
                       status: Opentelemetry::Proto::Trace::V1::Status.new(
                         code: Opentelemetry::Proto::Trace::V1::Status::StatusCode::STATUS_CODE_OK
+                      ),
+                      flags: (
+                        Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK |
+                        1
                       )
                     ),
                     Opentelemetry::Proto::Trace::V1::Span.new(
@@ -175,6 +179,10 @@ describe OpenTelemetry::Exporter::OTLP::Common do
                       end_time_unix_nano: (end_timestamp.to_r * 1_000_000_000).to_i,
                       status: Opentelemetry::Proto::Trace::V1::Status.new(
                         code: Opentelemetry::Proto::Trace::V1::Status::StatusCode::STATUS_CODE_UNSET
+                      ),
+                      flags: (
+                        Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK |
+                        1
                       )
                     ),
                     Opentelemetry::Proto::Trace::V1::Span.new(
@@ -187,6 +195,10 @@ describe OpenTelemetry::Exporter::OTLP::Common do
                       end_time_unix_nano: (end_timestamp.to_r * 1_000_000_000).to_i,
                       status: Opentelemetry::Proto::Trace::V1::Status.new(
                         code: Opentelemetry::Proto::Trace::V1::Status::StatusCode::STATUS_CODE_UNSET
+                      ),
+                      flags: (
+                        Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK |
+                        1
                       )
                     ),
                     Opentelemetry::Proto::Trace::V1::Span.new(
@@ -229,11 +241,19 @@ describe OpenTelemetry::Exporter::OTLP::Common do
                           span_id: root_span_id,
                           attributes: [
                             Opentelemetry::Proto::Common::V1::KeyValue.new(key: 'attr', value: Opentelemetry::Proto::Common::V1::AnyValue.new(int_value: 4))
-                          ]
+                          ],
+                          flags: (
+                            Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK |
+                            1
+                          )
                         )
                       ],
                       status: Opentelemetry::Proto::Trace::V1::Status.new(
                         code: Opentelemetry::Proto::Trace::V1::Status::StatusCode::STATUS_CODE_ERROR
+                      ),
+                      flags: (
+                        Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK |
+                        1
                       )
                     )
                   ]
@@ -253,6 +273,10 @@ describe OpenTelemetry::Exporter::OTLP::Common do
                       end_time_unix_nano: (end_timestamp.to_r * 1_000_000_000).to_i,
                       status: Opentelemetry::Proto::Trace::V1::Status.new(
                         code: Opentelemetry::Proto::Trace::V1::Status::StatusCode::STATUS_CODE_UNSET
+                      ),
+                      flags: (
+                        Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK |
+                        1
                       )
                     )
                   ]

--- a/exporter/otlp-common/test/opentelemetry/exporter/otlp/common/common_test.rb
+++ b/exporter/otlp-common/test/opentelemetry/exporter/otlp/common/common_test.rb
@@ -344,4 +344,136 @@ describe OpenTelemetry::Exporter::OTLP::Common do
       _(etsr.resource_spans.first.scope_spans.first.scope.version).must_be_empty
     end
   end
+
+  describe 'span flags' do
+    let(:common) { OpenTelemetry::Exporter::OTLP::Common }
+    let(:trace_id) { OpenTelemetry::Trace.generate_trace_id }
+    let(:span_id) { OpenTelemetry::Trace.generate_span_id }
+    let(:parent_span_id) { OpenTelemetry::Trace.generate_span_id }
+    let(:resource) { OpenTelemetry::SDK::Resources::Resource.create('service.name' => 'test-service') }
+    let(:instrumentation_scope) { OpenTelemetry::SDK::InstrumentationScope.new('test-lib', '1.0.0') }
+
+    describe 'build_span_flags' do
+      it 'sets flags to HAS_IS_REMOTE for local parent span context' do
+        flags = common.send(:build_span_flags, false, OpenTelemetry::Trace::TraceFlags::DEFAULT)
+        _(flags).must_equal(
+          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK
+        )
+      end
+
+      it 'sets flags to HAS_IS_REMOTE | IS_REMOTE for remote parent span context' do
+        flags = common.send(:build_span_flags, true, OpenTelemetry::Trace::TraceFlags::DEFAULT)
+        _(flags).must_equal(
+          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK |
+          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK
+        )
+      end
+
+      it 'preserves base trace flags' do
+        flags = common.send(:build_span_flags, false, OpenTelemetry::Trace::TraceFlags::SAMPLED)
+        _(flags).must_equal(
+          0x01 |
+          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK
+        )
+      end
+    end
+
+    describe 'as_otlp_span with flags' do
+      it 'sets flags to HAS_IS_REMOTE for local parent span context' do
+        span_data = create_span_data(parent_span_is_remote: false)
+        span = common.send(:as_otlp_span, span_data)
+        _(span.flags).must_equal(
+          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK
+        )
+      end
+
+      it 'sets flags to HAS_IS_REMOTE | IS_REMOTE for remote parent span context' do
+        span_data = create_span_data(parent_span_is_remote: true)
+        span = common.send(:as_otlp_span, span_data)
+        _(span.flags).must_equal(
+          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK |
+          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK
+        )
+      end
+    end
+
+    describe 'as_otlp_span with link flags' do
+      it 'sets link flags to HAS_IS_REMOTE for local link context' do
+        local_span_context = OpenTelemetry::Trace::SpanContext.new(trace_id: trace_id, span_id: parent_span_id, remote: false)
+        local_link = create_link(local_span_context)
+        span_data = create_span_data(links: [local_link])
+        span = common.send(:as_otlp_span, span_data)
+        _(span.links.first.flags).must_equal(
+          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK
+        )
+      end
+
+      it 'sets link flags to HAS_IS_REMOTE | IS_REMOTE for remote link context' do
+        remote_span_context = OpenTelemetry::Trace::SpanContext.new(trace_id: trace_id, span_id: parent_span_id, remote: true)
+        remote_link = create_link(remote_span_context)
+        span_data = create_span_data(links: [remote_link])
+        span = common.send(:as_otlp_span, span_data)
+        _(span.links.first.flags).must_equal(
+          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK |
+          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK
+        )
+      end
+    end
+
+    describe 'export with flags' do
+      it 'includes flags in exported spans' do
+        span_data = create_span_data(parent_span_is_remote: true)
+        encoded_data = common.send(:as_encoded_etsr, [span_data])
+        decoded = Opentelemetry::Proto::Collector::Trace::V1::ExportTraceServiceRequest.decode(encoded_data)
+        exported_span = decoded.resource_spans.first.scope_spans.first.spans.first
+        _(exported_span.flags).must_equal(
+          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK |
+          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK
+        )
+      end
+
+      it 'includes flags in exported links' do
+        remote_span_context = OpenTelemetry::Trace::SpanContext.new(trace_id: trace_id, span_id: parent_span_id, remote: true)
+        remote_link = create_link(remote_span_context)
+        span_data = create_span_data(links: [remote_link])
+        encoded_data = common.send(:as_encoded_etsr, [span_data])
+        decoded = Opentelemetry::Proto::Collector::Trace::V1::ExportTraceServiceRequest.decode(encoded_data)
+        exported_link = decoded.resource_spans.first.scope_spans.first.spans.first.links.first
+        _(exported_link.flags).must_equal(
+          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK |
+          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK
+        )
+      end
+    end
+
+    private
+
+    def create_span_data(parent_span_is_remote: false, links: [])
+      OpenTelemetry::SDK::Trace::SpanData.new(
+        'test-span',                    # name
+        :internal,                      # kind
+        OpenTelemetry::Trace::Status.ok, # status
+        parent_span_id, # parent_span_id
+        0,                             # total_recorded_attributes
+        0,                             # total_recorded_events
+        links.size,                    # total_recorded_links
+        Time.now.to_i * 1_000_000_000, # start_timestamp
+        Time.now.to_i * 1_000_000_000, # end_timestamp
+        {},                            # attributes
+        links,                         # links
+        [],                            # events
+        resource,                      # resource
+        instrumentation_scope,         # instrumentation_scope
+        span_id,                       # span_id
+        trace_id,                      # trace_id
+        OpenTelemetry::Trace::TraceFlags::DEFAULT, # trace_flags
+        OpenTelemetry::Trace::Tracestate::DEFAULT, # tracestate
+        parent_span_is_remote # parent_span_is_remote
+      )
+    end
+
+    def create_link(span_context)
+      OpenTelemetry::Trace::Link.new(span_context, { 'link-attribute' => 'link-value' })
+    end
+  end
 end

--- a/exporter/otlp-http/test/opentelemetry/exporter/otlp/http/trace_exporter_test.rb
+++ b/exporter/otlp-http/test/opentelemetry/exporter/otlp/http/trace_exporter_test.rb
@@ -741,6 +741,10 @@ describe OpenTelemetry::Exporter::OTLP::HTTP::TraceExporter do
                       end_time_unix_nano: (end_timestamp.to_r * 1_000_000_000).to_i,
                       status: Opentelemetry::Proto::Trace::V1::Status.new(
                         code: Opentelemetry::Proto::Trace::V1::Status::StatusCode::STATUS_CODE_OK
+                      ),
+                      flags: (
+                        Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK |
+                        1
                       )
                     ),
                     Opentelemetry::Proto::Trace::V1::Span.new(
@@ -753,6 +757,10 @@ describe OpenTelemetry::Exporter::OTLP::HTTP::TraceExporter do
                       end_time_unix_nano: (end_timestamp.to_r * 1_000_000_000).to_i,
                       status: Opentelemetry::Proto::Trace::V1::Status.new(
                         code: Opentelemetry::Proto::Trace::V1::Status::StatusCode::STATUS_CODE_UNSET
+                      ),
+                      flags: (
+                        Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK |
+                        1
                       )
                     ),
                     Opentelemetry::Proto::Trace::V1::Span.new(
@@ -765,6 +773,10 @@ describe OpenTelemetry::Exporter::OTLP::HTTP::TraceExporter do
                       end_time_unix_nano: (end_timestamp.to_r * 1_000_000_000).to_i,
                       status: Opentelemetry::Proto::Trace::V1::Status.new(
                         code: Opentelemetry::Proto::Trace::V1::Status::StatusCode::STATUS_CODE_UNSET
+                      ),
+                      flags: (
+                        Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK |
+                        1
                       )
                     ),
                     Opentelemetry::Proto::Trace::V1::Span.new(
@@ -807,11 +819,19 @@ describe OpenTelemetry::Exporter::OTLP::HTTP::TraceExporter do
                           span_id: root_span_id,
                           attributes: [
                             Opentelemetry::Proto::Common::V1::KeyValue.new(key: 'attr', value: Opentelemetry::Proto::Common::V1::AnyValue.new(int_value: 4))
-                          ]
+                          ],
+                          flags: (
+                            Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK |
+                            1
+                          )
                         )
                       ],
                       status: Opentelemetry::Proto::Trace::V1::Status.new(
                         code: Opentelemetry::Proto::Trace::V1::Status::StatusCode::STATUS_CODE_ERROR
+                      ),
+                      flags: (
+                        Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK |
+                        1
                       )
                     )
                   ]
@@ -831,6 +851,10 @@ describe OpenTelemetry::Exporter::OTLP::HTTP::TraceExporter do
                       end_time_unix_nano: (end_timestamp.to_r * 1_000_000_000).to_i,
                       status: Opentelemetry::Proto::Trace::V1::Status.new(
                         code: Opentelemetry::Proto::Trace::V1::Status::StatusCode::STATUS_CODE_UNSET
+                      ),
+                      flags: (
+                        Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK |
+                        1
                       )
                     )
                   ]

--- a/exporter/otlp/Gemfile
+++ b/exporter/otlp/Gemfile
@@ -23,6 +23,7 @@ group :test, :development do
   gem 'yard-doctest', '~> 0.1.6'
   gem 'opentelemetry-api', path: '../../api', require: false
   gem 'opentelemetry-common', path: '../../common', require: false
+  gem 'opentelemetry-exporter-otlp-common', path: '../otlp-common', require: false
   gem 'opentelemetry-registry', path: '../../registry', require: false
   gem 'opentelemetry-sdk', path: '../../sdk', require: false
   gem 'opentelemetry-semantic_conventions', path: '../../semantic_conventions', require: false

--- a/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
+++ b/exporter/otlp/lib/opentelemetry/exporter/otlp/exporter.rb
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 require 'opentelemetry/common'
+require 'opentelemetry/exporter/otlp/common'
 require 'opentelemetry/sdk'
 require 'net/http'
 require 'zlib'
@@ -104,26 +105,6 @@ module OpenTelemetry
         end
 
         private
-
-        # Builds span flags based on whether the parent span context is remote.
-        # This follows the OTLP specification for span flags.
-        def build_span_flags(parent_span_is_remote, base_flags)
-          # Extract integer value from TraceFlags object if needed
-          # Derive the low 8-bit W3C trace flags using the public API.
-          base_flags_int =
-            if base_flags.sampled?
-              1
-            else
-              0
-            end
-
-          has_remote_mask = Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK
-          is_remote_mask = Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK
-
-          flags = base_flags_int | has_remote_mask
-          flags |= is_remote_mask if parent_span_is_remote
-          flags
-        end
 
         def http_connection(uri, ssl_verify_mode, certificate_file, client_certificate_file, client_key_file)
           http = Net::HTTP.new(uri.hostname, uri.port)
@@ -293,32 +274,9 @@ module OpenTelemetry
           true
         end
 
-        def encode(span_data) # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
+        def encode(span_data)
           start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-          Opentelemetry::Proto::Collector::Trace::V1::ExportTraceServiceRequest.encode(
-            Opentelemetry::Proto::Collector::Trace::V1::ExportTraceServiceRequest.new(
-              resource_spans: span_data
-                              .group_by(&:resource)
-                              .map do |resource, span_datas|
-                                Opentelemetry::Proto::Trace::V1::ResourceSpans.new(
-                                  resource: Opentelemetry::Proto::Resource::V1::Resource.new(
-                                    attributes: resource.attribute_enumerator.map { |key, value| as_otlp_key_value(key, value) }
-                                  ),
-                                  scope_spans: span_datas
-                                               .group_by(&:instrumentation_scope)
-                                               .map do |il, sds|
-                                                 Opentelemetry::Proto::Trace::V1::ScopeSpans.new(
-                                                   scope: Opentelemetry::Proto::Common::V1::InstrumentationScope.new(
-                                                     name: il.name,
-                                                     version: il.version
-                                                   ),
-                                                   spans: sds.map { |sd| as_otlp_span(sd) }
-                                                 )
-                                               end
-                                )
-                              end
-            )
-          )
+          OpenTelemetry::Exporter::OTLP::Common.as_encoded_etsr(span_data)
         rescue StandardError => e
           OpenTelemetry.handle_error(exception: e, message: 'unexpected error in OTLP::Exporter#encode')
           nil
@@ -327,93 +285,6 @@ module OpenTelemetry
           duration_ms = 1000.0 * (stop - start)
           @metrics_reporter.record_value('otel.otlp_exporter.encode_duration',
                                          value: duration_ms)
-        end
-
-        def as_otlp_span(span_data) # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-          Opentelemetry::Proto::Trace::V1::Span.new(
-            trace_id: span_data.trace_id,
-            span_id: span_data.span_id,
-            trace_state: span_data.tracestate.to_s,
-            parent_span_id: span_data.parent_span_id == OpenTelemetry::Trace::INVALID_SPAN_ID ? nil : span_data.parent_span_id,
-            name: span_data.name,
-            kind: as_otlp_span_kind(span_data.kind),
-            start_time_unix_nano: span_data.start_timestamp,
-            end_time_unix_nano: span_data.end_timestamp,
-            attributes: span_data.attributes&.map { |k, v| as_otlp_key_value(k, v) },
-            dropped_attributes_count: span_data.total_recorded_attributes - span_data.attributes&.size.to_i,
-            events: span_data.events&.map do |event|
-              Opentelemetry::Proto::Trace::V1::Span::Event.new(
-                time_unix_nano: event.timestamp,
-                name: event.name,
-                attributes: event.attributes&.map { |k, v| as_otlp_key_value(k, v) }
-                # TODO: track dropped_attributes_count in Span#append_event
-              )
-            end,
-            dropped_events_count: span_data.total_recorded_events - span_data.events&.size.to_i,
-            links: span_data.links&.map do |link|
-              Opentelemetry::Proto::Trace::V1::Span::Link.new(
-                trace_id: link.span_context.trace_id,
-                span_id: link.span_context.span_id,
-                trace_state: link.span_context.tracestate.to_s,
-                attributes: link.attributes&.map { |k, v| as_otlp_key_value(k, v) },
-                # TODO: track dropped_attributes_count in Span#trim_links
-                flags: build_span_flags(link.span_context.remote?, link.span_context.trace_flags)
-              )
-            end,
-            dropped_links_count: span_data.total_recorded_links - span_data.links&.size.to_i,
-            status: span_data.status&.then do |status|
-              Opentelemetry::Proto::Trace::V1::Status.new(
-                code: as_otlp_status_code(status.code),
-                message: status.description
-              )
-            end,
-            flags: build_span_flags(span_data.parent_span_is_remote, span_data.trace_flags)
-          )
-        end
-
-        def as_otlp_status_code(code)
-          case code
-          when OpenTelemetry::Trace::Status::OK then Opentelemetry::Proto::Trace::V1::Status::StatusCode::STATUS_CODE_OK
-          when OpenTelemetry::Trace::Status::ERROR then Opentelemetry::Proto::Trace::V1::Status::StatusCode::STATUS_CODE_ERROR
-          else Opentelemetry::Proto::Trace::V1::Status::StatusCode::STATUS_CODE_UNSET
-          end
-        end
-
-        def as_otlp_span_kind(kind)
-          case kind
-          when :internal then Opentelemetry::Proto::Trace::V1::Span::SpanKind::SPAN_KIND_INTERNAL
-          when :server then Opentelemetry::Proto::Trace::V1::Span::SpanKind::SPAN_KIND_SERVER
-          when :client then Opentelemetry::Proto::Trace::V1::Span::SpanKind::SPAN_KIND_CLIENT
-          when :producer then Opentelemetry::Proto::Trace::V1::Span::SpanKind::SPAN_KIND_PRODUCER
-          when :consumer then Opentelemetry::Proto::Trace::V1::Span::SpanKind::SPAN_KIND_CONSUMER
-          else Opentelemetry::Proto::Trace::V1::Span::SpanKind::SPAN_KIND_UNSPECIFIED
-          end
-        end
-
-        def as_otlp_key_value(key, value)
-          Opentelemetry::Proto::Common::V1::KeyValue.new(key: key, value: as_otlp_any_value(value))
-        rescue Encoding::UndefinedConversionError => e
-          encoded_value = value.encode('UTF-8', invalid: :replace, undef: :replace, replace: '�')
-          OpenTelemetry.handle_error(exception: e, message: "encoding error for key #{key} and value #{encoded_value}")
-          Opentelemetry::Proto::Common::V1::KeyValue.new(key: key, value: as_otlp_any_value('Encoding Error'))
-        end
-
-        def as_otlp_any_value(value)
-          result = Opentelemetry::Proto::Common::V1::AnyValue.new
-          case value
-          when String
-            result.string_value = value
-          when Integer
-            result.int_value = value
-          when Float
-            result.double_value = value
-          when true, false
-            result.bool_value = value
-          when Array
-            values = value.map { |element| as_otlp_any_value(element) }
-            result.array_value = Opentelemetry::Proto::Common::V1::ArrayValue.new(values: values)
-          end
-          result
         end
 
         def prepare_endpoint(endpoint)

--- a/exporter/otlp/opentelemetry-exporter-otlp.gemspec
+++ b/exporter/otlp/opentelemetry-exporter-otlp.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'google-protobuf', '>= 3.18'
   spec.add_dependency 'opentelemetry-api', '~> 1.1'
   spec.add_dependency 'opentelemetry-common', '~> 0.20'
+  spec.add_dependency 'opentelemetry-exporter-otlp-common'
   spec.add_dependency 'opentelemetry-sdk', '~> 1.10'
   spec.add_dependency 'opentelemetry-semantic_conventions'
 

--- a/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
+++ b/exporter/otlp/test/opentelemetry/exporter/otlp/exporter_test.rb
@@ -562,7 +562,7 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       end
 
       _(log_stream.string).must_match(
-        /ERROR -- : OpenTelemetry error: unexpected error in OTLP::Exporter#encode - a little hell/
+        /ERROR -- : OpenTelemetry error: unexpected error in OTLP::Common#as_encoded_etsr - a little hell/
       )
     ensure
       OpenTelemetry.logger = logger
@@ -907,138 +907,6 @@ describe OpenTelemetry::Exporter::OTLP::Exporter do
       assert_requested(:post, 'http://localhost:4318/v1/traces') do |req|
         Zlib.gunzip(req.body) == encoded_etsr
       end
-    end
-  end
-
-  describe 'span flags' do
-    let(:exporter) { OpenTelemetry::Exporter::OTLP::Exporter.new }
-    let(:trace_id) { OpenTelemetry::Trace.generate_trace_id }
-    let(:span_id) { OpenTelemetry::Trace.generate_span_id }
-    let(:parent_span_id) { OpenTelemetry::Trace.generate_span_id }
-    let(:resource) { OpenTelemetry::SDK::Resources::Resource.create('service.name' => 'test-service') }
-    let(:instrumentation_scope) { OpenTelemetry::SDK::InstrumentationScope.new('test-lib', '1.0.0') }
-
-    describe 'build_span_flags' do
-      it 'sets flags to HAS_IS_REMOTE for local parent span context' do
-        flags = exporter.send(:build_span_flags, false, OpenTelemetry::Trace::TraceFlags::DEFAULT)
-        _(flags).must_equal(
-          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK
-        )
-      end
-
-      it 'sets flags to HAS_IS_REMOTE | IS_REMOTE for remote parent span context' do
-        flags = exporter.send(:build_span_flags, true, OpenTelemetry::Trace::TraceFlags::DEFAULT)
-        _(flags).must_equal(
-          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK |
-          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK
-        )
-      end
-
-      it 'preserves base trace flags' do
-        flags = exporter.send(:build_span_flags, false, OpenTelemetry::Trace::TraceFlags::SAMPLED)
-        _(flags).must_equal(
-          0x01 |
-          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK
-        )
-      end
-    end
-
-    describe 'as_otlp_span with flags' do
-      it 'sets flags to HAS_IS_REMOTE for local parent span context' do
-        span_data = create_span_data(parent_span_is_remote: false)
-        span = exporter.send(:as_otlp_span, span_data)
-        _(span.flags).must_equal(
-          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK
-        )
-      end
-
-      it 'sets flags to HAS_IS_REMOTE | IS_REMOTE for remote parent span context' do
-        span_data = create_span_data(parent_span_is_remote: true)
-        span = exporter.send(:as_otlp_span, span_data)
-        _(span.flags).must_equal(
-          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK |
-          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK
-        )
-      end
-    end
-
-    describe 'as_otlp_span with link flags' do
-      it 'sets link flags to HAS_IS_REMOTE for local link context' do
-        local_span_context = OpenTelemetry::Trace::SpanContext.new(trace_id: trace_id, span_id: parent_span_id, remote: false)
-        local_link = create_link(local_span_context)
-        span_data = create_span_data(links: [local_link])
-        span = exporter.send(:as_otlp_span, span_data)
-        _(span.links.first.flags).must_equal(
-          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK
-        )
-      end
-
-      it 'sets link flags to HAS_IS_REMOTE | IS_REMOTE for remote link context' do
-        remote_span_context = OpenTelemetry::Trace::SpanContext.new(trace_id: trace_id, span_id: parent_span_id, remote: true)
-        remote_link = create_link(remote_span_context)
-        span_data = create_span_data(links: [remote_link])
-        span = exporter.send(:as_otlp_span, span_data)
-        _(span.links.first.flags).must_equal(
-          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK |
-          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK
-        )
-      end
-    end
-
-    describe 'export with flags' do
-      it 'includes flags in exported spans' do
-        span_data = create_span_data(parent_span_is_remote: true)
-        encoded_data = exporter.send(:encode, [span_data])
-        decoded = Opentelemetry::Proto::Collector::Trace::V1::ExportTraceServiceRequest.decode(encoded_data)
-        exported_span = decoded.resource_spans.first.scope_spans.first.spans.first
-        _(exported_span.flags).must_equal(
-          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK |
-          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK
-        )
-      end
-
-      it 'includes flags in exported links' do
-        remote_span_context = OpenTelemetry::Trace::SpanContext.new(trace_id: trace_id, span_id: parent_span_id, remote: true)
-        remote_link = create_link(remote_span_context)
-        span_data = create_span_data(links: [remote_link])
-        encoded_data = exporter.send(:encode, [span_data])
-        decoded = Opentelemetry::Proto::Collector::Trace::V1::ExportTraceServiceRequest.decode(encoded_data)
-        exported_link = decoded.resource_spans.first.scope_spans.first.spans.first.links.first
-        _(exported_link.flags).must_equal(
-          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_HAS_IS_REMOTE_MASK |
-          Opentelemetry::Proto::Trace::V1::SpanFlags::SPAN_FLAGS_CONTEXT_IS_REMOTE_MASK
-        )
-      end
-    end
-
-    private
-
-    def create_span_data(parent_span_is_remote: false, links: [])
-      OpenTelemetry::SDK::Trace::SpanData.new(
-        'test-span',                    # name
-        :internal,                      # kind
-        OpenTelemetry::Trace::Status.ok, # status
-        parent_span_id, # parent_span_id
-        0,                             # total_recorded_attributes
-        0,                             # total_recorded_events
-        links.size,                    # total_recorded_links
-        Time.now.to_i * 1_000_000_000, # start_timestamp
-        Time.now.to_i * 1_000_000_000, # end_timestamp
-        {},                            # attributes
-        links,                         # links
-        [],                            # events
-        resource,                      # resource
-        instrumentation_scope,         # instrumentation_scope
-        span_id,                       # span_id
-        trace_id,                      # trace_id
-        OpenTelemetry::Trace::TraceFlags::DEFAULT, # trace_flags
-        OpenTelemetry::Trace::Tracestate::DEFAULT, # tracestate
-        parent_span_is_remote # parent_span_is_remote
-      )
-    end
-
-    def create_link(span_context)
-      OpenTelemetry::Trace::Link.new(span_context, { 'link-attribute' => 'link-value' })
     end
   end
 end


### PR DESCRIPTION
This ensures that the otlp exporter uses the common encoder which now has the flags functionality which was missing.