### PR TITLE
fix(logs): handle partial success responses

### DIFF
--- a/exporter/otlp-logs/lib/opentelemetry/exporter/otlp/logs/logs_exporter.rb
+++ b/exporter/otlp-logs/lib/opentelemetry/exporter/otlp/logs/logs_exporter.rb
@@ -170,7 +170,7 @@ module OpenTelemetry
 
               case response
               when Net::HTTPSuccess
-                response.body # Read and discard body
+                log_partial_success(response.body)
                 SUCCESS
               when Net::HTTPServiceUnavailable, Net::HTTPTooManyRequests
                 response.body # Read and discard body
@@ -246,6 +246,18 @@ module OpenTelemetry
             OpenTelemetry.handle_error(message: "OTLP logs exporter received rpc.Status{message=#{status.message}, details=#{details}}")
           rescue StandardError => e
             OpenTelemetry.handle_error(exception: e, message: 'unexpected error decoding rpc.Status in OTLP::Exporter#log_status')
+          end
+
+          def log_partial_success(body)
+            response = Opentelemetry::Proto::Collector::Logs::V1::ExportLogsServiceResponse.decode(body)
+            partial_success = response.partial_success
+            return if partial_success.nil? || partial_success.rejected_log_records <= 0
+
+            OpenTelemetry.handle_error(
+              message: "OTLP logs exporter received partial success: rejected_log_records=#{partial_success.rejected_log_records}, error_message=#{partial_success.error_message}"
+            )
+          rescue StandardError => e
+            OpenTelemetry.handle_error(exception: e, message: 'unexpected error decoding ExportLogsServiceResponse in OTLP::Exporter#log_partial_success')
           end
 
           def backoff?(retry_count:, retry_after: nil) # rubocop:disable Metrics/CyclomaticComplexity

--- a/exporter/otlp-logs/test/opentelemetry/exporter/otlp/logs_exporter_test.rb
+++ b/exporter/otlp-logs/test/opentelemetry/exporter/otlp/logs_exporter_test.rb
@@ -489,6 +489,24 @@ describe OpenTelemetry::Exporter::OTLP::Logs::LogsExporter do
       _(result).must_equal(FAILURE)
     end
 
+    it 'logs rejected records reported in a partial success response' do
+      response = Opentelemetry::Proto::Collector::Logs::V1::ExportLogsServiceResponse.encode(
+        Opentelemetry::Proto::Collector::Logs::V1::ExportLogsServiceResponse.new(
+          partial_success: Opentelemetry::Proto::Collector::Logs::V1::ExportLogsPartialSuccess.new(
+            rejected_log_records: 2,
+            error_message: 'record limit exceeded'
+          )
+        )
+      )
+      stub_request(:post, 'http://localhost:4318/v1/logs').to_return(status: 200, body: response)
+
+      OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
+        log_record_data = OpenTelemetry::TestHelpers.create_log_record_data
+        _(exporter.export([log_record_data])).must_equal(SUCCESS)
+        _(log_stream.string).must_match(/rejected_log_records=2, error_message=record limit exceeded/)
+      end
+    end
+
     it 'returns FAILURE on unexpected exceptions' do
       log_stream = StringIO.new
       logger = OpenTelemetry.logger


### PR DESCRIPTION
Fixes #2355

The OTLP logs exporter now decodes successful export responses and reports rejected log records from `partial_success` through the existing OpenTelemetry error handler. Successful partial exports still return `SUCCESS`.

Added focused WebMock coverage for the response and log message.

Validation:
- `git diff --check` passed
- Ruby/Bundler tests and RuboCop could not run because Ruby is not installed in the environment.

Signed-off-by: Louis Deconinck <louis.dck@gmail.com>
Assisted-by: Codex