### PR TITLE
chore: cleanup docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,19 +14,11 @@ x-shared-config:
       - bundle:/bundle
 
 services:
-  api:
-    <<: *base
-    working_dir: /app/api
-
   app:
     <<: *base
     build:
       context: .
     working_dir: /app
-
-  sdk:
-    <<: *base
-    working_dir: /app/sdk
 
 volumes:
   bundle:


### PR DESCRIPTION
Removed api and sdk services from docker-compose as they serve no benefit given they don’t require any services or setting changes to the base app.