### PR TITLE
fix(logs-api)!: align LoggerProvider#logger with the SDK signature

### DIFF
--- a/logs_api/lib/opentelemetry/internal/proxy_logger_provider.rb
+++ b/logs_api/lib/opentelemetry/internal/proxy_logger_provider.rb
@@ -38,19 +38,19 @@ module OpenTelemetry
 
         @mutex.synchronize do
           @delegate = provider
-          @registry.each { |key, logger| logger.delegate = provider.logger(key.name, key.version) }
+          @registry.each { |key, logger| logger.delegate = provider.logger(name: key.name, version: key.version) }
         end
       end
 
       # Returns a {Logger} instance.
       #
-      # @param [optional String] name Instrumentation package name
-      # @param [optional String] version Instrumentation package version
+      # @param [String] name Instrumentation scope name
+      # @param [optional String] version Instrumentation scope version
       #
       # @return [Logger]
-      def logger(name = nil, version = nil)
+      def logger(name:, version: nil)
         @mutex.synchronize do
-          return @delegate.logger(name, version) unless @delegate.nil?
+          return @delegate.logger(name: name, version: version) unless @delegate.nil?
 
           @registry[Key.new(name, version)] ||= ProxyLogger.new
         end

--- a/logs_api/lib/opentelemetry/logs/logger_provider.rb
+++ b/logs_api/lib/opentelemetry/logs/logger_provider.rb
@@ -13,11 +13,11 @@ module OpenTelemetry
 
       # Returns an {OpenTelemetry::Logs::Logger} instance.
       #
-      # @param [optional String] name Instrumentation package name
-      # @param [optional String] version Instrumentation package version
+      # @param [String] name Instrumentation scope name
+      # @param [optional String] version Instrumentation scope version
       #
       # @return [OpenTelemetry::Logs::Logger]
-      def logger(name = nil, version = nil)
+      def logger(name:, version: nil)
         @logger ||= NOOP_LOGGER
       end
     end

--- a/logs_api/test/opentelemetry_logs_api_test.rb
+++ b/logs_api/test/opentelemetry_logs_api_test.rb
@@ -17,7 +17,10 @@ describe OpenTelemetry do
   end
 
   class CustomLoggerProvider < OpenTelemetry::Logs::LoggerProvider
-    def logger(name = nil, version = nil)
+    attr_reader :requested
+
+    def logger(name:, version: nil)
+      @requested = { name: name, version: version }
       CustomLogger.new
     end
   end
@@ -51,13 +54,13 @@ describe OpenTelemetry do
     end
 
     it 'has a default proxy logger' do
-      refute_nil OpenTelemetry.logger_provider.logger
+      refute_nil OpenTelemetry.logger_provider.logger(name: 'component')
     end
 
     it 'upgrades default loggers to *real* loggers' do
       # proxy loggers do not emit any log records, nor does the API logger
       # the on_emit method is empty
-      default_logger = OpenTelemetry.logger_provider.logger
+      default_logger = OpenTelemetry.logger_provider.logger(name: 'component')
       _(default_logger.on_emit(body: 'test')).must_be_instance_of(NilClass)
       OpenTelemetry.logger_provider = CustomLoggerProvider.new
       _(default_logger.on_emit(body: 'test')).must_be_instance_of(CustomLogRecord)
@@ -66,7 +69,14 @@ describe OpenTelemetry do
     it 'upgrades the default logger provider to a *real* logger provider' do
       default_logger_provider = OpenTelemetry.logger_provider
       OpenTelemetry.logger_provider = CustomLoggerProvider.new
-      _(default_logger_provider.logger).must_be_instance_of(CustomLogger)
+      _(default_logger_provider.logger(name: 'component')).must_be_instance_of(CustomLogger)
+    end
+
+    it 'passes the instrumentation scope through when upgrading a proxy logger' do
+      OpenTelemetry.logger_provider.logger(name: 'component', version: '1.0')
+      custom_logger_provider = CustomLoggerProvider.new
+      OpenTelemetry.logger_provider = custom_logger_provider
+      _(custom_logger_provider.requested).must_equal(name: 'component', version: '1.0')
     end
   end
 end


### PR DESCRIPTION
Obtaining a logger before `SDK.configure` breaks SDK configuration. See below for a repro:

```ruby
OpenTelemetry.logger_provider.logger('component', '1.0')  # registers a ProxyLogger
OpenTelemetry::SDK.configure
# ERROR -- : OpenTelemetry error: unexpected configuration error due to
#            wrong number of arguments (given 2, expected 0; required keyword: name)
```

This is because `ProxyLoggerProvider#delegate=` calls `provider.logger(key.name, key.version)` positionally, but the logs SDK takes a required `name:` keyword, so upgrading any registered proxy logger raises. This PR aligns `LoggerProvider#logger` with the SDK signature.

This is technically a breaking change because API only users could previously write `logger('name', '1.0')`, but they now have to change to `logger(name: 'name', version: '1.0')`.