### PR TITLE
test: make dropped spans metrics test deterministic

### DIFF
--- a/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/export/batch_span_processor_test.rb
@@ -395,7 +395,8 @@ describe OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor do
       bsp = BatchSpanProcessor.new(exporter,
                                    metrics_reporter: metrics_reporter,
                                    max_queue_size: 1,
-                                   max_export_batch_size: 1)
+                                   max_export_batch_size: 1,
+                                   start_thread_on_boot: false)
 
       bsp.on_finish(TestSpan.new('dropped-because-buffer-full'))
       bsp.on_finish(TestSpan.new('causes-export-failure'))


### PR DESCRIPTION
The dropped spans metrics test can race with the worker thread and miss the queue overflow path. When that happens, the test only records the export failure metric and the label key assertion becomes nondeterministic.

This changes that example to construct BatchSpanProcessor with `start_thread_on_boot: false` so the test consistently exercises both dropped span reasons before shutdown flushes the remaining span.