### PR TITLE
chore: Set write permissions at job level

### DIFF
--- a/.github/workflows/ci-semconv.yml
+++ b/.github/workflows/ci-semconv.yml
@@ -13,11 +13,13 @@ on:
       - main
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   regenerate-semconv:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-24.04
     steps:
       - name: Create otelbot app token


### PR DESCRIPTION
This improves our openssf scorecard score by addressing the cause of us getting 0 for Token permissions.  See https://scorecard.dev/viewer/?uri=github.com/open-telemetry/opentelemetry-ruby

Note, having job permissions with write only limits us to a score of 9 like in contrib https://scorecard.dev/viewer/?uri=github.com/open-telemetry/opentelemetry-ruby-contrib