### PR TITLE
fix(logs): summarize discarded record attributes

### DIFF
--- a/logs_sdk/lib/opentelemetry/sdk/logs/log_record.rb
+++ b/logs_sdk/lib/opentelemetry/sdk/logs/log_record.rb
@@ -124,38 +124,51 @@ module OpenTelemetry
           return if attributes.nil?
 
           # truncate total attributes
-          truncate_attributes(attributes, @log_record_limits.attribute_count_limit)
+          discarded_attributes = truncate_attributes(
+            attributes,
+            @log_record_limits.attribute_count_limit
+          )
 
           # truncate attribute values
           truncate_attribute_values(attributes, @log_record_limits.attribute_length_limit)
 
           # validate attributes
-          validate_attributes(attributes)
+          discarded_attributes += validate_attributes(attributes)
+
+          if discarded_attributes.positive?
+            OpenTelemetry.handle_error(
+              message: "Discarded #{discarded_attributes} log record attributes due to limits or invalid values"
+            )
+          end
 
           nil
         end
 
         def truncate_attributes(attributes, attribute_limit)
           excess = attributes.size - attribute_limit
-          excess.times { attributes.shift } if excess.positive?
+          return 0 unless excess.positive?
+
+          excess.times { attributes.shift }
+          excess
         end
 
         def validate_attributes(attrs)
           # Similar to Internal.valid_attributes?, but with different messages
           # Future refactor opportunity: https://github.com/open-telemetry/opentelemetry-ruby/issues/1739
+          discarded_attributes = 0
           attrs.keep_if do |k, v|
             if !Internal.valid_key?(k)
-              OpenTelemetry.handle_error(message: "Invalid log record attribute key type #{k.class} for " \
-                                                  "key #{k.inspect} on record: '#{body}'. Attribute keys must be Strings. Dropping attribute.")
-              return false
+              discarded_attributes += 1
+              false
             elsif !Internal.valid_value?(v)
-              OpenTelemetry.handle_error(message: "Invalid log record attribute value type #{v.class} for key '#{k}' " \
-                                                  "on record: '#{body}'. Dropping attribute.")
-              return false
+              discarded_attributes += 1
+              false
             end
 
             true
           end
+
+          discarded_attributes
         end
 
         def truncate_attribute_values(attributes, attribute_length_limit)

--- a/logs_sdk/test/opentelemetry/sdk/logs/log_record_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/log_record_test.rb
@@ -125,14 +125,28 @@ describe OpenTelemetry::SDK::Logs::LogRecord do
       it 'emits an error message if attribute key is invalid' do
         OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
           logger.on_emit(attributes: { a: 'a' })
-          assert_match(/Invalid log record attribute key type Symbol/, log_stream.string)
+          assert_match(/Discarded 1 log record attributes/, log_stream.string)
         end
       end
 
       it 'emits an error message if the attribute value is invalid' do
         OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
           logger.on_emit(attributes: { 'a' => Class.new })
-          assert_match(/Invalid log record attribute value type Class/, log_stream.string)
+          assert_match(/Discarded 1 log record attributes/, log_stream.string)
+        end
+      end
+
+      it 'emits one error message when multiple attributes are discarded' do
+        OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
+          limits = Logs::LogRecordLimits.new(attribute_count_limit: 2)
+          Logs::LogRecord.new(
+            log_record_limits: limits,
+            attributes: { 'a' => 'a', 'b' => Class.new, c: 'c' }
+          )
+
+          messages = log_stream.string.lines.grep(/Discarded \d+ log record attributes/)
+          assert_equal(1, messages.length)
+          assert_match(/Discarded 2 log record attributes/, messages.first)
         end
       end
 

--- a/logs_sdk/test/opentelemetry/sdk/logs/log_record_test.rb
+++ b/logs_sdk/test/opentelemetry/sdk/logs/log_record_test.rb
@@ -141,7 +141,7 @@ describe OpenTelemetry::SDK::Logs::LogRecord do
           limits = Logs::LogRecordLimits.new(attribute_count_limit: 2)
           Logs::LogRecord.new(
             log_record_limits: limits,
-            attributes: { 'a' => 'a', 'b' => Class.new, c: 'c' }
+            attributes: { 'a' => 'a', 'b' => Class.new, 'c' => 'c' }
           )
 
           messages = log_stream.string.lines.grep(/Discarded \d+ log record attributes/)


### PR DESCRIPTION
Fixes #2351

LogRecord now emits a single summary error when attributes are discarded by the count limit or rejected during validation. This avoids both silent truncation and one error per invalid attribute while preserving the existing attribute filtering behavior.

Added focused coverage for a record that loses attributes through both paths.

Validation:
- `git diff --check` passed
- Ruby/Bundler tests and RuboCop could not run because Ruby is not installed in the environment.

Signed-off-by: Louis Deconinck <louis.dck@gmail.com>
Assisted-by: Codex