### PR TITLE
fix(metrics): prevent readers spanning providers

### DIFF
--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/export/metric_reader.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/export/metric_reader.rb
@@ -15,16 +15,19 @@ module OpenTelemetry
           attr_reader :metric_store
 
           def initialize(aggregation_cardinality_limit: nil)
+            @mutex = Mutex.new
             @metric_store = OpenTelemetry::SDK::Metrics::State::MetricStore.new(cardinality_limit: aggregation_cardinality_limit)
           end
 
           # Registers this reader with a MeterProvider.
           def register_meter_provider(meter_provider)
-            if @meter_provider && !@meter_provider.equal?(meter_provider)
-              raise ArgumentError, 'MetricReader cannot be registered with more than one MeterProvider'
-            end
+            @mutex.synchronize do
+              if @meter_provider && !@meter_provider.equal?(meter_provider)
+                raise ArgumentError, 'MetricReader cannot be registered with more than one MeterProvider'
+              end
 
-            @meter_provider = meter_provider
+              @meter_provider = meter_provider
+            end
           end
 
           # Collects and returns the current metrics from the metric store.

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/export/metric_reader.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/export/metric_reader.rb
@@ -18,6 +18,15 @@ module OpenTelemetry
             @metric_store = OpenTelemetry::SDK::Metrics::State::MetricStore.new(cardinality_limit: aggregation_cardinality_limit)
           end
 
+          # Registers this reader with a MeterProvider.
+          def register_meter_provider(meter_provider)
+            if @meter_provider && !@meter_provider.equal?(meter_provider)
+              raise ArgumentError, 'MetricReader cannot be registered with more than one MeterProvider'
+            end
+
+            @meter_provider = meter_provider
+          end
+
           # Collects and returns the current metrics from the metric store.
           def collect
             @metric_store.collect

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/meter_provider.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/meter_provider.rb
@@ -13,6 +13,10 @@ module OpenTelemetry
       # rubocop:disable-next Metrics/ClassLength
       class MeterProvider < OpenTelemetry::Metrics::MeterProvider
         EMPTY_ATTRIBUTES = {}.freeze
+        READER_OWNERS = ObjectSpace::WeakMap.new
+        READER_OWNERS_MUTEX = Mutex.new
+
+        private_constant :READER_OWNERS, :READER_OWNERS_MUTEX
 
         Key = Struct.new(:name, :version, :attributes)
         private_constant(:Key)
@@ -118,7 +122,7 @@ module OpenTelemetry
             if @stopped
               OpenTelemetry.logger.warn('calling MetricProvider#add_metric_reader after shutdown.')
             else
-              metric_reader.register_meter_provider(self) if metric_reader.respond_to?(:register_meter_provider)
+              register_metric_reader(metric_reader)
               @metric_readers.push(metric_reader)
               @meter_registry.each_value { |meter| meter.add_metric_reader(metric_reader) }
             end
@@ -126,6 +130,20 @@ module OpenTelemetry
             nil
           end
         end
+
+        def register_metric_reader(metric_reader)
+          READER_OWNERS_MUTEX.synchronize do
+            owner = READER_OWNERS[metric_reader]
+            if owner && !owner.equal?(self)
+              raise ArgumentError, 'MetricReader cannot be registered with more than one MeterProvider'
+            end
+
+            READER_OWNERS[metric_reader] = self
+          end
+
+          metric_reader.register_meter_provider(self) if metric_reader.respond_to?(:register_meter_provider)
+        end
+        private :register_metric_reader
 
         # @api private
         def register_synchronous_instrument(instrument)

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/meter_provider.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/meter_provider.rb
@@ -118,6 +118,7 @@ module OpenTelemetry
             if @stopped
               OpenTelemetry.logger.warn('calling MetricProvider#add_metric_reader after shutdown.')
             else
+              metric_reader.register_meter_provider(self) if metric_reader.respond_to?(:register_meter_provider)
               @metric_readers.push(metric_reader)
               @meter_registry.each_value { |meter| meter.add_metric_reader(metric_reader) }
             end

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/exemplar/exemplar_integration_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/exemplar/exemplar_integration_test.rb
@@ -229,7 +229,11 @@ describe OpenTelemetry::SDK do
 
     it 'emits exponential bucket histogram metrics with exemplars' do
       reset_metrics_sdk
-      meter = create_meter
+      # The let(:metric_exporter) reader is already registered with the
+      # MeterProvider created in the before block; the reset provider needs
+      # its own reader.
+      metric_exporter = OpenTelemetry::SDK::Metrics::Export::InMemoryMetricPullExporter.new
+      meter = create_meter(metric_exporter)
       OpenTelemetry.meter_provider.add_view(
         'exponential_histogram',
         aggregation: OpenTelemetry::SDK::Metrics::Aggregation::ExponentialBucketHistogram.new(exemplar_reservoir: OpenTelemetry::SDK::Metrics::Exemplar::SimpleFixedSizeExemplarReservoir.new(max_size: 4))
@@ -304,7 +308,11 @@ describe OpenTelemetry::SDK do
 
     it 'emits counter metrics with exemplars across multiple views' do
       reset_metrics_sdk
-      meter = create_meter
+      # The let(:metric_exporter) reader is already registered with the
+      # MeterProvider created in the before block; the reset provider needs
+      # its own reader.
+      metric_exporter = OpenTelemetry::SDK::Metrics::Export::InMemoryMetricPullExporter.new
+      meter = create_meter(metric_exporter)
 
       # Add multiple views for the same counter
       OpenTelemetry.meter_provider.add_view(

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/meter_provider_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/meter_provider_test.rb
@@ -163,6 +163,20 @@ describe OpenTelemetry::SDK::Metrics::MeterProvider do
       _(second_provider.metric_readers).must_equal([])
     end
 
+    it 'does not allow a duck-typed metric reader to be registered with multiple providers' do
+      metric_reader = Struct.new(:metric_store) do
+        def shutdown(timeout: nil); end
+        def force_flush(timeout: nil); end
+      end.new(nil)
+      first_provider = OpenTelemetry::SDK::Metrics::MeterProvider.new
+      second_provider = OpenTelemetry::SDK::Metrics::MeterProvider.new
+
+      first_provider.add_metric_reader(metric_reader)
+
+      _ { second_provider.add_metric_reader(metric_reader) }.must_raise(ArgumentError)
+      _(second_provider.metric_readers).must_equal([])
+    end
+
     it 'associates the metric store with instruments created before the metric reader' do
       meter_a = OpenTelemetry.meter_provider.meter('a').create_counter('meter_a')
 

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/meter_provider_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/meter_provider_test.rb
@@ -177,6 +177,23 @@ describe OpenTelemetry::SDK::Metrics::MeterProvider do
       _(second_provider.metric_readers).must_equal([])
     end
 
+    it 'serializes concurrent metric reader registration' do
+      metric_reader = OpenTelemetry::SDK::Metrics::Export::MetricReader.new
+      providers = 2.times.map { OpenTelemetry::SDK::Metrics::MeterProvider.new }
+      errors = Queue.new
+
+      threads = providers.map do |provider|
+        Thread.new do
+          metric_reader.register_meter_provider(provider)
+        rescue ArgumentError => e
+          errors << e
+        end
+      end
+      threads.each(&:join)
+
+      _(errors.size).must_equal 1
+    end
+
     it 'associates the metric store with instruments created before the metric reader' do
       meter_a = OpenTelemetry.meter_provider.meter('a').create_counter('meter_a')
 

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/meter_provider_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/meter_provider_test.rb
@@ -152,6 +152,17 @@ describe OpenTelemetry::SDK::Metrics::MeterProvider do
       _(OpenTelemetry.meter_provider.instance_variable_get(:@metric_readers)).must_equal([metric_reader])
     end
 
+    it 'does not allow a metric reader to be registered with multiple providers' do
+      metric_reader = OpenTelemetry::SDK::Metrics::Export::MetricReader.new
+      first_provider = OpenTelemetry::SDK::Metrics::MeterProvider.new
+      second_provider = OpenTelemetry::SDK::Metrics::MeterProvider.new
+
+      first_provider.add_metric_reader(metric_reader)
+
+      _ { second_provider.add_metric_reader(metric_reader) }.must_raise(ArgumentError)
+      _(second_provider.metric_readers).must_equal([])
+    end
+
     it 'associates the metric store with instruments created before the metric reader' do
       meter_a = OpenTelemetry.meter_provider.meter('a').create_counter('meter_a')
 

--- a/metrics_sdk/test/test_helper.rb
+++ b/metrics_sdk/test/test_helper.rb
@@ -35,7 +35,7 @@ ensure
   OpenTelemetry.logger = original_logger
 end
 
-def create_meter
+def create_meter(metric_exporter)
   ENV['OTEL_TRACES_EXPORTER'] = 'console'
   ENV['OTEL_METRICS_EXPORTER'] = 'none'
   OpenTelemetry::SDK.configure


### PR DESCRIPTION
Fixes #2365.

The metrics SDK must reject registering the same `MetricReader` with more than one `MeterProvider`. This adds reader ownership tracking and raises `ArgumentError` before the second provider stores or wires the reader.

Validation:
- `git diff --check`
- Added a focused regression test in `meter_provider_test.rb`
- Ruby/Bundler tests unavailable in this environment because Ruby is not installed.

AI assistance is disclosed in the commit trailer.