### PR TITLE
fix(metrics_sdk): size exponential histogram exemplar reservoirs

### DIFF
--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/aggregation/exponential_bucket_histogram.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/aggregation/exponential_bucket_histogram.rb
@@ -29,10 +29,6 @@ module OpenTelemetry
 
           attr_reader :exemplar_reservoir
 
-          # if no reservoir pass from instrument, then use this empty reservoir to avoid no method found error
-          DEFAULT_RESERVOIR = Metrics::Exemplar::SimpleFixedSizeExemplarReservoir.new
-          private_constant :DEFAULT_RESERVOIR
-
           # The default boundaries are calculated based on default max_size and max_scale values
           def initialize(
             aggregation_temporality: ENV.fetch('OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE', :delta),
@@ -53,7 +49,7 @@ module OpenTelemetry
             @size           = validate_size(max_size)
             @scale          = validate_scale(max_scale)
 
-            @exemplar_reservoir = exemplar_reservoir || DEFAULT_RESERVOIR
+            @exemplar_reservoir = exemplar_reservoir || Metrics::Exemplar::SimpleFixedSizeExemplarReservoir.new(max_size: [20, @size].min)
             @exemplar_reservoir_storage = {}
 
             @mapping = new_mapping(@scale)

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/aggregation/exponential_bucket_histogram_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/aggregation/exponential_bucket_histogram_test.rb
@@ -27,6 +27,16 @@ describe OpenTelemetry::SDK::Metrics::Aggregation::ExponentialBucketHistogram do
   let(:end_time) { Process.clock_gettime(Process::CLOCK_REALTIME, :nanosecond) + (60 * 1_000_000_000) }
   let(:cardinality_limit) { 2000 }
 
+  describe '#initialize' do
+    it 'sizes the default exemplar reservoir from max_size' do
+      [[10, 10], [25, 20]].each do |max_size, expected_size|
+        histogram = OpenTelemetry::SDK::Metrics::Aggregation::ExponentialBucketHistogram.new(max_size: max_size)
+
+        _(histogram.exemplar_reservoir.instance_variable_get(:@exemplar_buckets).size).must_equal expected_size
+      end
+    end
+  end
+
   describe '#collect' do
     it 'returns all the data points' do
       expbh.update(1.03, {}, data_points, cardinality_limit)


### PR DESCRIPTION
## Problem

Base-2 exponential histograms use the generic CPU-count-sized exemplar reservoir. The Metrics SDK specification instead recommends sizing this default to the smaller of 20 and the histogram's configured maximum bucket count.

## Changes

- construct each default exponential-histogram exemplar reservoir with min(20, max_size)
- cover histogram limits below and above the 20-exemplar cap

## User impact

Default exemplar storage now follows the Metrics SDK sizing requirement without changing explicitly supplied reservoirs.

## Verification

- bundle exec rake test — 333 runs, 17,022 assertions, 0 failures, 0 errors, 2 skips
- bundle exec rubocop --except Layout/EndOfLine — 98 files inspected, no offenses; the exclusion avoids RuboCop's Windows-native CRLF expectation on the repository's LF checkout
- bundle exec rake yard — completed successfully with the existing unresolved-reference warnings

Fixes #2366