### PR TITLE
fix: Remove config argument from compatible?

### DIFF
--- a/registry/lib/opentelemetry/instrumentation/registry.rb
+++ b/registry/lib/opentelemetry/instrumentation/registry.rb
@@ -81,7 +81,7 @@ module OpenTelemetry
           OpenTelemetry.logger.info "Instrumentation: #{instrumentation.name} was successfully installed with the following options #{instrumentation.config}"
         elsif !instrumentation.enabled?(config)
           OpenTelemetry.logger.info "Instrumentation: #{instrumentation.name} was not installed because it is not enabled"
-        elsif !instrumentation.compatible?(config)
+        elsif !instrumentation.compatible?
           OpenTelemetry.logger.warn "Instrumentation: #{instrumentation.name} failed to install: compatibility issue"
         else
           OpenTelemetry.logger.warn "Instrumentation: #{instrumentation.name} failed to install"

--- a/registry/test/opentelemetry/instrumentation/registry_test.rb
+++ b/registry/test/opentelemetry/instrumentation/registry_test.rb
@@ -42,7 +42,7 @@ class FakeInstrumentation
 
   def install(config)
     # lets branches in the install_instrumentation method that occur after
-    # the install check to be evaluted (ex. enabled?, compatible?)
+    # the install check be evaluated (ex. enabled?, compatible?)
     return false unless @installable
 
     @install = true

--- a/registry/test/opentelemetry/instrumentation/registry_test.rb
+++ b/registry/test/opentelemetry/instrumentation/registry_test.rb
@@ -9,12 +9,15 @@ require 'test_helper'
 class FakeInstrumentation
   attr_reader :name, :version, :config
 
-  def initialize(name, version, present: true)
+  def initialize(name, version, present: true, enabled: true, compatible: true, installable: true)
     @name = name
     @version = version
     @install = false
     @config = nil
     @present = present
+    @enabled = enabled
+    @compatible = compatible
+    @installable = installable
   end
 
   def instance
@@ -29,7 +32,19 @@ class FakeInstrumentation
     @install == true
   end
 
+  def enabled?(_config = nil)
+    @enabled
+  end
+
+  def compatible?
+    @compatible
+  end
+
   def install(config)
+    # lets branches in the install_instrumentation method that occur after
+    # the install check to be evaluted (ex. enabled?, compatible?)
+    return false unless @installable
+
     @install = true
     @config = config
   end
@@ -170,6 +185,78 @@ describe OpenTelemetry::Instrumentation::Registry do
 
         _(instrumentation2).must_be :installed?
         _(instrumentation2.config).must_equal(b: 'b')
+      end
+    end
+
+    describe 'given an instrumentation that is not present' do
+      let(:instrumentation1) do
+        FakeInstrumentation.new('TestInstrumentation1', '0.1.1', present: false)
+      end
+
+      before do
+        @log_stream = StringIO.new
+        OpenTelemetry.logger = ::Logger.new(@log_stream)
+      end
+
+      it 'skips install and logs a debug message' do
+        registry.install(%w[TestInstrumentation1])
+
+        _(instrumentation1).wont_be :installed?
+        _(@log_stream.string).must_match(/TestInstrumentation1 skipping install given corresponding dependency not found/)
+      end
+    end
+
+    describe 'given an instrumentation that is not enabled' do
+      let(:instrumentation1) do
+        FakeInstrumentation.new('TestInstrumentation1', '0.1.1', installable: false, enabled: false)
+      end
+
+      before do
+        @log_stream = StringIO.new
+        OpenTelemetry.logger = ::Logger.new(@log_stream)
+      end
+
+      it 'does not install and logs that it was not enabled' do
+        registry.install(%w[TestInstrumentation1])
+
+        _(instrumentation1).wont_be :installed?
+        _(@log_stream.string).must_match(/TestInstrumentation1 was not installed because it is not enabled/)
+      end
+    end
+
+    describe 'given an instrumentation that is not compatible' do
+      let(:instrumentation1) do
+        FakeInstrumentation.new('TestInstrumentation1', '0.1.1', installable: false, enabled: true, compatible: false)
+      end
+
+      before do
+        @log_stream = StringIO.new
+        OpenTelemetry.logger = ::Logger.new(@log_stream)
+      end
+
+      it 'does not install and logs a compatibility issue' do
+        registry.install(%w[TestInstrumentation1])
+
+        _(instrumentation1).wont_be :installed?
+        _(@log_stream.string).must_match(/TestInstrumentation1 failed to install: compatibility issue/)
+      end
+    end
+
+    describe 'given an instrumentation that fails to install for an unknown reason' do
+      let(:instrumentation1) do
+        FakeInstrumentation.new('TestInstrumentation1', '0.1.1', installable: false, enabled: true, compatible: true)
+      end
+
+      before do
+        @log_stream = StringIO.new
+        OpenTelemetry.logger = ::Logger.new(@log_stream)
+      end
+
+      it 'does not install and logs a generic failure' do
+        registry.install(%w[TestInstrumentation1])
+
+        _(instrumentation1).wont_be :installed?
+        _(@log_stream.string).must_match(/Instrumentation: TestInstrumentation1 failed to install\n/)
       end
     end
   end


### PR DESCRIPTION
[The `compatible?` method does not have any arguments.](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/3638a0de9961aa43bbb90e460d4640852eb206d6/instrumentation/base/lib/opentelemetry/instrumentation/base.rb#L246-L252)

Tested by locally installing the API, SDK, and Registry gems and then running the `releases/run.sh` script with a binding.irb breakpoint on the SDK#configure rescue to get a look at the real error.

Resolves: #2252 

This PR also improves the tests for the registry to include cases for each branch in the `install_instrumentation` method.