### PR TITLE
chore: Filter metric names to exclude refinements

### DIFF
--- a/.github/workflows/ci-semconv.yml
+++ b/.github/workflows/ci-semconv.yml
@@ -7,6 +7,8 @@ on:
       - '.github/workflows/ci-semconv.yml'
       - 'semantic_conventions/compose.yml'
       - 'semantic_conventions/Rakefile'
+      - 'semantic_conventions/lib/**'
+      - 'semantic_conventions/templates/**'
     branches:
       - main
 
@@ -76,6 +78,7 @@ jobs:
         if: ${{ steps.changes.outputs.spec_version == 'false' && steps.changes.outputs.files == 'true' }}
         run: |
           git diff --cached
+          echo "::error:: The semantic convention files are out of date. If the file changes are intended, commit the updated files locally."
           return 1
 
       - name: Commit and push changes

--- a/semantic_conventions/templates/registry/ruby/weaver.yaml
+++ b/semantic_conventions/templates/registry/ruby/weaver.yaml
@@ -20,6 +20,9 @@ templates:
         "exclude_root_namespace": $excluded_namespaces,
         "exclude_stability": ["experimental", "deprecated"],
         "exclude_deprecated": false
+      })| map({
+          root_namespace: .root_namespace,
+          metrics: [.metrics[] | select(.id == ("metric." + .metric_name))]
       })
     file_name: "{{ctx.root_namespace | snake_case}}/metrics.rb"
   # incubating
@@ -41,6 +44,9 @@ templates:
         "exclude_root_namespace": $excluded_namespaces,
         "exclude_stability": [],
         "exclude_deprecated": false
+      })| map({
+          root_namespace: .root_namespace,
+          metrics: [.metrics[] | select(.id == ("metric." + .metric_name))]
       })
     file_name: "incubating/{{ctx.root_namespace | snake_case}}/metrics.rb"
     params:


### PR DESCRIPTION
Add an additional filter to work around refinements in v1 syntax as done in java.

The build issue is resolved as per https://github.com/open-telemetry/opentelemetry-ruby/actions/runs/31070825398/job/92518231737