### PR TITLE
feat: Add attributes to Meter InstrumentationScope

### DIFF
--- a/metrics_api/lib/opentelemetry/internal/proxy_meter_provider.rb
+++ b/metrics_api/lib/opentelemetry/internal/proxy_meter_provider.rb
@@ -13,7 +13,7 @@ module OpenTelemetry
     # It delegates to a "real" MeterProvider after the global meter provider is registered.
     # It returns {ProxyMeter} instances until the delegate is installed.
     class ProxyMeterProvider < Metrics::MeterProvider
-      Key = Struct.new(:name, :version)
+      Key = Struct.new(:name, :version, :attributes)
       private_constant(:Key)
 
       # Returns a new {ProxyMeterProvider} instance.
@@ -43,15 +43,17 @@ module OpenTelemetry
 
       # Returns a {Meter} instance.
       #
-      # @param [optional String] name Instrumentation package name
-      # @param [optional String] version Instrumentation package version
+      # @param [optional String] name Instrumentation scope name
+      # @param [optional String] version Instrumentation scope version
+      # @param [optional Hash{String => String, Numeric, Boolean, Array<String, Numeric, Boolean>}] attributes
+      #   Instrumentation scope attributes
       #
       # @return [Meter]
-      def meter(name = nil, version: nil)
+      def meter(name = nil, version: nil, attributes: nil)
         @mutex.synchronize do
-          return @delegate.meter(name, version: version) unless @delegate.nil?
+          return @delegate.meter(name, version: version, attributes: attributes) unless @delegate.nil?
 
-          @registry[Key.new(name, version)] ||= ProxyMeter.new
+          @registry[Key.new(name, version, attributes)] ||= ProxyMeter.new
         end
       end
     end

--- a/metrics_api/lib/opentelemetry/metrics/meter_provider.rb
+++ b/metrics_api/lib/opentelemetry/metrics/meter_provider.rb
@@ -10,11 +10,13 @@ module OpenTelemetry
     class MeterProvider
       # Returns a {Meter} instance.
       #
-      # @param [String] name Instrumentation package name
-      # @param [optional String] version Instrumentation package version
+      # @param [String] name Instrumentation scope name
+      # @param [optional String] version Instrumentation scope version
+      # @param [optional Hash{String => String, Numeric, Boolean, Array<String, Numeric, Boolean>}] attributes
+      #   Instrumentation scope attributes
       #
       # @return [Meter]
-      def meter(name, version: nil)
+      def meter(name, version: nil, attributes: nil)
         @meter ||= Meter.new
       end
     end

--- a/metrics_api/test/opentelemetry/metrics/meter_provider_test.rb
+++ b/metrics_api/test/opentelemetry/metrics/meter_provider_test.rb
@@ -14,6 +14,28 @@ describe OpenTelemetry::Metrics::MeterProvider do
       _(-> { meter_provider.meter }).must_raise(ArgumentError)
     end
 
+    it 'optionally accepts a version' do
+      meter_provider = build_meter_provider
+      meter = meter_provider.meter('name', version: '1.0')
+
+      _(meter).must_be_instance_of(OpenTelemetry::Metrics::Meter)
+    end
+
+    it 'optionally accepts attributes' do
+      meter_provider = build_meter_provider
+      meter = meter_provider.meter('name', attributes: { 'key' => 'value' })
+
+      _(meter).must_be_instance_of(OpenTelemetry::Metrics::Meter)
+    end
+
+    it 'treats nil attributes the same as no attributes' do
+      meter_provider = build_meter_provider
+      meter1 = meter_provider.meter('name')
+      meter2 = meter_provider.meter('name', attributes: nil)
+
+      _(meter1).must_equal(meter2)
+    end
+
     it 'returns an instance of Meter' do
       meter_provider = build_meter_provider
 

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/meter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/meter.rb
@@ -17,14 +17,16 @@ module OpenTelemetry
         #
         # Returns a new {Meter} instance.
         #
-        # @param [String] name Instrumentation package name
-        # @param [String] version Instrumentation package version
+        # @param [String] name Instrumentation scope name
+        # @param [String] version Instrumentation scope version
+        # @param [optional Hash{String => String, Numeric, Boolean, Array<String, Numeric, Boolean>}] attributes
+        #   Instrumentation scope attributes
         #
         # @return [Meter]
-        def initialize(name, version, meter_provider)
+        def initialize(name, version, meter_provider, attributes: nil)
           @mutex = Mutex.new
           @instrument_registry = {}
-          @instrumentation_scope = InstrumentationScope.new(name, version)
+          @instrumentation_scope = InstrumentationScope.new(name, version, attributes || {}.freeze)
           @meter_provider = meter_provider
         end
 

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/meter_provider.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/meter_provider.rb
@@ -12,7 +12,9 @@ module OpenTelemetry
       # {MeterProvider} is the SDK implementation of {OpenTelemetry::Metrics::MeterProvider}.
       # rubocop:disable Metrics/ClassLength
       class MeterProvider < OpenTelemetry::Metrics::MeterProvider
-        Key = Struct.new(:name, :version)
+        EMPTY_ATTRIBUTES = {}.freeze
+
+        Key = Struct.new(:name, :version, :attributes)
         private_constant(:Key)
 
         attr_reader :resource, :metric_readers, :registered_views, :exemplar_filter
@@ -29,18 +31,23 @@ module OpenTelemetry
 
         # Returns a {Meter} instance.
         #
-        # @param [String] name Instrumentation package name
-        # @param [optional String] version Instrumentation package version
+        # @param [String] name Instrumentation scope name
+        # @param [optional String] version Instrumentation scope version
+        # @param [optional Hash{String => String, Numeric, Boolean, Array<String, Numeric, Boolean>}] attributes
+        #   Instrumentation scope attributes
         #
         # @return [Meter]
-        def meter(name, version: nil)
+        def meter(name, version: nil, attributes: nil)
           version ||= ''
+          # TODO: DO we need to check attributes here?
+          attributes = attributes&.dup&.freeze || EMPTY_ATTRIBUTES
+
           if @stopped
             OpenTelemetry.logger.warn 'calling MeterProvider#meter after shutdown, a noop meter will be returned.'
             OpenTelemetry::Metrics::Meter.new
           else
             OpenTelemetry.logger.warn "Invalid meter name provided: #{name.nil? ? 'nil' : 'empty'} value" if name.to_s.empty?
-            @mutex.synchronize { @meter_registry[Key.new(name, version)] ||= Meter.new(name, version, self) }
+            @mutex.synchronize { @meter_registry[Key.new(name, version, attributes)] ||= Meter.new(name, version, self, attributes: attributes) }
           end
         end
 

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/meter_provider.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/meter_provider.rb
@@ -39,7 +39,6 @@ module OpenTelemetry
         # @return [Meter]
         def meter(name, version: nil, attributes: nil)
           version ||= ''
-          # TODO: DO we need to check attributes here?
           attributes = attributes&.dup&.freeze || EMPTY_ATTRIBUTES
 
           if @stopped

--- a/metrics_sdk/opentelemetry-metrics-sdk.gemspec
+++ b/metrics_sdk/opentelemetry-metrics-sdk.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'opentelemetry-api', '~> 1.1'
   spec.add_dependency 'opentelemetry-metrics-api', '~> 0.2'
-  spec.add_dependency 'opentelemetry-sdk', '~> 1.2'
+  spec.add_dependency 'opentelemetry-sdk', '~> 1.13.0'
 
   if spec.respond_to?(:metadata)
     spec.metadata['changelog_uri'] = "https://rubydoc.info/gems/#{spec.name}/#{spec.version}/file/CHANGELOG.md"

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/meter_provider_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/meter_provider_test.rb
@@ -33,6 +33,49 @@ describe OpenTelemetry::SDK::Metrics::MeterProvider do
 
       _(meter_a).must_equal(meter_b)
     end
+
+    it 'accepts attributes' do
+      meter = OpenTelemetry.meter_provider.meter('test', attributes: { 'key' => 'value' })
+
+      _(meter).must_be_instance_of(OpenTelemetry::SDK::Metrics::Meter)
+    end
+
+    it 'returns the same meter for the same name, version, and attributes' do
+      meter_a = OpenTelemetry.meter_provider.meter('test', version: '1.0', attributes: { 'key' => 'value' })
+      meter_b = OpenTelemetry.meter_provider.meter('test', version: '1.0', attributes: { 'key' => 'value' })
+
+      _(meter_a).must_equal(meter_b)
+    end
+
+    it 'returns different meters for different attributes' do
+      meter_a = OpenTelemetry.meter_provider.meter('test', attributes: { 'key' => 'value1' })
+      meter_b = OpenTelemetry.meter_provider.meter('test', attributes: { 'key' => 'value2' })
+
+      _(meter_a).wont_equal(meter_b)
+    end
+
+    it 'returns different meters for attributes vs no attributes' do
+      meter_a = OpenTelemetry.meter_provider.meter('test')
+      meter_b = OpenTelemetry.meter_provider.meter('test', attributes: { 'key' => 'value' })
+
+      _(meter_a).wont_equal(meter_b)
+    end
+
+    it 'treats nil attributes the same as no attributes' do
+      meter_a = OpenTelemetry.meter_provider.meter('test')
+      meter_b = OpenTelemetry.meter_provider.meter('test', attributes: nil)
+
+      _(meter_a).must_equal(meter_b)
+    end
+
+    it 'does not allow mutation of attributes after meter creation' do
+      attrs = { 'key' => 'value' }
+      meter_a = OpenTelemetry.meter_provider.meter('test', attributes: attrs)
+      attrs['key'] = 'mutated'
+      meter_b = OpenTelemetry.meter_provider.meter('test', attributes: { 'key' => 'value' })
+
+      _(meter_a).must_equal(meter_b)
+    end
   end
 
   describe '#shutdown' do

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/meter_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/meter_test.rb
@@ -11,6 +11,49 @@ describe OpenTelemetry::SDK::Metrics::Meter do
 
   let(:meter) { OpenTelemetry.meter_provider.meter('new_meter') }
 
+  describe 'instrumentation scope attributes' do
+    let(:metric_exporter) { OpenTelemetry::SDK::Metrics::Export::InMemoryMetricPullExporter.new }
+
+    before do
+      reset_metrics_sdk
+      OpenTelemetry::SDK.configure
+      OpenTelemetry.meter_provider.add_metric_reader(metric_exporter)
+    end
+
+    it 'creates a meter with empty attributes by default' do
+      OpenTelemetry.meter_provider.meter('test').create_counter('a_counter').add(1)
+
+      metric_exporter.pull
+      _(metric_exporter.metric_snapshots[0].instrumentation_scope.attributes).must_equal({})
+    end
+
+    it 'normalizes nil attributes to empty hash' do
+      OpenTelemetry.meter_provider.meter('test', attributes: nil).create_counter('a_counter').add(1)
+
+      metric_exporter.pull
+      _(metric_exporter.metric_snapshots[0].instrumentation_scope.attributes).must_equal({})
+    end
+
+    it 'creates a meter with attributes' do
+      attrs = { 'key' => 'value' }
+      OpenTelemetry.meter_provider.meter('test', attributes: attrs).create_counter('a_counter').add(1)
+
+      metric_exporter.pull
+      _(metric_exporter.metric_snapshots[0].instrumentation_scope.attributes).must_equal(attrs)
+    end
+
+    it 'propagates attributes through to exported metric data' do
+      attrs = { 'key' => 'value' }
+      OpenTelemetry.meter_provider.meter('test', version: '1.0', attributes: attrs).create_counter('a_counter').add(1)
+
+      metric_exporter.pull
+      snapshot = metric_exporter.metric_snapshots[0]
+      _(snapshot.instrumentation_scope.name).must_equal('test')
+      _(snapshot.instrumentation_scope.version).must_equal('1.0')
+      _(snapshot.instrumentation_scope.attributes).must_equal(attrs)
+    end
+  end
+
   describe '#create_counter' do
     it 'creates a counter instrument' do
       instrument = meter.create_counter('a_counter', unit: 'minutes', description: 'useful description')


### PR DESCRIPTION
Following the pattern in #2094, add attributes to the MeterProvider#meter method and the instrumentation scope associated with a Meter.

This will hopefully allow us to quiet the unnecessary release with something that has a related feature.