### PR TITLE
feat: samplers are self sufficient

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/samplers.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/samplers.rb
@@ -81,8 +81,6 @@ module OpenTelemetry
         #   Must be within [0.0, 1.0].
         # @raise [ArgumentError] if ratio is out of range
         def self.trace_id_ratio_based(ratio)
-          raise ArgumentError, 'ratio must be in range [0.0, 1.0]' unless (0.0..1.0).cover?(ratio)
-
           TraceIdRatioBased.new(ratio)
         end
       end

--- a/sdk/lib/opentelemetry/sdk/trace/samplers/parent_based.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/samplers/parent_based.rb
@@ -18,12 +18,19 @@ module OpenTelemetry
         #   * Local parent (!SpanContext.remote? with trace_flags.sampled?)
         #   * Local parent (!SpanContext.remote? with !trace_flags.sampled?)
         class ParentBased
-          def initialize(root, remote_parent_sampled, remote_parent_not_sampled, local_parent_sampled, local_parent_not_sampled)
-            @root = root
-            @remote_parent_sampled = remote_parent_sampled
-            @remote_parent_not_sampled = remote_parent_not_sampled
-            @local_parent_sampled = local_parent_sampled
-            @local_parent_not_sampled = local_parent_not_sampled
+          def initialize(root = nil, remote_parent_sampled = nil, remote_parent_not_sampled = nil, local_parent_sampled = nil, local_parent_not_sampled = nil)
+            # rubocop:disable-next Lint/DuplicateBranch
+            @root = root ||
+                    case ENV.fetch('OTEL_TRACES_SAMPLER', 'parentbased_always_on')
+                    when 'parentbased_always_on' then Samplers::ALWAYS_ON
+                    when 'parentbased_always_off' then Samplers::ALWAYS_OFF
+                    when 'parentbased_traceidratio' then TraceIdRatioBased.new
+                    else Samplers::ALWAYS_ON
+                    end
+            @remote_parent_sampled = remote_parent_sampled || Samplers::ALWAYS_ON
+            @remote_parent_not_sampled = remote_parent_not_sampled || Samplers::ALWAYS_OFF
+            @local_parent_sampled = local_parent_sampled || Samplers::ALWAYS_ON
+            @local_parent_not_sampled = local_parent_not_sampled || Samplers::ALWAYS_OFF
           end
 
           def ==(other)

--- a/sdk/lib/opentelemetry/sdk/trace/samplers/trace_id_ratio_based.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/samplers/trace_id_ratio_based.rb
@@ -14,10 +14,12 @@ module OpenTelemetry
         class TraceIdRatioBased
           attr_reader :description
 
-          def initialize(probability)
-            @probability = probability
-            @id_upper_bound = (probability * ((2**64) - 1)).ceil
-            @description = format('TraceIdRatioBased{%.6f}', probability)
+          def initialize(probability = nil)
+            @probability = probability || Float(ENV.fetch('OTEL_TRACES_SAMPLER_ARG', 1.0))
+            raise ArgumentError, 'ratio must be in range [0.0, 1.0]' unless (0.0..1.0).cover?(@probability)
+
+            @id_upper_bound = (@probability * ((2**64) - 1)).ceil
+            @description = format('TraceIdRatioBased{%.6f}', @probability)
           end
 
           def ==(other)

--- a/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/tracer_provider.rb
@@ -29,7 +29,7 @@ module OpenTelemetry
         #   TracerProvider
         #
         # @return [TracerProvider]
-        def initialize(sampler: sampler_from_environment(Samplers.parent_based(root: Samplers::ALWAYS_ON)),
+        def initialize(sampler: sampler_from_environment,
                        resource: OpenTelemetry::SDK::Resources::Resource.create,
                        id_generator: OpenTelemetry::Trace,
                        span_limits: SpanLimits::DEFAULT)
@@ -184,17 +184,19 @@ module OpenTelemetry
 
         private
 
-        def sampler_from_environment(default_sampler)
-          case ENV.fetch('OTEL_TRACES_SAMPLER', nil)
+        # rubocop:disable-next Lint/DuplicateBranch
+        def sampler_from_environment
+          samplar = ENV.fetch('OTEL_TRACES_SAMPLER', 'parentbased')
+          samplar = 'parentbased' if samplar.start_with?('parentbased')
+          case samplar
           when 'always_on' then Samplers::ALWAYS_ON
           when 'always_off' then Samplers::ALWAYS_OFF
-          when 'traceidratio' then Samplers.trace_id_ratio_based(Float(ENV.fetch('OTEL_TRACES_SAMPLER_ARG', 1.0)))
-          when 'parentbased_always_on' then Samplers.parent_based(root: Samplers::ALWAYS_ON)
-          when 'parentbased_always_off' then Samplers.parent_based(root: Samplers::ALWAYS_OFF)
-          when 'parentbased_traceidratio' then Samplers.parent_based(root: Samplers.trace_id_ratio_based(Float(ENV.fetch('OTEL_TRACES_SAMPLER_ARG', 1.0))))
-          else default_sampler
+          when 'traceidratio' then Samplers::TraceIdRatioBased.new
+          when 'parentbased' then Samplers::ParentBased.new
+          else Samplers::ParentBased.new
           end
         rescue StandardError => e
+          default_sampler = Samplers::ParentBased.new(root: Samplers::ALWAYS_ON)
           OpenTelemetry.handle_error(exception: e, message: "installing default sampler #{default_sampler.description}")
           default_sampler
         end


### PR DESCRIPTION
The samplers are now responsible for obtaining their own config from the environment in cases where no config is supplied.

This makes trace provider only need to know the name of the sampler to be used.