### PR TITLE
chore: Renovate updatable version array

### DIFF
--- a/exporter/otlp-logs/Appraisals
+++ b/exporter/otlp-logs/Appraisals
@@ -4,18 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-appraise 'google-protobuf-3.18.0' do
-  gem 'google-protobuf', '~> 3.18.0'
-end
-
-appraise 'google-protobuf-3.25.0' do
-  gem 'google-protobuf', '~> 3.25.0'
-end
-
-appraise 'google-protobuf-4.29.0' do
-  gem 'google-protobuf', '~> 4.29.0'
-end
-
-appraise 'google-protobuf-latest' do
-  gem 'google-protobuf'
+%w[3.18.0 3.25.0 4.29.0 4.36.0].each do |version|
+  appraise "google-protobuf-#{version}" do
+    gem 'google-protobuf', "~> #{version}"
+  end
 end

--- a/exporter/otlp-metrics/Appraisals
+++ b/exporter/otlp-metrics/Appraisals
@@ -10,3 +10,9 @@
     gem 'google-protobuf', "~> #{version}"
   end
 end
+
+%w[4.29.0 4.36.0].each do |version|
+  appraise "google-protobuf-#{version}" do
+    gem 'google-protobuf', "~> #{version}"
+  end
+end

--- a/exporter/otlp/Appraisals
+++ b/exporter/otlp/Appraisals
@@ -10,3 +10,9 @@
     gem 'google-protobuf', "~> #{version}"
   end
 end
+
+%w[4.29.0 4.36.0].each do |version|
+  appraise "google-protobuf-#{version}" do
+    gem 'google-protobuf', "~> #{version}"
+  end
+end


### PR DESCRIPTION
This switches the appraisal syntax to one which renovate could update going forward. No appraisals have been removed but some added.