### PR TITLE
chore: Add condition for PR title spelling check

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -52,6 +52,7 @@ jobs:
         run: |
           echo "Title: $TITLE" > pr_title.md
       - name: Check PR Title spelling
+        if: ${{ steps.lint_pr_title.outputs.scope != 'deps' }}
         uses: streetsidesoftware/cspell-action@de2a73e963e7443969755b648a1008f77033c5b2 # v8.4.0
         with:
           config: .cspell.yml


### PR DESCRIPTION
This skips spell checking pr titles when the scope of the pr is ‘deps’ as done by renovate/dependabot