### PR TITLE
ci: Sync Renovate configuration from contrib

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -145,7 +145,7 @@
       managerFilePatterns: ["**/Appraisals"],
       matchStrings: [
         "gem\\s'(?<packageName>.+?)',\\s'(?<depVersion>.+\\s[0-9.]+)'",
-        "\\n\\s%w\\[([0-9.]+\\s)+(?<depVersion>[0-9.]+)\\].+\\n.+\\n\\s+gem\\s'(?<packageName>.+?)', \"~> #{version}\"",
+        "\\n\\s*?%w\\[([0-9.]+\\s)+(?<depVersion>[0-9.]+)\\].+\\n.+\\n\\s+gem\\s'(?<packageName>.+?)', \"~> #{version}\"",
       ],
       datasourceTemplate: "rubygems",
       versioningTemplate: "ruby",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -144,7 +144,7 @@
       description: "Update dependencies in Appraisals",
       managerFilePatterns: ["**/Appraisals"],
       matchStrings: [
-        "gem\\s'(?<packageName>.+?)',\\s'(?<depVersion>.+\\s[0-9.]+)'",
+        "gem\\s'(?<packageName>.+?)',\\s'(?<depVersion>=\\s[0-9.]+)'",
         "\\n\\s*?%w\\[([0-9.]+\\s)+(?<depVersion>[0-9.]+)\\].+\\n.+\\n\\s+gem\\s'(?<packageName>.+?)', \"~> #{version}\"",
       ],
       datasourceTemplate: "rubygems",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,21 +16,41 @@
   prHourlyLimit: 12,
   packageRules: [
     {
-      groupName: "all patch versions",
-      matchDepNames: ["!ruby"],
-      matchUpdateTypes: ["patch"],
+      groupName: "all [patches]",
+      matchDepNames: ["!ruby", "!renovate"],
+      matchUpdateTypes: ["patch", "digest"],
       schedule: ["before 6am every weekday"],
     },
     {
-      groupName: "all digest versions",
-      matchDepNames: ["!ruby"],
-      matchUpdateTypes: ["digest"],
-      schedule: ["before 6am every weekday"],
+      groupName: "infra [minor]",
+      matchCategories: ["ci", "docker", "js"],
+      matchDepNames: [
+        "!ruby",
+        "!markdownlint-cli2",
+        "!setup-ruby",
+        "!confluentinc/cp-kafka",
+      ],
+      matchUpdateTypes: ["minor"],
+      schedule: ["before 7am on Monday"],
+    },
+    {
+      groupName: "infra [minor]",
+      matchCategories: ["js"],
+      matchDepNames: ["renovate"],
+      matchUpdateTypes: ["patch", "digest"],
+      schedule: ["before 7am on Monday"],
     },
     {
       matchDepNames: ["ruby"],
       matchUpdateTypes: ["digest", "patch"],
       schedule: ["before 6am every weekday"],
+    },
+    {
+      groupName: "test dependencies [minor]",
+      matchUpdateTypes: ["minor"],
+      matchDatasources: ["rubygems"],
+      matchDepTypes: ["testDependency"],
+      schedule: ["before 7am on Monday"],
     },
     {
       description: "Separate ruby updates so that patches can be installed after new minor has been released.",
@@ -125,6 +145,7 @@
       managerFilePatterns: ["**/Appraisals"],
       matchStrings: [
         "gem\\s'(?<packageName>.+?)',\\s'(?<depVersion>.+\\s[0-9.]+)'",
+        "\\n\\s%w\\[([0-9.]+\\s)+(?<depVersion>[0-9.]+)\\].+\\n.+\\n\\s+gem\\s'(?<packageName>.+?)', \"~> #{version}\"",
       ],
       datasourceTemplate: "rubygems",
       versioningTemplate: "ruby",


### PR DESCRIPTION
This syncs the latest renovate rules from contrib which has resulted in a reduction in pr qty & added support for updating versions in appraisal arrays.