### PR TITLE
fix: detect metric instrument name conflicts case-insensitively

### DIFF
--- a/metrics_api/lib/opentelemetry/internal/proxy_meter.rb
+++ b/metrics_api/lib/opentelemetry/internal/proxy_meter.rb
@@ -39,17 +39,17 @@ module OpenTelemetry
       private
 
       def create_instrument(kind, name, unit, description, callback, exemplar_filter, exemplar_reservoir)
-        super do
-          next ProxyInstrument.new(kind, name, unit, description, callback, exemplar_filter, exemplar_reservoir) if @delegate.nil?
+        super do |instrument_name|
+          next ProxyInstrument.new(kind, instrument_name, unit, description, callback, exemplar_filter, exemplar_reservoir) if @delegate.nil?
 
           case kind
-          when :counter then @delegate.create_counter(name, unit: unit, description: description, exemplar_filter: exemplar_filter, exemplar_reservoir: exemplar_reservoir)
-          when :histogram then @delegate.create_histogram(name, unit: unit, description: description, exemplar_filter: exemplar_filter, exemplar_reservoir: exemplar_reservoir)
-          when :up_down_counter then @delegate.create_up_down_counter(name, unit: unit, description: description, exemplar_filter: exemplar_filter, exemplar_reservoir: exemplar_reservoir)
-          when :gauge then @delegate.create_gauge(name, unit: unit, description: description, exemplar_filter: exemplar_filter, exemplar_reservoir: exemplar_reservoir)
-          when :observable_counter then @delegate.create_observable_counter(name, unit: unit, description: description, exemplar_filter: exemplar_filter, exemplar_reservoir: exemplar_reservoir, callback: callback)
-          when :observable_gauge then @delegate.create_observable_gauge(name, unit: unit, description: description, exemplar_filter: exemplar_filter, exemplar_reservoir: exemplar_reservoir, callback: callback)
-          when :observable_up_down_counter then @delegate.create_observable_up_down_counter(name, unit: unit, description: description, exemplar_filter: exemplar_filter, exemplar_reservoir: exemplar_reservoir, callback: callback)
+          when :counter then @delegate.create_counter(instrument_name, unit: unit, description: description, exemplar_filter: exemplar_filter, exemplar_reservoir: exemplar_reservoir)
+          when :histogram then @delegate.create_histogram(instrument_name, unit: unit, description: description, exemplar_filter: exemplar_filter, exemplar_reservoir: exemplar_reservoir)
+          when :up_down_counter then @delegate.create_up_down_counter(instrument_name, unit: unit, description: description, exemplar_filter: exemplar_filter, exemplar_reservoir: exemplar_reservoir)
+          when :gauge then @delegate.create_gauge(instrument_name, unit: unit, description: description, exemplar_filter: exemplar_filter, exemplar_reservoir: exemplar_reservoir)
+          when :observable_counter then @delegate.create_observable_counter(instrument_name, unit: unit, description: description, exemplar_filter: exemplar_filter, exemplar_reservoir: exemplar_reservoir, callback: callback)
+          when :observable_gauge then @delegate.create_observable_gauge(instrument_name, unit: unit, description: description, exemplar_filter: exemplar_filter, exemplar_reservoir: exemplar_reservoir, callback: callback)
+          when :observable_up_down_counter then @delegate.create_observable_up_down_counter(instrument_name, unit: unit, description: description, exemplar_filter: exemplar_filter, exemplar_reservoir: exemplar_reservoir, callback: callback)
           end
         end
       end

--- a/metrics_api/lib/opentelemetry/metrics/meter.rb
+++ b/metrics_api/lib/opentelemetry/metrics/meter.rb
@@ -30,6 +30,7 @@ module OpenTelemetry
       def initialize
         @mutex = Mutex.new
         @instrument_registry = {}
+        @instrument_name_registry = {}
       end
 
       # {https://opentelemetry.io/docs/specs/otel/metrics/api/#counter Counter} is a synchronous Instrument which supports non-negative increments.
@@ -255,9 +256,14 @@ module OpenTelemetry
 
       def create_instrument(kind, name, unit, description, callback, exemplar_filter, exemplar_reservoir)
         @mutex.synchronize do
-          OpenTelemetry.logger.warn("duplicate instrument registration occurred for instrument #{name}") if @instrument_registry.include? name
+          registry_key = name.is_a?(String) ? name.downcase : name
+          registered_name = @instrument_name_registry[registry_key]
 
-          @instrument_registry[name] = yield
+          OpenTelemetry.logger.warn("duplicate instrument registration occurred for instrument #{name}") if registered_name
+
+          instrument_name = registered_name || name
+          @instrument_name_registry[registry_key] = instrument_name
+          @instrument_registry[registry_key] = yield(instrument_name)
         end
       end
     end

--- a/metrics_api/lib/opentelemetry/metrics/meter.rb
+++ b/metrics_api/lib/opentelemetry/metrics/meter.rb
@@ -256,14 +256,15 @@ module OpenTelemetry
 
       def create_instrument(kind, name, unit, description, callback, exemplar_filter, exemplar_reservoir)
         @mutex.synchronize do
-          registry_key = name.is_a?(String) ? name.downcase : name
-          registered_name = @instrument_name_registry[registry_key]
+          name_key = name.is_a?(String) ? name.downcase : name
+          registered_name = @instrument_name_registry[name_key]
 
           OpenTelemetry.logger.warn("duplicate instrument registration occurred for instrument #{name}") if registered_name
 
           instrument_name = registered_name || name
-          @instrument_name_registry[registry_key] = instrument_name
-          @instrument_registry[registry_key] = yield(instrument_name)
+          @instrument_name_registry[name_key] = instrument_name
+          registry_key = [name_key, kind, unit, description, callback, exemplar_filter, exemplar_reservoir]
+          @instrument_registry[registry_key] ||= yield(instrument_name)
         end
       end
     end

--- a/metrics_api/test/opentelemetry/metrics/meter_test.rb
+++ b/metrics_api/test/opentelemetry/metrics/meter_test.rb
@@ -19,6 +19,14 @@ describe OpenTelemetry::Metrics::Meter do
       end
     end
 
+    it 'case-insensitive duplicate instrument registration logs a warning' do
+      OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
+        meter.create_counter('requestCount')
+        meter.create_counter('RequestCount')
+        _(log_stream.string).must_match(/duplicate instrument registration occurred for instrument RequestCount/)
+      end
+    end
+
     it 'test create_counter' do
       counter = meter.create_counter('test')
       _(counter.class).must_equal(OpenTelemetry::Metrics::Instrument::Counter)

--- a/metrics_api/test/opentelemetry/metrics/meter_test.rb
+++ b/metrics_api/test/opentelemetry/metrics/meter_test.rb
@@ -32,6 +32,27 @@ describe OpenTelemetry::Metrics::Meter do
       _(counter.class).must_equal(OpenTelemetry::Metrics::Instrument::Counter)
     end
 
+    it 'reuses matching proxy instruments before and after installing a delegate' do
+      proxy = OpenTelemetry::Internal::ProxyMeter.new
+      first = proxy.create_counter('requestCount')
+      _(proxy.create_counter('RequestCount')).must_be_same_as(first)
+
+      proxy.delegate = meter
+
+      _(proxy.create_counter('REQUESTCOUNT')).must_be_same_as(first)
+      first.add(1)
+    end
+
+    it 'preserves separate callbacks for observable proxy instruments' do
+      proxy = OpenTelemetry::Internal::ProxyMeter.new
+      callback = -> { 1 }
+      first = proxy.create_observable_counter('requestCount', callback: callback)
+      second = proxy.create_observable_counter('RequestCount', callback: -> { 2 })
+
+      _(second).wont_be_same_as(first)
+      _(proxy.create_observable_counter('REQUESTCOUNT', callback: callback)).must_be_same_as(first)
+    end
+
     it 'test create_histogram' do
       counter = meter.create_histogram('test')
       _(counter.class).must_equal(OpenTelemetry::Metrics::Instrument::Histogram)

--- a/metrics_sdk/lib/opentelemetry/sdk/metrics/meter.rb
+++ b/metrics_sdk/lib/opentelemetry/sdk/metrics/meter.rb
@@ -26,6 +26,7 @@ module OpenTelemetry
         def initialize(name, version, meter_provider, attributes: nil)
           @mutex = Mutex.new
           @instrument_registry = {}
+          @instrument_name_registry = {}
           @instrumentation_scope = InstrumentationScope.new(name, version, attributes || {}.freeze)
           @meter_provider = meter_provider
         end
@@ -70,15 +71,15 @@ module OpenTelemetry
           raise InstrumentUnitError if unit && (!unit.ascii_only? || unit.size > 63)
           raise InstrumentDescriptionError if description && (description.size > 1023 || !utf8mb3_encoding?(description.dup))
 
-          super do
+          super do |instrument_name|
             case kind
-            when :counter then OpenTelemetry::SDK::Metrics::Instrument::Counter.new(name, unit, description, @instrumentation_scope, @meter_provider, exemplar_filter, exemplar_reservoir)
-            when :observable_counter then OpenTelemetry::SDK::Metrics::Instrument::ObservableCounter.new(name, unit, description, callback, @instrumentation_scope, @meter_provider, exemplar_filter, exemplar_reservoir)
-            when :gauge then OpenTelemetry::SDK::Metrics::Instrument::Gauge.new(name, unit, description, @instrumentation_scope, @meter_provider, exemplar_filter, exemplar_reservoir)
-            when :histogram then OpenTelemetry::SDK::Metrics::Instrument::Histogram.new(name, unit, description, @instrumentation_scope, @meter_provider, exemplar_filter, exemplar_reservoir)
-            when :observable_gauge then OpenTelemetry::SDK::Metrics::Instrument::ObservableGauge.new(name, unit, description, callback, @instrumentation_scope, @meter_provider, exemplar_filter, exemplar_reservoir)
-            when :up_down_counter then OpenTelemetry::SDK::Metrics::Instrument::UpDownCounter.new(name, unit, description, @instrumentation_scope, @meter_provider, exemplar_filter, exemplar_reservoir)
-            when :observable_up_down_counter then OpenTelemetry::SDK::Metrics::Instrument::ObservableUpDownCounter.new(name, unit, description, callback, @instrumentation_scope, @meter_provider, exemplar_filter, exemplar_reservoir)
+            when :counter then OpenTelemetry::SDK::Metrics::Instrument::Counter.new(instrument_name, unit, description, @instrumentation_scope, @meter_provider, exemplar_filter, exemplar_reservoir)
+            when :observable_counter then OpenTelemetry::SDK::Metrics::Instrument::ObservableCounter.new(instrument_name, unit, description, callback, @instrumentation_scope, @meter_provider, exemplar_filter, exemplar_reservoir)
+            when :gauge then OpenTelemetry::SDK::Metrics::Instrument::Gauge.new(instrument_name, unit, description, @instrumentation_scope, @meter_provider, exemplar_filter, exemplar_reservoir)
+            when :histogram then OpenTelemetry::SDK::Metrics::Instrument::Histogram.new(instrument_name, unit, description, @instrumentation_scope, @meter_provider, exemplar_filter, exemplar_reservoir)
+            when :observable_gauge then OpenTelemetry::SDK::Metrics::Instrument::ObservableGauge.new(instrument_name, unit, description, callback, @instrumentation_scope, @meter_provider, exemplar_filter, exemplar_reservoir)
+            when :up_down_counter then OpenTelemetry::SDK::Metrics::Instrument::UpDownCounter.new(instrument_name, unit, description, @instrumentation_scope, @meter_provider, exemplar_filter, exemplar_reservoir)
+            when :observable_up_down_counter then OpenTelemetry::SDK::Metrics::Instrument::ObservableUpDownCounter.new(instrument_name, unit, description, callback, @instrumentation_scope, @meter_provider, exemplar_filter, exemplar_reservoir)
             end
           end
         end

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/meter_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/meter_test.rb
@@ -222,8 +222,31 @@ describe OpenTelemetry::SDK::Metrics::Meter do
 
         _(first_instrument.instance_variable_get(:@name)).must_equal('requestCount')
         _(second_instrument.instance_variable_get(:@name)).must_equal('requestCount')
+        _(second_instrument).must_be_same_as(first_instrument)
         _(log_stream.string).must_match(/duplicate instrument registration occurred for instrument RequestCount/)
       end
+    end
+
+    it 'keeps different instrument kinds functional when names differ only in casing' do
+      counter = meter.create_counter('requestCount')
+      histogram = meter.create_histogram('RequestCount')
+
+      _(histogram).must_be_instance_of(OpenTelemetry::SDK::Metrics::Instrument::Histogram)
+      _(histogram.instance_variable_get(:@name)).must_equal('requestCount')
+      _(meter.create_counter('REQUESTCOUNT')).must_be_same_as(counter)
+      _(meter.create_histogram('REQUESTCOUNT')).must_be_same_as(histogram)
+      counter.add(1)
+      histogram.record(1)
+    end
+
+    it 'does not reuse instruments with different units or descriptions' do
+      counter = meter.create_counter('requestCount', unit: 's', description: 'first')
+      other_unit = meter.create_counter('RequestCount', unit: 'ms', description: 'first')
+      other_description = meter.create_counter('REQUESTCOUNT', unit: 's', description: 'second')
+
+      _(other_unit).wont_be_same_as(counter)
+      _(other_description).wont_be_same_as(counter)
+      _(meter.create_counter('RequestCount', unit: 's', description: 'first')).must_be_same_as(counter)
     end
 
     it 'instrument name must not be nil' do

--- a/metrics_sdk/test/opentelemetry/sdk/metrics/meter_test.rb
+++ b/metrics_sdk/test/opentelemetry/sdk/metrics/meter_test.rb
@@ -215,6 +215,17 @@ describe OpenTelemetry::SDK::Metrics::Meter do
       end
     end
 
+    it 'uses the first-seen casing for case-insensitive duplicate instrument names' do
+      OpenTelemetry::TestHelpers.with_test_logger do |log_stream|
+        first_instrument = meter.create_counter('requestCount')
+        second_instrument = meter.create_counter('RequestCount')
+
+        _(first_instrument.instance_variable_get(:@name)).must_equal('requestCount')
+        _(second_instrument.instance_variable_get(:@name)).must_equal('requestCount')
+        _(log_stream.string).must_match(/duplicate instrument registration occurred for instrument RequestCount/)
+      end
+    end
+
     it 'instrument name must not be nil' do
       _(-> { meter.create_counter(nil) }).must_raise(INSTRUMENT_NAME_ERROR)
     end


### PR DESCRIPTION
## Summary

- make instrument registry lookups case-insensitive
- preserve the first-seen instrument name casing across API, proxy, and SDK meters
- add regression coverage for collision warnings and preserved names

## Testing

- `metrics_api`: 16 tests, 21 assertions, 0 failures
- `metrics_sdk`: 336 tests, 17,224 assertions, 0 failures
- RuboCop: 130 files inspected, no offenses
- YARD documentation tasks completed successfully

Fixes #2357