### PR TITLE
refactor!: make metrics and logs instrumentation-only

### DIFF
--- a/logs_api/lib/opentelemetry-logs-api.rb
+++ b/logs_api/lib/opentelemetry-logs-api.rb
@@ -9,33 +9,11 @@ require 'opentelemetry/logs'
 require 'opentelemetry/logs/version'
 require 'opentelemetry/internal/proxy_logger_provider'
 require 'opentelemetry/internal/proxy_logger'
+require 'opentelemetry/internal/global_logger_provider'
 
 # OpenTelemetry is an open source observability framework, providing a
 # general-purpose API, SDK, and related tools required for the instrumentation
 # of cloud-native software, frameworks, and libraries.
 #
-# The OpenTelemetry module in the Logs API gem provides global accessors
-# for logs-related objects.
-module OpenTelemetry
-  @logger_provider = Internal::ProxyLoggerProvider.new
-
-  # Register the global logger provider.
-  #
-  # @param [LoggerProvider] provider A logger provider to register as the
-  #   global instance.
-  def logger_provider=(provider)
-    @mutex.synchronize do
-      if @logger_provider.instance_of? Internal::ProxyLoggerProvider
-        logger.debug("Upgrading default proxy logger provider to #{provider.class}")
-        @logger_provider.delegate = provider
-      end
-      @logger_provider = provider
-    end
-  end
-
-  # @return [Object, Logs::LoggerProvider] registered logger provider or a
-  #   default no-op implementation of the logger provider.
-  def logger_provider
-    @mutex.synchronize { @logger_provider }
-  end
-end
+# Requiring this gem makes the Logs API available to instrumentation through
+# {OpenTelemetry::Internal.logger_provider}.

--- a/logs_api/lib/opentelemetry/internal/global_logger_provider.rb
+++ b/logs_api/lib/opentelemetry/internal/global_logger_provider.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  # @api private
+  module Internal
+    @logger_provider = ProxyLoggerProvider.new
+    @logger_provider_mutex = Mutex.new
+
+    class << self
+      # Registers the process-wide logger provider that instrumentation reads
+      # from. The public +OpenTelemetry.logger_provider+ accessor, defined in
+      # +opentelemetry/logs/global+, delegates here.
+      #
+      # @param [LoggerProvider] provider A logger provider to register as the
+      #   global instance.
+      def logger_provider=(provider)
+        @logger_provider_mutex.synchronize do
+          if @logger_provider.instance_of?(ProxyLoggerProvider)
+            OpenTelemetry.logger.debug("Upgrading default proxy logger provider to #{provider.class}")
+            @logger_provider.delegate = provider
+          end
+          @logger_provider = provider
+        end
+      end
+
+      # @return [Object, Logs::LoggerProvider] registered logger provider or a
+      #   default no-op implementation of the logger provider.
+      def logger_provider
+        @logger_provider_mutex.synchronize { @logger_provider }
+      end
+    end
+  end
+end

--- a/logs_api/lib/opentelemetry/logs/global.rb
+++ b/logs_api/lib/opentelemetry/logs/global.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry-logs-api'
+
+# Defines the top-level accessors for the global logger provider. The Logs
+# API is unstable, so requiring +opentelemetry-logs-api+ does not define
+# these. Requiring +opentelemetry-logs-sdk+ does.
+#
+# These are delegators. The provider itself lives in
+# {OpenTelemetry::Internal}, so this file can be required at any point,
+# before or after the SDK is configured.
+module OpenTelemetry
+  # Register the global logger provider.
+  #
+  # @param [LoggerProvider] provider A logger provider to register as the
+  #   global instance.
+  def logger_provider=(provider)
+    Internal.logger_provider = provider
+  end
+
+  # @return [Object, Logs::LoggerProvider] registered logger provider or a
+  #   default no-op implementation of the logger provider.
+  def logger_provider
+    Internal.logger_provider
+  end
+end

--- a/logs_api/test/opentelemetry/logs/global_test.rb
+++ b/logs_api/test/opentelemetry/logs/global_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+require 'opentelemetry/logs/global'
+
+describe 'OpenTelemetry.logger_provider' do
+  after do
+    OpenTelemetry::Internal.logger_provider = OpenTelemetry::Internal::ProxyLoggerProvider.new
+  end
+
+  it 'reads the provider held in the internal slot' do
+    provider = OpenTelemetry::Logs::LoggerProvider.new
+    OpenTelemetry::Internal.logger_provider = provider
+
+    _(OpenTelemetry.logger_provider).must_equal(provider)
+  end
+
+  it 'writes through to the internal slot' do
+    provider = OpenTelemetry::Logs::LoggerProvider.new
+    OpenTelemetry.logger_provider = provider
+
+    _(OpenTelemetry::Internal.logger_provider).must_equal(provider)
+  end
+
+  it 'can be required after a provider is already registered' do
+    provider = OpenTelemetry::Logs::LoggerProvider.new
+    OpenTelemetry::Internal.logger_provider = provider
+    require 'opentelemetry/logs/global'
+
+    _(OpenTelemetry.logger_provider).must_equal(provider)
+  end
+end

--- a/logs_api/test/opentelemetry_logs_api_test.rb
+++ b/logs_api/test/opentelemetry_logs_api_test.rb
@@ -6,7 +6,7 @@
 
 require 'test_helper'
 
-describe OpenTelemetry do
+describe OpenTelemetry::Internal do
   class CustomLogRecord < OpenTelemetry::Logs::LogRecord
   end
 
@@ -28,64 +28,80 @@ describe OpenTelemetry do
     end
   end
 
+  describe 'requiring the gem' do
+    it 'does not define the top-level logger provider accessor' do
+      # Asserted in a subprocess because requiring opentelemetry/logs/global
+      # anywhere in this suite defines the accessor for the whole process.
+      script = 'require "opentelemetry-logs-api"; exit(OpenTelemetry.respond_to?(:logger_provider) ? 1 : 0)'
+
+      assert(system(RbConfig.ruby, '-e', script), 'requiring opentelemetry-logs-api defined OpenTelemetry.logger_provider')
+    end
+
+    it 'defines the internal logger provider that instrumentation reads' do
+      script = 'require "opentelemetry-logs-api"; exit(OpenTelemetry::Internal.logger_provider ? 0 : 1)'
+
+      assert(system(RbConfig.ruby, '-e', script))
+    end
+  end
+
   describe '.logger_provider' do
     after do
       # Ensure we don't leak custom logger factories and loggers to other tests
-      OpenTelemetry.logger_provider = OpenTelemetry::Internal::ProxyLoggerProvider.new
+      OpenTelemetry::Internal.logger_provider = OpenTelemetry::Internal::ProxyLoggerProvider.new
     end
 
     it 'returns a Logs::LoggerProvider by default' do
-      logger_provider = OpenTelemetry.logger_provider
+      logger_provider = OpenTelemetry::Internal.logger_provider
       _(logger_provider).must_be_kind_of(OpenTelemetry::Logs::LoggerProvider)
     end
 
     it 'returns the same instance when accessed multiple times' do
-      _(OpenTelemetry.logger_provider).must_equal(OpenTelemetry.logger_provider)
+      _(OpenTelemetry::Internal.logger_provider).must_equal(OpenTelemetry::Internal.logger_provider)
     end
 
     it 'returns user-specified logger provider' do
       custom_logger_provider = CustomLoggerProvider.new
-      OpenTelemetry.logger_provider = custom_logger_provider
-      _(OpenTelemetry.logger_provider).must_equal(custom_logger_provider)
+      OpenTelemetry::Internal.logger_provider = custom_logger_provider
+      _(OpenTelemetry::Internal.logger_provider).must_equal(custom_logger_provider)
     end
   end
 
   describe '.logger_provider=' do
     after do
       # Ensure we don't leak custom logger factories and loggers to other tests
-      OpenTelemetry.logger_provider = OpenTelemetry::Internal::ProxyLoggerProvider.new
+      OpenTelemetry::Internal.logger_provider = OpenTelemetry::Internal::ProxyLoggerProvider.new
     end
 
     it 'has a default proxy logger' do
-      refute_nil OpenTelemetry.logger_provider.logger(name: 'component')
+      refute_nil OpenTelemetry::Internal.logger_provider.logger(name: 'component')
     end
 
     it 'upgrades default loggers to *real* loggers' do
       # proxy loggers do not emit any log records, nor does the API logger
       # the on_emit method is empty
-      default_logger = OpenTelemetry.logger_provider.logger(name: 'component')
+      default_logger = OpenTelemetry::Internal.logger_provider.logger(name: 'component')
       _(default_logger.on_emit(body: 'test')).must_be_instance_of(NilClass)
-      OpenTelemetry.logger_provider = CustomLoggerProvider.new
+      OpenTelemetry::Internal.logger_provider = CustomLoggerProvider.new
       _(default_logger.on_emit(body: 'test')).must_be_instance_of(CustomLogRecord)
     end
 
     it 'upgrades the default logger provider to a *real* logger provider' do
-      default_logger_provider = OpenTelemetry.logger_provider
-      OpenTelemetry.logger_provider = CustomLoggerProvider.new
+      default_logger_provider = OpenTelemetry::Internal.logger_provider
+      OpenTelemetry::Internal.logger_provider = CustomLoggerProvider.new
       _(default_logger_provider.logger(name: 'component')).must_be_instance_of(CustomLogger)
     end
 
     it 'passes the instrumentation scope through when upgrading a proxy logger' do
-      OpenTelemetry.logger_provider.logger(name: 'component', version: '1.0')
+      OpenTelemetry::Internal.logger_provider.logger(name: 'component', version: '1.0')
       custom_logger_provider = CustomLoggerProvider.new
-      OpenTelemetry.logger_provider = custom_logger_provider
+      OpenTelemetry::Internal.logger_provider = custom_logger_provider
       _(custom_logger_provider.requested).must_equal(name: 'component', version: '1.0')
     end
 
     it 'forwards log record fields through an upgraded proxy logger' do
-      proxy_logger = OpenTelemetry.logger_provider.logger(name: 'component')
+      proxy_logger = OpenTelemetry::Internal.logger_provider.logger(name: 'component')
       custom_logger_provider = CustomLoggerProvider.new
-      OpenTelemetry.logger_provider = custom_logger_provider
+      OpenTelemetry::Internal.logger_provider = custom_logger_provider
 
       proxy_logger.on_emit(body: 'hello', severity_text: 'WARN', severity_number: 13)
 

--- a/logs_sdk/lib/opentelemetry/sdk/logs.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs.rb
@@ -6,6 +6,7 @@
 
 require 'opentelemetry/sdk'
 require 'opentelemetry-logs-api'
+require 'opentelemetry/logs/global'
 
 require_relative 'logs/version'
 require_relative 'logs/configurator_patch'

--- a/logs_sdk/lib/opentelemetry/sdk/logs/configurator_patch.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/configurator_patch.rb
@@ -26,13 +26,13 @@ module OpenTelemetry
         # The logs_configuration_hook method is where we define the setup
         # process for logs SDK.
         def logs_configuration_hook
-          OpenTelemetry.logger_provider = Logs::LoggerProvider.new(resource: @resource)
+          OpenTelemetry::Internal.logger_provider = Logs::LoggerProvider.new(resource: @resource)
           configure_log_record_processors
         end
 
         def configure_log_record_processors
           processors = @log_record_processors.empty? ? wrapped_log_exporters_from_env.compact : @log_record_processors
-          processors.each { |p| OpenTelemetry.logger_provider.add_log_record_processor(p) }
+          processors.each { |p| OpenTelemetry::Internal.logger_provider.add_log_record_processor(p) }
         end
 
         def wrapped_log_exporters_from_env

--- a/metrics_api/lib/opentelemetry-metrics-api.rb
+++ b/metrics_api/lib/opentelemetry-metrics-api.rb
@@ -10,32 +10,11 @@ require 'opentelemetry/metrics/version'
 require 'opentelemetry/internal/proxy_instrument'
 require 'opentelemetry/internal/proxy_meter_provider'
 require 'opentelemetry/internal/proxy_meter'
+require 'opentelemetry/internal/global_meter_provider'
 
 # OpenTelemetry is an open source observability framework, providing a
 # general-purpose API, SDK, and related tools required for the instrumentation
 # of cloud-native software, frameworks, and libraries.
 #
-# The OpenTelemetry module provides global accessors for telemetry objects.
-module OpenTelemetry
-  @meter_provider = Internal::ProxyMeterProvider.new
-
-  # Register the global meter provider.
-  #
-  # @param [MeterProvider] provider A meter provider to register as the
-  #   global instance.
-  def meter_provider=(provider)
-    @mutex.synchronize do
-      if @meter_provider.instance_of? Internal::ProxyMeterProvider
-        logger.debug("Upgrading default proxy meter provider to #{provider.class}")
-        @meter_provider.delegate = provider
-      end
-      @meter_provider = provider
-    end
-  end
-
-  # @return [Object, Metrics::MeterProvider] registered meter provider or a
-  #   default no-op implementation of the meter provider.
-  def meter_provider
-    @mutex.synchronize { @meter_provider }
-  end
-end
+# Requiring this gem makes the Metrics API available to instrumentation through
+# {OpenTelemetry::Internal.meter_provider}.

--- a/metrics_api/lib/opentelemetry/internal/global_meter_provider.rb
+++ b/metrics_api/lib/opentelemetry/internal/global_meter_provider.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+module OpenTelemetry
+  # @api private
+  module Internal
+    @meter_provider = ProxyMeterProvider.new
+    @meter_provider_mutex = Mutex.new
+
+    class << self
+      # Registers the process-wide meter provider that instrumentation reads
+      # from. The public +OpenTelemetry.meter_provider+ accessor, defined in
+      # +opentelemetry/metrics/global+, delegates here.
+      #
+      # @param [MeterProvider] provider A meter provider to register as the
+      #   global instance.
+      def meter_provider=(provider)
+        @meter_provider_mutex.synchronize do
+          if @meter_provider.instance_of?(ProxyMeterProvider)
+            OpenTelemetry.logger.debug("Upgrading default proxy meter provider to #{provider.class}")
+            @meter_provider.delegate = provider
+          end
+          @meter_provider = provider
+        end
+      end
+
+      # @return [Object, Metrics::MeterProvider] registered meter provider or a
+      #   default no-op implementation of the meter provider.
+      def meter_provider
+        @meter_provider_mutex.synchronize { @meter_provider }
+      end
+    end
+  end
+end

--- a/metrics_api/lib/opentelemetry/metrics/global.rb
+++ b/metrics_api/lib/opentelemetry/metrics/global.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'opentelemetry-metrics-api'
+
+# Defines the top-level accessors for the global meter provider. The Metrics
+# API is unstable, so requiring +opentelemetry-metrics-api+ does not define
+# these. Requiring +opentelemetry-metrics-sdk+ does.
+#
+# These are delegators. The provider itself lives in
+# {OpenTelemetry::Internal}, so this file can be required at any point,
+# before or after the SDK is configured.
+module OpenTelemetry
+  # Register the global meter provider.
+  #
+  # @param [MeterProvider] provider A meter provider to register as the
+  #   global instance.
+  def meter_provider=(provider)
+    Internal.meter_provider = provider
+  end
+
+  # @return [Object, Metrics::MeterProvider] registered meter provider or a
+  #   default no-op implementation of the meter provider.
+  def meter_provider
+    Internal.meter_provider
+  end
+end

--- a/metrics_api/test/opentelemetry/metrics/global_test.rb
+++ b/metrics_api/test/opentelemetry/metrics/global_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Copyright The OpenTelemetry Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+require 'opentelemetry/metrics/global'
+
+describe 'OpenTelemetry.meter_provider' do
+  after do
+    OpenTelemetry::Internal.instance_variable_set(
+      :@meter_provider,
+      OpenTelemetry::Internal::ProxyMeterProvider.new
+    )
+  end
+
+  it 'reads the provider held in the internal slot' do
+    provider = OpenTelemetry::Metrics::MeterProvider.new
+    OpenTelemetry::Internal.meter_provider = provider
+
+    assert_same(OpenTelemetry.meter_provider, provider)
+  end
+
+  it 'writes through to the internal slot' do
+    provider = OpenTelemetry::Metrics::MeterProvider.new
+    OpenTelemetry.meter_provider = provider
+
+    assert_same(OpenTelemetry::Internal.meter_provider, provider)
+  end
+
+  it 'can be required after a provider is already registered' do
+    provider = OpenTelemetry::Metrics::MeterProvider.new
+    OpenTelemetry::Internal.meter_provider = provider
+    require 'opentelemetry/metrics/global'
+
+    assert_same(OpenTelemetry.meter_provider, provider)
+  end
+end

--- a/metrics_api/test/opentelemetry/opentelemetry_test.rb
+++ b/metrics_api/test/opentelemetry/opentelemetry_test.rb
@@ -6,39 +6,55 @@
 
 require 'test_helper'
 
-describe OpenTelemetry do
+describe OpenTelemetry::Internal do
   after do
     # TODO: After Metrics SDK is incorporated into OpenTelemetry SDK, move this
     # to OpenTelemetry::TestHelpers.reset_opentelemetry
-    OpenTelemetry.instance_variable_set(
+    OpenTelemetry::Internal.instance_variable_set(
       :@meter_provider,
       OpenTelemetry::Internal::ProxyMeterProvider.new
     )
   end
 
+  describe 'requiring the gem' do
+    it 'does not define the top-level meter provider accessor' do
+      # Asserted in a subprocess because requiring opentelemetry/metrics/global
+      # anywhere in this suite defines the accessor for the whole process.
+      script = 'require "opentelemetry-metrics-api"; exit(OpenTelemetry.respond_to?(:meter_provider) ? 1 : 0)'
+
+      assert(system(RbConfig.ruby, '-e', script), 'requiring opentelemetry-metrics-api defined OpenTelemetry.meter_provider')
+    end
+
+    it 'defines the internal meter provider that instrumentation reads' do
+      script = 'require "opentelemetry-metrics-api"; exit(OpenTelemetry::Internal.meter_provider ? 0 : 1)'
+
+      assert(system(RbConfig.ruby, '-e', script))
+    end
+  end
+
   describe '#meter_provider and #meter_provider=' do
     it 'initializes with a global instance of ProxyMeterProvider' do
-      assert_kind_of(OpenTelemetry::Internal::ProxyMeterProvider, OpenTelemetry.meter_provider)
+      assert_kind_of(OpenTelemetry::Internal::ProxyMeterProvider, OpenTelemetry::Internal.meter_provider)
     end
 
     it 'sets global MeterProvider to the given meter_provider' do
       new_meter_provider = OpenTelemetry::Metrics::MeterProvider.new
 
-      OpenTelemetry.meter_provider = new_meter_provider
+      OpenTelemetry::Internal.meter_provider = new_meter_provider
 
-      assert_same(OpenTelemetry.meter_provider, new_meter_provider)
+      assert_same(OpenTelemetry::Internal.meter_provider, new_meter_provider)
     end
 
     describe 'when global MeterProvider is an instance of Internal::ProxyMeterProvider' do
       it 'sets ProxyMeterProvider#delegate to the given meter_provider and logs a debug message' do
-        proxy_meter_provider = OpenTelemetry.meter_provider
+        proxy_meter_provider = OpenTelemetry::Internal.meter_provider
         new_meter_provider = OpenTelemetry::Metrics::MeterProvider.new
 
         OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
-          OpenTelemetry.meter_provider = new_meter_provider
+          OpenTelemetry::Internal.meter_provider = new_meter_provider
 
           assert_same(proxy_meter_provider.instance_variable_get(:@delegate), new_meter_provider)
-          assert_same(OpenTelemetry.meter_provider, new_meter_provider)
+          assert_same(OpenTelemetry::Internal.meter_provider, new_meter_provider)
           assert_match(/Upgrading default proxy meter provider to #{new_meter_provider.class}/i, log_stream.string)
         end
       end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics.rb
@@ -6,6 +6,7 @@
 
 require 'opentelemetry/sdk'
 require 'opentelemetry-metrics-api'
+require 'opentelemetry/metrics/global'
 
 module OpenTelemetry
   module SDK

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/configurator_patch.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/configurator_patch.rb
@@ -24,14 +24,14 @@ module OpenTelemetry
 
         # The metrics_configuration_hook method is where we define the setup process for the metrics SDK.
         def metrics_configuration_hook
-          OpenTelemetry.meter_provider = Metrics::MeterProvider.new(resource: @resource)
+          OpenTelemetry::Internal.meter_provider = Metrics::MeterProvider.new(resource: @resource)
           configure_metric_readers
           attach_fork_hooks!
         end
 
         def configure_metric_readers
           readers = @metric_readers.empty? ? wrapped_metric_exporters_from_env.compact : @metric_readers
-          readers.each { |r| OpenTelemetry.meter_provider.add_metric_reader(r) }
+          readers.each { |r| OpenTelemetry::Internal.meter_provider.add_metric_reader(r) }
         end
 
         def wrapped_metric_exporters_from_env
@@ -41,14 +41,14 @@ module OpenTelemetry
             when 'none' then nil
             when 'console'
               default_console_interval = ENV['OTEL_METRIC_EXPORT_INTERVAL'] || 10_000
-              OpenTelemetry.meter_provider.add_metric_reader(Metrics::Export::PeriodicMetricReader.new(
-                                                               export_interval_millis: Float(default_console_interval),
-                                                               exporter: Metrics::Export::ConsoleMetricPullExporter.new
-                                                             ))
-            when 'in-memory' then OpenTelemetry.meter_provider.add_metric_reader(Metrics::Export::InMemoryMetricPullExporter.new)
+              OpenTelemetry::Internal.meter_provider.add_metric_reader(Metrics::Export::PeriodicMetricReader.new(
+                                                                         export_interval_millis: Float(default_console_interval),
+                                                                         exporter: Metrics::Export::ConsoleMetricPullExporter.new
+                                                                       ))
+            when 'in-memory' then OpenTelemetry::Internal.meter_provider.add_metric_reader(Metrics::Export::InMemoryMetricPullExporter.new)
             when 'otlp'
               begin
-                OpenTelemetry.meter_provider.add_metric_reader(Metrics::Export::PeriodicMetricReader.new(exporter: OpenTelemetry::Exporter::OTLP::Metrics::MetricsExporter.new))
+                OpenTelemetry::Internal.meter_provider.add_metric_reader(Metrics::Export::PeriodicMetricReader.new(exporter: OpenTelemetry::Exporter::OTLP::Metrics::MetricsExporter.new))
               rescue NameError
                 OpenTelemetry.logger.warn 'The otlp metrics exporter cannot be configured - please add opentelemetry-exporter-otlp-metrics to your Gemfile, metrics will not be exported'
                 nil

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/fork_hooks.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/fork_hooks.rb
@@ -20,7 +20,7 @@ module OpenTelemetry
 
         # Notifies metric readers that a fork just occurred.
         def self.after_fork
-          ::OpenTelemetry.meter_provider.metric_readers.each do |reader|
+          ::OpenTelemetry::Internal.meter_provider.metric_readers.each do |reader|
             reader.after_fork if reader.respond_to?(:after_fork)
           end
         end

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/fork_hooks_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/fork_hooks_test.rb
@@ -56,7 +56,7 @@ describe OpenTelemetry::SDK::Metrics::ForkHooks do
       end
 
       meter_provider = OpenTelemetry::SDK::Metrics::MeterProvider.new
-      ::OpenTelemetry.stub(:meter_provider, meter_provider) do
+      ::OpenTelemetry::Internal.stub(:meter_provider, meter_provider) do
         forking_pid, forked_pid = fork_with_fork_hooks(after_fork_lambda)
         pid_from_after_fork = JSON.parse(after_fork_read_io.gets.chomp)['after_fork_pid'].to_i
 
@@ -81,7 +81,7 @@ describe OpenTelemetry::SDK::Metrics::ForkHooks do
     meter_provider = OpenTelemetry::SDK::Metrics::MeterProvider.new
     meter_provider.add_metric_reader(reader1)
     meter_provider.add_metric_reader(reader2)
-    ::OpenTelemetry.stub(:meter_provider, meter_provider) do
+    ::OpenTelemetry::Internal.stub(:meter_provider, meter_provider) do
       OpenTelemetry::SDK::Metrics::ForkHooks.after_fork
     end
     assert(reader1.after_fork_called)

--- a/metrics_sdk/test/test_helper.rb
+++ b/metrics_sdk/test/test_helper.rb
@@ -17,7 +17,7 @@ require 'minitest/autorun'
 # reset_metrics_sdk is a test helper used to clear
 # SDK configuration state between calls
 def reset_metrics_sdk
-  OpenTelemetry.instance_variable_set(
+  OpenTelemetry::Internal.instance_variable_set(
     :@meter_provider,
     OpenTelemetry::Internal::ProxyMeterProvider.new
   )


### PR DESCRIPTION
Draft for discussion. Core half of making the unstable metrics and logs APIs usable by instrumentation without exposing them to users. The contrib half of this work is here: open-telemetry/opentelemetry-ruby-contrib/pull/2569.

## Problem

Requiring `opentelemetry-metrics-api` or `opentelemetry-logs-api` immediately defines `OpenTelemetry.meter_provider` and `OpenTelemetry.logger_provider`. Those are the public, user-facing surface of unstable APIs. So instrumentation cannot depend on either API without exposing them to users via the globals on the `OpenTelemetry` module.

Separating the two lets us exercise and evolve these APIs against our instrumentation without committing users to them, and gives us much more confidence before we stabilize.

## Change

Requiring the API does not need to set the global on the `OpenTelemetry` module. In this PR that responsibility is moved to the SDK. This allows us to consume the API in instrumentation without exposing it to users via the global. The changes are as follows:

- the provider slot moves to `OpenTelemetry::Internal`
- the public accessors move to `opentelemetry/metrics/global.rb` and `opentelemetry/logs/global.rb`
- each SDK requires its own `global.rb` (the API does not)

| you require | instrumentation gets | user gets |
| --- | --- | --- |
| `opentelemetry-metrics-api` | a meter, via `Internal.meter_provider` | no `OpenTelemetry.meter_provider` |
| `opentelemetry-metrics-sdk` | the same meter, backed by the SDK | `OpenTelemetry.meter_provider` |

Requiring the SDK is the opt-in. Logs work the same way. Nothing changes for anyone already using the SDKs.

## Breaking

Only for code that requires an `-api` gem directly and reads the top-level accessor (without an SDK). Requiring the SDK restores it.

## Notes

- Release sequencing needs care. This will require coordinating changes across contrib, the API, and the SDK.