### PR TITLE
chore: Replicate simplecov changes to config gems

### DIFF
--- a/config/Gemfile
+++ b/config/Gemfile
@@ -10,6 +10,7 @@ eval_gemfile File.expand_path('../Gemfile', __dir__)
 gemspec
 
 group :test, :development do
+  gem 'dotenv', '3.2.0'
   gem 'minitest', '6.0.6'
   gem 'simplecov', '1.0.0'
   gem 'yard', '0.9.45'

--- a/config/test/test_helper.rb
+++ b/config/test/test_helper.rb
@@ -3,6 +3,9 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+require 'dotenv'
+Dotenv.load(File.expand_path('.env', __dir__))
+
 require 'simplecov'
 SimpleCov.start
 


### PR DESCRIPTION
This replicates the changes in https://github.com/open-telemetry/opentelemetry-ruby/pull/2117 to the config gem as it was missed