### PR TITLE
fix: use spec-recommended 10000ms default interval for stdout exporter

### DIFF
--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/configurator_patch.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/configurator_patch.rb
@@ -40,9 +40,8 @@ module OpenTelemetry
             case exporter.strip
             when 'none' then nil
             when 'console'
-              default_console_interval = ENV['OTEL_METRIC_EXPORT_INTERVAL'] || 10_000
               OpenTelemetry.meter_provider.add_metric_reader(Metrics::Export::PeriodicMetricReader.new(
-                                                               export_interval_millis: Float(default_console_interval),
+                                                               export_interval_millis: 10_000.0,
                                                                exporter: Metrics::Export::ConsoleMetricPullExporter.new
                                                              ))
             when 'in-memory' then OpenTelemetry.meter_provider.add_metric_reader(Metrics::Export::InMemoryMetricPullExporter.new)


### PR DESCRIPTION
Fixes #2373

### Context & Thought Process
While investigating this issue, I noticed that the codebase had changed since the issue was originally opened. 

Specifically, PR #2301 (by @xuan-cao-swi) recently modified `configurator_patch.rb` to add a 10,000ms fallback for the console exporter. However, that PR still included a check for the general-purpose environment variable (`ENV['OTEL_METRIC_EXPORT_INTERVAL'] || 10_000`).

As noted in the original issue description and the OpenTelemetry specification (`sdk_exporters/stdout.md`), the Console Exporter is meant to be special-cased to *always* default to 10,000ms, completely decoupled from the general-purpose `OTEL_METRIC_EXPORT_INTERVAL`.

### Changes Made
This PR removes the environment variable fallback for the console exporter and explicitly passes `export_interval_millis: 10_000.0`. This ensures that even if a user configures a global `OTEL_METRIC_EXPORT_INTERVAL` (e.g., to 30,000ms for their OTLP exporters), the console exporter will stubbornly and correctly run every 10 seconds.

*(Note: AI tools were utilized to help analyze the data flow and draft this PR.)*
