### PR TITLE
fix(metrics-api): pass the callback through when upgrading a proxy

### DIFF
--- a/metrics_api/lib/opentelemetry/internal/proxy_instrument.rb
+++ b/metrics_api/lib/opentelemetry/internal/proxy_instrument.rb
@@ -8,12 +8,12 @@ module OpenTelemetry
   module Internal
     # @api private
     class ProxyInstrument
-      def initialize(kind, name, unit, desc, callable, exemplar_filter, exemplar_reservoir)
+      def initialize(kind, name, unit, desc, callback, exemplar_filter, exemplar_reservoir)
         @kind = kind
         @name = name
         @unit = unit
         @desc = desc
-        @callable = callable
+        @callback = callback
         @exemplar_filter    = exemplar_filter
         @exemplar_reservoir = exemplar_reservoir
         @delegate = nil

--- a/metrics_api/test/opentelemetry/internal/proxy_instrument_test.rb
+++ b/metrics_api/test/opentelemetry/internal/proxy_instrument_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+describe OpenTelemetry::Internal::ProxyInstrument do
+  # Captures the arguments the proxy uses to recreate an instrument on a real meter.
+  class RecordingMeter
+    attr_reader :created
+
+    def create_counter(name, unit: nil, description: nil, exemplar_filter: nil, exemplar_reservoir: nil)
+      @created = { name: name, unit: unit, description: description }
+    end
+
+    def create_observable_counter(name, callback:, unit: nil, description: nil, exemplar_filter: nil, exemplar_reservoir: nil)
+      @created = { name: name, unit: unit, description: description, callback: callback }
+    end
+  end
+
+  describe '#upgrade_with' do
+    it 'passes the callback to an upgraded asynchronous instrument' do
+      callback = -> { 5 }
+      instrument = build_proxy_instrument(:observable_counter, callback)
+      meter = RecordingMeter.new
+
+      instrument.upgrade_with(meter)
+
+      _(meter.created[:callback]).must_equal(callback)
+    end
+
+    it 'passes the descriptor to an upgraded synchronous instrument' do
+      instrument = build_proxy_instrument(:counter, nil)
+      meter = RecordingMeter.new
+
+      instrument.upgrade_with(meter)
+
+      _(meter.created).must_equal(name: 'my.instrument', unit: 's', description: 'a description')
+    end
+  end
+
+  def build_proxy_instrument(kind, callback)
+    OpenTelemetry::Internal::ProxyInstrument.new(kind, 'my.instrument', 's', 'a description', callback, nil, nil)
+  end
+end


### PR DESCRIPTION
`ProxyInstrument#initialize` stores the callback in `@callable`, but `upgrade_with` reads `@callback`, which is always nil. So when the metrics SDK is installed, observable instruments created against the proxy are rebuilt with `callback: nil` and never report. This affects `observable_counter`, `observable_gauge` and `observable_up_down_counter` created before the SDK is configured. 

This PR renames the parameter to `callback` and adds test coverage.