### PR TITLE
fix: Allow span processors to mutate a span from on_finishing

### DIFF
--- a/sdk/lib/opentelemetry/sdk/trace/span.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span.rb
@@ -77,7 +77,7 @@ module OpenTelemetry
         #
         # @return [self] returns itself
         def set_attribute(key, value)
-          @mutex.synchronize do
+          synchronize do
             if @ended
               OpenTelemetry.logger.warn('Calling set_attribute on an ended Span.')
             else
@@ -105,7 +105,7 @@ module OpenTelemetry
         #
         # @return [self] returns itself
         def add_attributes(attributes)
-          @mutex.synchronize do
+          synchronize do
             if @ended
               OpenTelemetry.logger.warn('Calling add_attributes on an ended Span.')
             else
@@ -137,7 +137,7 @@ module OpenTelemetry
         #
         # @return [self] returns itself
         def add_link(link)
-          @mutex.synchronize do
+          synchronize do
             if @ended
               OpenTelemetry.logger.warn('Calling add_link on an ended Span.')
             else
@@ -170,7 +170,7 @@ module OpenTelemetry
         def add_event(name, attributes: nil, timestamp: nil)
           event = Event.new(name, truncate_attribute_values(attributes, @span_limits.event_attribute_length_limit), relative_timestamp(timestamp))
 
-          @mutex.synchronize do
+          synchronize do
             if @ended
               OpenTelemetry.logger.warn('Calling add_event on an ended Span.')
             else
@@ -217,7 +217,7 @@ module OpenTelemetry
         def status=(status)
           return if status.code == OpenTelemetry::Trace::Status::UNSET
 
-          @mutex.synchronize do
+          synchronize do
             if @ended
               OpenTelemetry.logger.warn('Calling status= on an ended Span.')
             elsif @status.code != OpenTelemetry::Trace::Status::OK
@@ -236,7 +236,7 @@ module OpenTelemetry
         #
         # @return [void]
         def name=(new_name)
-          @mutex.synchronize do
+          synchronize do
             if @ended
               OpenTelemetry.logger.warn('Calling name= on an ended Span.')
             else
@@ -265,7 +265,7 @@ module OpenTelemetry
         #
         # @return [self] returns itself
         def finish(end_timestamp: nil)
-          @mutex.synchronize do
+          synchronize do
             if @ended
               OpenTelemetry.logger.warn('Calling finish on an ended Span.')
               return self
@@ -374,6 +374,15 @@ module OpenTelemetry
         attr_reader :monotonic_start_timestamp, :realtime_start_timestamp
 
         private
+
+        # The lock is held across the on_finishing callouts so that no other
+        # thread can mutate the span once it starts ending. Re-entering from
+        # that callout is the one legitimate case, and Mutex is not reentrant.
+        def synchronize(&)
+          return yield if @mutex.owned?
+
+          @mutex.synchronize(&)
+        end
 
         def validated_attributes(attrs)
           return attrs if Internal.valid_attributes?(name, 'span', attrs)

--- a/sdk/lib/opentelemetry/sdk/trace/span.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span.rb
@@ -270,10 +270,13 @@ module OpenTelemetry
               OpenTelemetry.logger.warn('Calling finish on an ended Span.')
               return self
             end
-            @end_timestamp = relative_timestamp(end_timestamp)
-            @span_processors.each do |processor|
-              processor.on_finishing(self) if processor.respond_to?(:on_finishing)
+            if @ending
+              OpenTelemetry.logger.warn('Calling finish on a Span that is ending.')
+              return self
             end
+
+            @end_timestamp = relative_timestamp(end_timestamp)
+            run_on_finishing_callbacks
             @attributes = validated_attributes(@attributes).freeze
             @events.freeze
             @links.freeze
@@ -330,6 +333,7 @@ module OpenTelemetry
           @resource = resource
           @instrumentation_scope = instrumentation_scope
           @ended = false
+          @ending = false
           @status = DEFAULT_STATUS
           @total_recorded_events = 0
           @total_recorded_links = links&.size || 0
@@ -382,6 +386,15 @@ module OpenTelemetry
           return yield if @mutex.owned?
 
           @mutex.synchronize(&)
+        end
+
+        def run_on_finishing_callbacks
+          @ending = true
+          @span_processors.each do |processor|
+            processor.on_finishing(self) if processor.respond_to?(:on_finishing)
+          end
+        ensure
+          @ending = false
         end
 
         def validated_attributes(attrs)

--- a/sdk/lib/opentelemetry/sdk/trace/span.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span.rb
@@ -259,7 +259,13 @@ module OpenTelemetry
         # (*) not actually non-blocking. In particular, it synchronizes on an
         # internal mutex, which will typically be uncontended, and
         # {Export::BatchSpanProcessor} will also synchronize on a mutex, if that
-        # processor is used.
+        # processor is used. The mutex is held across the {SpanProcessor#on_finishing}
+        # callbacks, so a slow processor blocks every other thread writing to
+        # this span.
+        #
+        # A {#finish} call made from within a {SpanProcessor#on_finishing}
+        # callback is ignored, with a warning logged; its `end_timestamp`
+        # argument has no effect.
         #
         # @param [Time] end_timestamp optional end timestamp for the span.
         #

--- a/sdk/lib/opentelemetry/sdk/trace/span_processor.rb
+++ b/sdk/lib/opentelemetry/sdk/trace/span_processor.rb
@@ -28,8 +28,19 @@ module OpenTelemetry
         # keyword in Ruby, we are using `on_finishing` instead.
         #
         # Called when a {Span} is ending, after the end timestamp has been set
-        # but before span becomes immutable. This allows for updating the span
-        # by setting attributes or adding links and events.
+        # but before span becomes immutable. The span may be updated here by
+        # setting attributes or adding links and events.
+        #
+        # The SDK holds the span's lock for the duration of this callback, so
+        # only the calling thread may modify the span. Writes from any other
+        # thread block until the span has ended and are then dropped with a
+        # warning. A processor must not modify the span from another thread or
+        # fiber it spawns here, because that thread or fiber would block on a
+        # lock this one holds.
+        #
+        # If any processor raises here, the span stays finishable and a later
+        # {Span#finish} runs this callback again, so it must tolerate being
+        # called more than once for the same span.
         #
         # This method is called synchronously and should not block the current
         # thread nor throw exceptions.

--- a/sdk/test/opentelemetry/sdk/trace/span_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/span_test.rb
@@ -636,6 +636,54 @@ describe OpenTelemetry::SDK::Trace::Span do
       span.finish
       _(recording).must_equal(true)
     end
+
+    it 'ignores a nested finish from a processor' do
+      OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
+        processor = OnFinishingProcessor.new(&:finish)
+        span = span_with_processors([processor])
+        span.finish
+
+        _(processor.on_finishing_count).must_equal(1)
+        _(processor.on_finish_count).must_equal(1)
+        _(log_stream.string).must_match(/Calling finish on a Span that is ending/)
+      end
+    end
+
+    it 'leaves the span finishable when a processor raises' do
+      raised = false
+      processor = OnFinishingProcessor.new do |_span|
+        next if raised
+
+        raised = true
+        raise 'boom'
+      end
+      span = span_with_processors([processor])
+
+      error = _(proc { span.finish }).must_raise(RuntimeError)
+      _(error.message).must_equal('boom')
+      _(span).must_be :recording?
+
+      span.finish
+      _(span).wont_be :recording?
+      _(processor.on_finishing_count).must_equal(2)
+      _(processor.on_finish_count).must_equal(1)
+    end
+
+    it 'runs every processor in the list' do
+      OpenTelemetry::TestHelpers.with_test_logger do
+        observed = nil
+        first = OnFinishingProcessor.new do |s|
+          s.set_attribute('first', 'yes')
+          s.finish
+        end
+        second = OnFinishingProcessor.new { |s| observed = s.attributes }
+        span = span_with_processors([first, second])
+        span.finish
+
+        _(observed).must_equal('first' => 'yes')
+        _(second.on_finishing_count).must_equal(1)
+      end
+    end
   end
 
   describe '#instrumentation_library' do

--- a/sdk/test/opentelemetry/sdk/trace/span_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/span_test.rb
@@ -504,6 +504,72 @@ describe OpenTelemetry::SDK::Trace::Span do
     end
   end
 
+  describe '#on_finishing' do
+    OnFinishingProcessor = Struct.new(:on_finishing_block, :on_finishing_count, :on_finish_count) do
+      def initialize(&block)
+        super(block, 0, 0)
+      end
+
+      def on_start(_span, _parent_context); end
+
+      def on_finishing(span)
+        self.on_finishing_count += 1
+        on_finishing_block.call(span)
+      end
+
+      def on_finish(_span)
+        self.on_finish_count += 1
+      end
+    end
+
+    # The file-level span_limits caps attributes, events and links at 1 each,
+    # which would mask what these tests are checking.
+    def span_with_processors(processors)
+      Span.new(context, Context.empty, OpenTelemetry::Trace::Span::INVALID, 'name', SpanKind::INTERNAL, nil,
+               OpenTelemetry::SDK::Trace::SpanLimits::DEFAULT, processors, nil, nil, Time.now, nil, nil)
+    end
+
+    def wait_until(timeout: 5)
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+      until yield
+        flunk('timed out waiting for the writer thread to block on the span') if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+
+        sleep(0.001)
+      end
+    end
+
+    it 'prevents other threads from modifying the span once it is ending' do
+      OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
+        ending = Queue.new
+        release = Queue.new
+        span = span_with_processors([OnFinishingProcessor.new do |_span|
+          ending << :ending
+          release.pop
+        end])
+
+        finisher = Thread.new { span.finish }
+        writer = nil
+        begin
+          ending.pop
+
+          writer = Thread.new { span.set_attribute('other', 'thread') }
+          wait_until { writer.status == 'sleep' }
+
+          release << :go
+          [finisher, writer].each(&:join)
+
+          _(span.to_span_data.attributes).must_be_nil
+          _(log_stream.string).must_match(/Calling set_attribute on an ended Span/)
+        ensure
+          # A failed assertion or a flunk above leaves both threads parked on
+          # the span's mutex, which would leak them into the rest of the suite.
+          release << :go
+          [finisher, writer].compact.each { |thread| thread.kill.join }
+        end
+      end
+    end
+  end
+
   describe '#instrumentation_library' do
     it 'is identical to the instrumentation_scope' do
       mock_span_processor.expect(:on_start, nil) { |_s| pass }

--- a/sdk/test/opentelemetry/sdk/trace/span_test.rb
+++ b/sdk/test/opentelemetry/sdk/trace/span_test.rb
@@ -568,6 +568,74 @@ describe OpenTelemetry::SDK::Trace::Span do
         end
       end
     end
+
+    it 'allows a processor to set an attribute' do
+      span = span_with_processors([OnFinishingProcessor.new { |s| s.set_attribute('finishing', 'yes') }])
+      span.finish
+      _(span.to_span_data.attributes).must_equal('finishing' => 'yes')
+    end
+
+    it 'allows a processor to add attributes' do
+      span = span_with_processors([OnFinishingProcessor.new { |s| s.add_attributes('finishing' => 'yes') }])
+      span.finish
+      _(span.to_span_data.attributes).must_equal('finishing' => 'yes')
+    end
+
+    it 'allows a processor to add an event' do
+      span = span_with_processors([OnFinishingProcessor.new { |s| s.add_event('finishing') }])
+      span.finish
+      _(span.to_span_data.events.map(&:name)).must_equal(['finishing'])
+    end
+
+    it 'allows a processor to add a link' do
+      span = span_with_processors([OnFinishingProcessor.new { |s| s.add_link(OpenTelemetry::Trace::Link.new(context)) }])
+      span.finish
+      _(span.to_span_data.links.map(&:span_context)).must_equal([context])
+    end
+
+    it 'allows a processor to set the status' do
+      span = span_with_processors([OnFinishingProcessor.new { |s| s.status = Status.error('cancelled') }])
+      span.finish
+      _(span.to_span_data.status.code).must_equal(Status::ERROR)
+    end
+
+    it 'allows a processor to set the name' do
+      span = span_with_processors([OnFinishingProcessor.new { |s| s.name = 'renamed' }])
+      span.finish
+      _(span.to_span_data.name).must_equal('renamed')
+    end
+
+    it 'counts attributes set by a processor' do
+      span = span_with_processors([OnFinishingProcessor.new { |s| s.set_attribute('finishing', 'yes') }])
+      span.set_attribute('before', 'yes')
+      span.finish
+      _(span.to_span_data.total_recorded_attributes).must_equal(2)
+    end
+
+    it 'does not warn that the span has ended' do
+      OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
+        span = span_with_processors([OnFinishingProcessor.new { |s| s.set_attribute('finishing', 'yes') }])
+        span.finish
+        _(log_stream.string).must_be_empty
+      end
+    end
+
+    it 'validates attributes written by a processor' do
+      OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
+        span = span_with_processors([OnFinishingProcessor.new { |s| s.set_attribute('finishing', :invalid) }])
+        span.finish
+        _(span.to_span_data.attributes).must_equal({})
+        _(span.to_span_data.attributes).must_be :frozen?
+        _(log_stream.string).must_match(/invalid span attribute value type Symbol for key 'finishing' on span 'name'/)
+      end
+    end
+
+    it 'is still recording while a processor runs' do
+      recording = nil
+      span = span_with_processors([OnFinishingProcessor.new { |s| recording = s.recording? }])
+      span.finish
+      _(recording).must_equal(true)
+    end
   end
 
   describe '#instrumentation_library' do


### PR DESCRIPTION
## Summary

Fix a bug prevented `on_finishing` callouts from mutating the span, while adhering to the OpenTelmetry requirement that no other thread be allowed to mutate the span while `on_finishing` is running (see #1740). If this is attempted, the semantics are unchanged: the other thread will block on the mutex, and then see the ended span causing the call to be dropped with the usual warning.

Previously, `Span#finish` held the span's mutex across `on_finishing` cause a `ThreadError: deadlock; recursive locking`.

Two implementation notes:

- Reentrancy would turn a processor's nested `finish` into unbounded recursion, so an
  `@ending` flag makes that call warn and return.
- An `ensure` resets `@ending`, so a processor that raises leaves the span unended,
  mutable and finishable — exactly as today.

## AI Disclosure

This PR was assisted by AI (Claude Code), with human review before submitting.

Fixes #1824
Fixes #1740