### PR TITLE
fix(logs-api): forward on_emit arguments to the delegate logger

### DIFF
--- a/logs_api/lib/opentelemetry/internal/proxy_logger.rb
+++ b/logs_api/lib/opentelemetry/internal/proxy_logger.rb
@@ -22,6 +22,8 @@ module OpenTelemetry
         @delegate = nil
       end
 
+      # Emits a {LogRecord} through the delegate logger, or discards it while
+      # no delegate is installed. See {OpenTelemetry::Logs::Logger#on_emit}.
       def on_emit(
         timestamp: nil,
         observed_timestamp: nil,
@@ -37,17 +39,17 @@ module OpenTelemetry
       )
         unless @delegate.nil?
           return @delegate.on_emit(
-            timestamp: nil,
-            observed_timestamp: nil,
-            severity_number: nil,
-            severity_text: nil,
-            body: nil,
-            trace_id: nil,
-            span_id: nil,
-            trace_flags: nil,
-            attributes: nil,
-            event_name: nil,
-            context: nil
+            timestamp: timestamp,
+            observed_timestamp: observed_timestamp,
+            severity_number: severity_number,
+            severity_text: severity_text,
+            body: body,
+            trace_id: trace_id,
+            span_id: span_id,
+            trace_flags: trace_flags,
+            attributes: attributes,
+            event_name: event_name,
+            context: context
           )
         end
 

--- a/logs_api/test/opentelemetry_logs_api_test.rb
+++ b/logs_api/test/opentelemetry_logs_api_test.rb
@@ -11,7 +11,10 @@ describe OpenTelemetry do
   end
 
   class CustomLogger < OpenTelemetry::Logs::Logger
-    def on_emit(*)
+    attr_reader :emitted
+
+    def on_emit(**args)
+      @emitted = args
       CustomLogRecord.new
     end
   end
@@ -21,7 +24,7 @@ describe OpenTelemetry do
 
     def logger(name:, version: nil)
       @requested = { name: name, version: version }
-      CustomLogger.new
+      @logger ||= CustomLogger.new
     end
   end
 
@@ -77,6 +80,28 @@ describe OpenTelemetry do
       custom_logger_provider = CustomLoggerProvider.new
       OpenTelemetry.logger_provider = custom_logger_provider
       _(custom_logger_provider.requested).must_equal(name: 'component', version: '1.0')
+    end
+
+    it 'forwards log record fields through an upgraded proxy logger' do
+      proxy_logger = OpenTelemetry.logger_provider.logger(name: 'component')
+      custom_logger_provider = CustomLoggerProvider.new
+      OpenTelemetry.logger_provider = custom_logger_provider
+
+      proxy_logger.on_emit(body: 'hello', severity_text: 'WARN', severity_number: 13)
+
+      _(custom_logger_provider.logger(name: 'component').emitted).must_equal(
+        timestamp: nil,
+        observed_timestamp: nil,
+        severity_number: 13,
+        severity_text: 'WARN',
+        body: 'hello',
+        trace_id: nil,
+        span_id: nil,
+        trace_flags: nil,
+        attributes: nil,
+        event_name: nil,
+        context: nil
+      )
     end
   end
 end


### PR DESCRIPTION
Log records emitted through an upgraded proxy are empty. The proxy accepts the log record fields, but it passes `nil`s for all of them to the delegate. This affects any logger obtained before the logs SDK is configured.

This PR fixes that by forwarding the actual values through the delegate.