### PR TITLE
fix(metrics): make exemplar reservoirs thread-safe

### DIFF
--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/aligned_histogram_bucket_exemplar_reservoir.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/aligned_histogram_bucket_exemplar_reservoir.rb
@@ -22,7 +22,8 @@ module OpenTelemetry
           # @param boundaries [Array<Numeric>] The bucket boundaries for the histogram
           def initialize(boundaries: nil)
             @boundaries = boundaries || DEFAULT_BOUNDARIES
-            reset
+            @mutex = Mutex.new
+            reset!
           end
 
           # Offers a measurement to the reservoir for potential sampling
@@ -32,8 +33,10 @@ module OpenTelemetry
           # @param attributes [Hash] The complete set of attributes
           # @param context [Context] The OpenTelemetry context
           def offer(value: nil, timestamp: nil, attributes: nil, context: nil)
-            bucket_index = find_histogram_bucket(value)
-            @exemplar_buckets[bucket_index].offer(value: value, time_unix_nano: timestamp, attributes: attributes, context: context)
+            @mutex.synchronize do
+              bucket_index = find_histogram_bucket(value)
+              @exemplar_buckets[bucket_index].offer(value: value, time_unix_nano: timestamp, attributes: attributes, context: context)
+            end
             nil
           end
 
@@ -43,15 +46,17 @@ module OpenTelemetry
           # @param aggregation_temporality [Symbol] :delta or :cumulative
           # @return [Array<Exemplar>] The collected exemplars
           def collect(attributes: nil, aggregation_temporality: nil)
-            exemplars = @exemplar_buckets.map { |bucket| bucket.collect(point_attributes: attributes) }
-            reset if aggregation_temporality == :delta
-            exemplars.compact!
-            exemplars
+            @mutex.synchronize do
+              exemplars = @exemplar_buckets.map { |bucket| bucket.collect(point_attributes: attributes) }
+              reset! if aggregation_temporality == :delta
+              exemplars.compact!
+              exemplars
+            end
           end
 
           # Clears all sampled exemplars from the reservoir.
           def reset
-            @exemplar_buckets = Array.new(@boundaries.size + 1) { ExemplarBucket.new }
+            @mutex.synchronize { reset! }
           end
 
           private
@@ -62,6 +67,10 @@ module OpenTelemetry
           # @return [Integer] The bucket index (0 to boundaries.size)
           def find_histogram_bucket(value)
             @boundaries.bsearch_index { |boundary| boundary >= value } || @boundaries.size
+          end
+
+          def reset!
+            @exemplar_buckets = Array.new(@boundaries.size + 1) { ExemplarBucket.new }
           end
         end
       end

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/simple_fixed_size_exemplar_reservoir.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/exemplar/simple_fixed_size_exemplar_reservoir.rb
@@ -21,35 +21,46 @@ module OpenTelemetry
 
           def initialize(max_size: nil)
             @max_size = max_size || DEFAULT_SIZE
-            reset
+            @mutex = Mutex.new
+            reset!
           end
 
           # Uses a uniformly-weighted sampling algorithm based on the number of samples the reservoir has seen
           # Fill the buckets array first then randomly override existing bucket
           def offer(value: nil, timestamp: nil, attributes: nil, context: nil)
-            bucket_index = find_histogram_bucket
-            @exemplar_buckets[bucket_index].offer(value: value, time_unix_nano: timestamp, attributes: attributes, context: context) if bucket_index < @max_size
-            @num_measurements_seen += 1
+            @mutex.synchronize do
+              bucket_index = find_histogram_bucket
+              @exemplar_buckets[bucket_index].offer(value: value, time_unix_nano: timestamp, attributes: attributes, context: context) if bucket_index < @max_size
+              @num_measurements_seen += 1
+            end
             nil
           end
 
           # Reset measurement counter on collection for delta temporality
           def collect(attributes: nil, aggregation_temporality: nil)
-            exemplars = @exemplar_buckets.map { |bucket| bucket.collect(point_attributes: attributes) }
-            reset if aggregation_temporality == :delta
-            exemplars.compact!
-            exemplars
+            @mutex.synchronize do
+              exemplars = @exemplar_buckets.map { |bucket| bucket.collect(point_attributes: attributes) }
+              reset! if aggregation_temporality == :delta
+              exemplars.compact!
+              exemplars
+            end
           end
 
           # Clears all sampled exemplars and the measurement counter.
           def reset
-            @exemplar_buckets = Array.new(@max_size) { ExemplarBucket.new }
-            @num_measurements_seen = 0
+            @mutex.synchronize { reset! }
           end
 
           # Returns the bucket index to sample into for the current measurement.
           def find_histogram_bucket
             @num_measurements_seen < @max_size ? @num_measurements_seen : rand(0..(@num_measurements_seen - 1))
+          end
+
+          private
+
+          def reset!
+            @exemplar_buckets = Array.new(@max_size) { ExemplarBucket.new }
+            @num_measurements_seen = 0
           end
         end
       end

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/exemplar/aligned_histogram_bucket_exemplar_reservoir_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/exemplar/aligned_histogram_bucket_exemplar_reservoir_test.rb
@@ -80,6 +80,17 @@ describe OpenTelemetry::SDK::Metrics::Exemplar::AlignedHistogramBucketExemplarRe
       _(bucket_1_exemplars[0].value).must_be :>, 0
       _(bucket_1_exemplars[0].value).must_be :<=, 5
     end
+
+    it 'supports concurrent offers' do
+      threads = 10.times.map do
+        Thread.new do
+          100.times { reservoir.offer(value: 3, timestamp: timestamp, attributes: attributes, context: context) }
+        end
+      end
+      threads.each(&:join)
+
+      _(reservoir.collect.size).must_equal 1
+    end
   end
 
   describe '#collect' do

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/exemplar/simple_fixed_size_exemplar_reservoir_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/exemplar/simple_fixed_size_exemplar_reservoir_test.rb
@@ -54,6 +54,19 @@ describe OpenTelemetry::SDK::Metrics::Exemplar::SimpleFixedSizeExemplarReservoir
         _(exemplar.trace_id.unpack1('H*')).must_equal '77cb6ccc522d310611014dd6ecbb70036a'
       end
     end
+
+    it 'supports concurrent offers' do
+      threads = 10.times.map do |thread_index|
+        Thread.new do
+          100.times do |i|
+            reservoir.offer(value: thread_index * 100 + i, timestamp: timestamp, attributes: attributes, context: context)
+          end
+        end
+      end
+      threads.each(&:join)
+
+      _(reservoir.collect.size).must_equal max_size
+    end
   end
 
   describe '#collect' do


### PR DESCRIPTION
## Summary

- synchronize exemplar reservoir mutation and collection with a mutex
- keep delta resets atomic with collection
- add concurrent-offer regression coverage for both reservoir implementations

Fixes #2367

## Validation

- `git diff --check`
- `bundle exec rake test` in `metrics_sdk` (337 runs), `metrics_api` (17 runs), and `logs_api` (10 runs) via the repo's docker image — all green.

Assisted-by: Codex
