### PR TITLE
fix(metrics): size exponential histogram exemplar reservoirs

### DIFF
--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/aggregation/exponential_bucket_histogram.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/aggregation/exponential_bucket_histogram.rb
@@ -29,10 +29,6 @@ module OpenTelemetry
 
           attr_reader :exemplar_reservoir
 
-          # if no reservoir pass from instrument, then use this empty reservoir to avoid no method found error
-          DEFAULT_RESERVOIR = Metrics::Exemplar::SimpleFixedSizeExemplarReservoir.new
-          private_constant :DEFAULT_RESERVOIR
-
           # The default boundaries are calculated based on default max_size and max_scale values
           def initialize(
             aggregation_temporality: ENV.fetch('OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE', :delta),
@@ -53,7 +49,7 @@ module OpenTelemetry
             @size           = validate_size(max_size)
             @scale          = validate_scale(max_scale)
 
-            @exemplar_reservoir = exemplar_reservoir || DEFAULT_RESERVOIR
+            @exemplar_reservoir = exemplar_reservoir || Metrics::Exemplar::SimpleFixedSizeExemplarReservoir.new(max_size: [20, @size].min)
             @exemplar_reservoir_storage = {}
 
             @mapping = new_mapping(@scale)

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/aggregation/exponential_bucket_histogram_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/aggregation/exponential_bucket_histogram_test.rb
@@ -27,6 +27,16 @@ describe OpenTelemetry::SDK::Metrics::Aggregation::ExponentialBucketHistogram do
   let(:end_time) { Process.clock_gettime(Process::CLOCK_REALTIME, :nanosecond) + (60 * 1_000_000_000) }
   let(:cardinality_limit) { 2000 }
 
+  describe '#initialize' do
+    it 'sizes the default exemplar reservoir to the number of buckets up to 20' do
+      [[4, 4], [20, 20], [32, 20]].each do |max_size, expected_size|
+        histogram = OpenTelemetry::SDK::Metrics::Aggregation::ExponentialBucketHistogram.new(max_size: max_size)
+
+        _(histogram.exemplar_reservoir.instance_variable_get(:@max_size)).must_equal expected_size
+      end
+    end
+  end
+
   describe '#collect' do
     it 'returns all the data points' do
       expbh.update(1.03, {}, data_points, cardinality_limit)


### PR DESCRIPTION
Fixes #2366.

The default exemplar reservoir for exponential histograms used the reservoir's CPU-count default instead of the specification's `min(20, max_size)` sizing rule.

This creates the default reservoir after validating `max_size`, with an explicit size capped at 20. Custom reservoirs are unchanged. The regression test covers smaller-than-20, equal-to-20, and larger-than-20 histograms.

Validation:
- `git diff --check`
- Focused Ruby tests not run: Ruby/Bundler is not installed in the execution environment.

AI assistance is disclosed in the commit trailer: `Assisted-by: Codex`.